### PR TITLE
a more efficient way of dealing with the new environment variable

### DIFF
--- a/gwells/settings.py
+++ b/gwells/settings.py
@@ -40,9 +40,6 @@ ENABLE_GOOGLE_ANALYTICS = os.getenv('ENABLE_GOOGLE_ANALYTICS', 'False') == 'True
 
 # Controls app context
 APP_CONTEXT_ROOT = os.getenv('APP_CONTEXT_ROOT','')
-SETTINGS_EXPORT = [
-    'APP_CONTEXT_ROOT',
-]
 
 ALLOWED_HOSTS = ['*']
 
@@ -89,7 +86,6 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'django_settings_export.settings_export',
             ],
         },
     },

--- a/gwells/templates/gwells/search.html
+++ b/gwells/templates/gwells/search.html
@@ -158,12 +158,7 @@
     // the search was driven by drawing a rectangle or by a user manually submitting the form.
     // Wells can be clicked to display a subset of their tabulated information in a popup directly on the map.
     var searchMapOptions = {
-    // Changes the called url dependng on the application context root setting
-    {% if settings.APP_CONTEXT_ROOT %}
-        SEARCH_URL: '/{{ settings.APP_CONTEXT_ROOT }}/ajax/map_well_search/',
-    {% else %}
-        SEARCH_URL: '/ajax/map_well_search/',
-    {% endif %}
+        SEARCH_URL: "{% url 'map_well_search' %}",
         // The ID of the addMap div.
         mapNodeId: searchMapNodeId,
         // Minimum zoom level of the map (i.e., how far it can be zoomed out)

--- a/navunit/src/test/resources/GebConfig.groovy
+++ b/navunit/src/test/resources/GebConfig.groovy
@@ -66,7 +66,12 @@ environments {
 // phantomJs --> “./gradlew phantomJsTest”   (headless)
 // chrome    --> "./gradlew chromeTest"
 //baseUrl = "http://localhost:8000"
-baseUrl = "http://gwells-dev.pathfinder.gov.bc.ca"
+//baseUrl = "http://gwells-dev.pathfinder.gov.bc.ca"
+baseUrl = "https://dlvrapps.nrs.gov.bc.ca" //Dev
+//baseUrl = "https://testapps.nrs.gov.bc.ca" //Test
+//baseUrl = "https://apps.nrs.gov.bc.ca" //Prod
+
+
 
 baseNavigatorWaiting = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ whitenoise==3.3
 django-model-utils==2.6.1
 django-crispy-forms==1.6.1
 django-formtools==2.0
-django-settings-export==1.2.1


### PR DESCRIPTION
After a night's sleep I found a better way (definitely more elegant) of dealing with the environment variable and the way to get the new url into the wellsmap.js. This eliminates the need for the new component that I had identified and leaves Django more standard.