### PR TITLE
Control Move and Fix for Select Zoom Mouseout Bug

### DIFF
--- a/gwells/static/gwells/css/custom-main.css
+++ b/gwells/static/gwells/css/custom-main.css
@@ -56,7 +56,7 @@ div .leaflet-select-zoom {
     background-image: url('../icons/select-zoom.png');
     width: 30px;
     height: 30px;
-    padding: 5px;
+    left: 4px;
     box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.4);
     cursor: pointer;
 }
@@ -69,7 +69,7 @@ div .leaflet-geolocation {
     background-image: url('../icons/geolocate.png');
     width: 30px;
     height: 30px;
-    padding: 5px;
+    left: 4px;
     box-shadow: 0px 0px 5px 1px rgba(0, 0, 0, 0.4);
     cursor: pointer;
 }

--- a/gwells/static/gwells/js/wellsMap.js
+++ b/gwells/static/gwells/js/wellsMap.js
@@ -488,16 +488,17 @@ function WellsMap(options) {
 
     /** Rectangle zoom matter */
 
+    var _zoomToRectangle = function () {
+        // Get the final bounds of the rectangle.
+        if (_exists(_zoomRectangle)) {
+            _leafletMap.flyToBounds(_zoomRectangle.getBounds());                
+        }
+        _stopRectangleZoom();
+    };
+
     // Handles the end of the drawing behaviour.
-    var _rectangleZoomMouseupEvent = function (e) {
-        // Get the final bounds.
-        var bounds = L.latLngBounds([_zoomRectangleAnchor, e.latlng]);
-        // Remove the rectangle and null the members.
-        _leafletMap.removeLayer(_zoomRectangle);
-        _zoomRectangle = null;
-        _zoomRectangleAnchor = null;
-        // Fit the map to the new bounds.
-        _leafletMap.flyToBounds(bounds);
+    var _rectangleZoomMouseupEvent = function () {
+        _zoomToRectangle();
         _stopRectangleZoom();
     };
 
@@ -507,6 +508,7 @@ function WellsMap(options) {
         var startCorner = _zoomRectangleAnchor;
         // Set by mousemove.
         var endCorner = e.latlng;
+
         // Draw or modify the rectangle.
         if (!_exists(_zoomRectangle)) {
             _zoomRectangle = L.rectangle([startCorner, endCorner]).addTo(_leafletMap);
@@ -517,27 +519,34 @@ function WellsMap(options) {
         _leafletMap.on('mouseup', _rectangleZoomMouseupEvent);
     };
 
+    var _rectangleZoomMouseoutEvent = function () {
+        _zoomToRectangle();
+        _stopRectangleZoom();
+    }
+
     // When the user clicks, set the rectangle's anchor point and set the map to begin drawing.
     var _rectangleZoomMousedownEvent = function (e) {
         // The map shouldn't pan during rectangle draw.
         _leafletMap.dragging.disable();
-        if (_exists(_zoomRectangle)) {
-            // If the _zoomRectangle somehow exists, remove it.
-            _leafletMap.removeLayer(_zoomRectangle);
-            _zoomRectangle = null;
-            _zoomRectangleAnchor = null;
-        }
         // Set the anchor point and the mousemove handler.
         _zoomRectangleAnchor = e.latlng;
         _leafletMap.on('mousemove', _rectangleZoomMousemoveEvent);
+        _leafletMap.on('mouseout', _rectangleZoomMouseoutEvent);
     };
 
     // The wrap-up once rectangle zoom is ended, including event unsubscription and mouse icon change.
     var _stopRectangleZoom = function () {
-        // Unsubscribe to all of the event handlers (including this one).
+        // Remove the rectangle and null the members.
+        if (_exists(_zoomRectangle)) {
+            _leafletMap.removeLayer(_zoomRectangle);
+            _zoomRectangle = null;
+            _zoomRectangleAnchor = null;    
+        }
+        // Unsubscribe to all of the event handlers.
         _leafletMap.off('mousedown', _rectangleZoomMousedownEvent);
         _leafletMap.off('mousemove', _rectangleZoomMousemoveEvent);
         _leafletMap.off('mouseup', _rectangleZoomMouseupEvent);
+        _leafletMap.off('mouseout', _rectangleZoomMouseoutEvent);
         // Re-enable panning.
         _leafletMap.dragging.enable();
         // Re-enable regular cursor.

--- a/gwells/static/gwells/js/wellsMap.js
+++ b/gwells/static/gwells/js/wellsMap.js
@@ -519,6 +519,7 @@ function WellsMap(options) {
         _leafletMap.on('mouseup', _rectangleZoomMouseupEvent);
     };
 
+    // If the mouse leaves the map, we attempt to finish the operation as though the mouse were released.
     var _rectangleZoomMouseoutEvent = function () {
         _zoomToRectangle();
         _stopRectangleZoom();


### PR DESCRIPTION
This work comprises a trivial change to the custom controls' CSS, as well as a more in-depth investigation and resolution of the bug Calvin notified me of wherein moving the mouse off of the map during the select-zoom operation plays havoc with the control.

I've added a mouseout event handler for the situation, which attempts to fly the map to the rectangle's bounds when the mouse leaves the map. There appears to be a bug deep within the Leaflet code for the flyToBounds and/or the panTo methods in this case, however, because it generally results in the map moving a bit but not zooming.

The most expedient resolution would be to have mouseouts simply cancel the operation, but I'm open to other ideas for the resolution.