### PR TITLE
Add/Edit Map Refactors

### DIFF
--- a/gwells/static/gwells/js/coordSync.js
+++ b/gwells/static/gwells/js/coordSync.js
@@ -207,10 +207,10 @@ function _areUTMFieldsValid () {
 /** Field updates */
 
 // Dispatches changes to DMS and UTM with suitable conversions and validation.
-function _latLongDDFieldOnChange (programmaticChange) {
+function _latLongDDFieldOnChange () {
     // If a user enters DD directly, we accept positive longitudes, but correct them on the fly.
     _correctPositiveLong();
-    if (_areLatLongDDFieldsValid(programmaticChange)) {
+    if (_areLatLongDDFieldsValid()) {
         _setDMSFromDD();
         _setUTMFromDD();
         _validationSuccessCallback();
@@ -872,6 +872,7 @@ function UTMXYToLatLon (x, y, zone, southhemi, latlon)
 
 // Synchronises the non-DD fields to the DD fields. This function should be called with programmatic
 // coordinate updates, and so does not require validation.
+// TODO: Comment on why this is necessary or refactor to remove it
 var syncFromDDFields = function () {
     _setDMSFromDD();
     _setUTMFromDD();
@@ -879,8 +880,7 @@ var syncFromDDFields = function () {
 
 /** Module initialisation.
  * @param options An object with properties conforming to: 
- * {  
- *    customChangeEventName: string, // The name of the custom change event, which is fired programmatically (as opposed to by user input)
+ * {
  *    // Each nodeSelector is a JQuery selector string; e.g., '#nodeId'.
  *    latDDNodeSelector: string, 
  *    longDDNodeSelector: string,

--- a/gwells/static/gwells/js/wellsMap.js
+++ b/gwells/static/gwells/js/wellsMap.js
@@ -22,7 +22,7 @@
  *          layers: string, // Layers of the OWS service; e.g., 'pub:WHSE_CADASTRE.PMBC_PARCEL_FABRIC_POLY_SVW'.
  *          styles: string, // Styles of the OWS service; e.g., 'PMBC_Parcel_Fabric_Cadastre_Outlined'
  *          transparent: boolean // Whether the tiles are transparent (other than the features drawn upon them)
- *      } 
+ *      }
  *   ],
  *   initCentre?: [float], // A two-element array representing the latitude and longitude of the centre of the map. If omitted, the map is fit to mapBounds, so one of these must exist.
  *   canZoom?: bool, // Whether the map can be zoomed. Defaults to true.
@@ -34,7 +34,7 @@
  *      south: float, // The bottom latitude of the map
  *      west: float, // The leftmost longitude of the map
  *      east: float, // The rightmost longitude of the map
- *      padding: int // Margin beyond extremes to pad the bounds with, as a percentage of the total bounding box.     
+ *      padding: int // Margin beyond extremes to pad the bounds with, as a percentage of the total bounding box.
  *   },
  *   wellPushpinInit?: { // An object for setting the latitude, longitude, and details of a wellPushpin on init.
  *      lat: float, // The initial latitude of the pushpin
@@ -43,12 +43,12 @@
  *          guid: string // The GUID of the well, for identification and special handling
  *      }
  *   },
- *   wellPushpinMoveCallback?: function, // Function to call when the map's wellPushpin moves 
+ *   wellPushpinMoveCallback?: function, // Function to call when the map's wellPushpin moves
  *   identifyWellsStartCallback?: function, // Function to call when an identifyWells operation is started
  *   identifyWellsEndCallback?: function // Function to call when an identifyWells operation ends
  * }
  */
-function WellsMap (options) {
+function WellsMap(options) {
     'use strict';
 
     /** Class constants */

--- a/gwells/templates/gwells/activity_submission_form.html
+++ b/gwells/templates/gwells/activity_submission_form.html
@@ -97,7 +97,7 @@
 </script>
 {% elif wizard.steps.current == 'gps' %}
 <script>
-//VOCTORIA LAT LONG: 48.4284, -123.3656
+  /** addMap block */
   var addMap = null;
   // Options for creating the addMap
   var addMapOptions = {
@@ -145,6 +145,44 @@
       wellPushpinMoveCallback: pushpinMoveCallback,      
   };
 
+  // Sets the latitude and longitude fields programmatically, rounding to
+  // six decimal places per database standard.
+  function setLatLongFields(lat, long) {
+    var fixedLat = lat.toFixed(6);
+    var fixedLong = long.toFixed(6);
+    $(latNodeSelector).val(fixedLat);
+    $(longNodeSelector).val(fixedLong);
+    // Since this change is programmatic, we can bypass user validation.
+    CoordSync.syncFromDDFields();
+  }
+
+  // Updates the latitude and longitude fields with the position of the pushpin
+  // for the prospective well when the pushpin is moved.
+  // newLatLng is a Leaflet LatLng object.
+  function pushpinMoveCallback (newLatLng) {
+    setLatLongFields(newLatLng.lat, newLatLng.lng);
+  }
+
+  // Places a well pushpin on the map based on the coordinates of the lat/long fields (in decimal degrees),
+  // passing these coordinates along to the map for it to generate or move the pushpin as it sees fit.
+  function placeWellPushpin () {
+    var lat = parseFloat($(latNodeSelector).val());
+    var long = parseFloat($(longNodeSelector).val());
+    lat = isNaN(lat) ? void 0 : lat;
+    long = isNaN(long) ? void 0 : long;
+    if (lat !== void 0 && long !== void 0) {
+      var latLng = L.latLng([lat,long]);
+      addMap.placeWellPushpin(latLng);
+    }
+  };
+
+  // Calls on the map to remove the well pushpin. Currently used for 'Clear Map' button.
+  function removeWellPushpin () {
+    addMap.removeWellPushpin();
+  };
+
+  /** CoordSync block */
+
   // JQuery selectors for the appropriate spatial coordinate DOM nodes.
   var latNodeSelector = '#id_gps-latitude';
   var longNodeSelector = '#id_gps-longitude';
@@ -166,24 +204,6 @@
   // CSS selector for the geographic warning pane
   var coordErrorPaneSelector = '#coord-error-pane'
 
-  // Sets the latitude and longitude fields programmatically, rounding to
-  // six decimal places per database standard.
-  function setLatLongFields(lat, long) {
-    var fixedLat = lat.toFixed(6);
-    var fixedLong = long.toFixed(6);
-    $(latNodeSelector).val(fixedLat);
-    $(longNodeSelector).val(fixedLong);
-    // Since this change is programmatic, we can bypass user validation.
-    CoordSync.syncFromDDFields();
-  }
-
-  // Updates the latitude and longitude fields with the position of the pushpin
-  // for the prospective well when the pushpin is moved.
-  // newLatLng is a Leaflet LatLng object.
-  function pushpinMoveCallback (newLatLng) {
-    setLatLongFields(newLatLng.lat, newLatLng.lng);
-  }
-
   // Callback sent to coordSync, to be run when users manually change coordinate fields.
   function validationErrorCallback (error) {
     if (error === '') {
@@ -198,30 +218,7 @@
     }
   }
 
-
-  // Places a well pushpin on the map based on the coordinates of the lat/long fields (in decimal degrees),
-  // passing these coordinates along to the map for it to generate or move the pushpin as it sees fit.
-  function placeWellPushpin () {
-    var lat = parseFloat($(latNodeSelector).val());
-    var long = parseFloat($(longNodeSelector).val());
-    lat = isNaN(lat) ? void 0 : lat;
-    long = isNaN(long) ? void 0 : long;
-    if (lat !== void 0 && long !== void 0) {
-      var latLng = L.latLng([lat,long]);
-      addMap.placeWellPushpin(latLng);
-    }
-  };
-
-  // Calls on the map to remove the well pushpin.
-  function removeWellPushpin () {
-    addMap.removeWellPushpin();
-  };
-
-  // On page load, we generate addMap and initiate CoordSync to individually manage map behaviour and
-  // the coordination of the coordinate input fields.
-  $(document).ready(function (){
-    addMap = new WellsMap(addMapOptions);
-    CoordSync.init({
+  var coordSyncOptions = {
       latDDNodeSelector: latNodeSelector, 
       longDDNodeSelector: longNodeSelector,
       latDMSDegreeNodeSelector: latDMSDegreeNodeSelector,
@@ -239,7 +236,13 @@
       utmPrecision: utmPrecision,
       validationErrorCallback: validationErrorCallback,
       validationSuccessCallback: placeWellPushpin      
-    });
+    };
+
+  // On page load, we generate addMap and initiate CoordSync to individually manage map behaviour and
+  // the coordination of the coordinate input fields.
+  $(document).ready(function (){
+    addMap = new WellsMap(addMapOptions);
+    CoordSync.init(coordSyncOptions);
   });
 </script>
 {% endif %}


### PR DESCRIPTION
This work comprises some minor refactors that nevertheless improve add/edit map functionality. Most substantively, the 'Map It!' and 'Clear Map' buttons have been removed, and CoordSync validation has been clarified so that the validation success callback (i.e., trying to place/move the well pushpin) only responds to user input and not programmatic changes. This allows for a smooth user experience, as a pin is placed and moved on the map whenever valid coordinates are entered, and the coordinates are updated and synched whenever the pin is moved.