### PR TITLE
Update path in Test Scripts....

### DIFF
--- a/navunit/src/test/groovy/pages/app/ActivitySubmissionPage.groovy
+++ b/navunit/src/test/groovy/pages/app/ActivitySubmissionPage.groovy
@@ -5,5 +5,5 @@ import geb.Page
 class ActivitySubmissionPage extends Page {
     static at = { title == "Groundwater Wells Activity Submission - Province of British Columbia" }
 
-    static url = "/gwells/submission/create"
+    static url = "gwells/submission/create"
 }

--- a/navunit/src/test/groovy/pages/app/AdditionalInformationPage.groovy
+++ b/navunit/src/test/groovy/pages/app/AdditionalInformationPage.groovy
@@ -5,5 +5,5 @@ import geb.Page
 class AdditionalInformationPage extends Page {
     static at = { title == "Groundwater Wells Groundwater Information - Province of British Columbia" }
 
-    static url = "/gwells/groundwater-information"
+    static url = "gwells/groundwater-information"
 }

--- a/navunit/src/test/groovy/pages/app/HomePage.groovy
+++ b/navunit/src/test/groovy/pages/app/HomePage.groovy
@@ -6,5 +6,5 @@ class HomePage extends Page {
 	// NOTE - the title comparison is based on parsed HTML, not an exact character match of the HTML source.  For example "  " becomes " ". 
 	// So even though there are currently two spaces after Wells in the page source, we have to compare against a single space after Wells.
     static at = { title == "Groundwater Wells - Province of British Columbia" }
-    static url = "/gwells"
+    static url = "gwells"
 }

--- a/navunit/src/test/groovy/pages/app/SearchPage.groovy
+++ b/navunit/src/test/groovy/pages/app/SearchPage.groovy
@@ -5,7 +5,7 @@ import geb.Module
 
 class SearchPage extends Page {
     static at = { title == "Groundwater Wells Search - Province of British Columbia" }
-    static url = "/gwells/search"
+    static url = "gwells/search"
 
     static content = {
         well_id(wait: true) { $("input", id:"id_well") } 

--- a/navunit/src/test/resources/GebConfig.groovy
+++ b/navunit/src/test/resources/GebConfig.groovy
@@ -66,12 +66,10 @@ environments {
 // phantomJs --> “./gradlew phantomJsTest”   (headless)
 // chrome    --> "./gradlew chromeTest"
 //baseUrl = "http://localhost:8000"
-baseUrl = "http://gwells-dev.pathfinder.gov.bc.ca"
-//baseUrl = "https://dlvrapps.nrs.gov.bc.ca" //Dev
-//baseUrl = "https://testapps.nrs.gov.bc.ca" //Test
-//baseUrl = "https://apps.nrs.gov.bc.ca" //Prod
-
-
+baseUrl = "http://gwells-dev.pathfinder.gov.bc.ca/"
+//baseUrl = "https://dlvrapps.nrs.gov.bc.ca/" //Dev
+//baseUrl = "https://testapps.nrs.gov.bc.ca/" //Test
+//baseUrl = "https://apps.nrs.gov.bc.ca/" //Prod
 
 baseNavigatorWaiting = true
 


### PR DESCRIPTION
 To align with the strong suggestion in GEB Manual. 
http://www.gebish.org/manual/current/#base-url in which it is suggested that **It is usually most desirable to define your base urls with trailing slashes and not to use leading slashes on relative URLs.**

It did not cause us trouble, but when helping another team with an issue, it was found that not following above directive was the cause of their trouble.