### PR TITLE
Returning WellPushpin's WellMarker In All Pushpin Maps

### DIFF
--- a/gwells/static/gwells/js/wellsMap.js
+++ b/gwells/static/gwells/js/wellsMap.js
@@ -5,7 +5,7 @@
  * A NOTE ON FUNCTIONALITY: This class can be initialised in different ways, which exposes its functionality differently.
  * If sufficient parameters are supplied in map construction, the map can perform the following tasks:
  *  - Draw a single pushpin (i.e., a Leaflet marker akin to a Google marker) which causes the map to emit AJAX requests to show all wells
- *      in the bounding box (except the well that is being represented by the pushpinm which the pin itself has coupled). The map will
+ *      in the bounding box (except the well that is being represented by the pushpin which the pin itself has coupled). The map will
  *      reissue queries for wells in the bounding box whenever the map is panned or zoomed, provided the pushpin is present.
  *      If the map is beneath a certain zoom level, it will draw a rectangle to show queried wells and refrain from querying further
  *      until zoomed beyond the minimum (in order to prevent querying and rendering an inordinate number of wells).

--- a/gwells/templates/gwells/search.html
+++ b/gwells/templates/gwells/search.html
@@ -172,7 +172,7 @@ Use <a href="#">Advanced Search</a> for additional search options
         minZoom: 4,
         // Maximum zoom of the map (i.e., how far it can be zoomed in)
         maxZoom: 17,
-        // Bounding lats and longs of the map, corresponding to the lat/long extremes of BC.
+        // Bounding lats and longs of the map, containing the lat/long extremes of BC.
         mapBounds: {
             north:  60.4,
             south: 47.5,


### PR DESCRIPTION
This work represents the compromise position, wherein the wellPushpin has its wellMarker in all maps where the pushpin exists (and the marker can move with the pin), but this special wellMarker has a different outline to the other wells and is also drawn beneath them, so there will be hints when a well is being added/moved onto the location of an extant well.