### PR TITLE
Search Map Feedback Refinement and Attribution Reset

### DIFF
--- a/gwells/templates/gwells/activity_submission_form.html
+++ b/gwells/templates/gwells/activity_submission_form.html
@@ -107,8 +107,6 @@
   // triggers the change events on the designated latitude and longitude fields. As with all pushpin map instances, the
   // map issues AJAX queries every time the map or the pushpin moves, so that the user always sees surrounding wells, and
   // the map 'forgets' wells that are outside of the bounding box.
-  // TODO: Make the $(document).ready() call fetch the lat/long fields and feed them in as an initial pushpin location, if
-  // present.
   var addMapOptions = {
       // The ID of the addMap div.
       mapNodeId: 'add-map',

--- a/gwells/templates/gwells/search.html
+++ b/gwells/templates/gwells/search.html
@@ -210,7 +210,6 @@
 
     // We want to alter the map to have crosshairs during identifyWells,
     // as well as disabling the button until the operation is over.
-    // TODO: Style button, hide on operation init?
     function identifyWellsStartCallback() {
         $("#search-map").addClass('identify-wells-operation');
         $("#identify-wells-btn").prop("disabled", true);


### PR DESCRIPTION
This PR resets attribution to the map's default pending a decision on how to handle attribution; also, the search map now draws a rectangle for searched wells but does not restrict the map's panning ability.