### PR TITLE
GWELLS HTML page Metadata

### DIFF
--- a/gwells/templates/gwells/base.html
+++ b/gwells/templates/gwells/base.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <meta name="HandheldFriendly" content="true"/>
-    <meta name="description" content=""/>
+    <meta name="description" content="{% block meta %}Search for and access details on over 100,000 groundwater wells in British Columbia by map or text.{% endblock %}"/>
     <meta name="author" content=""/>
     <meta name="navigaton_title" content=""/>
     <meta name="dcterms.publisher" content="Province of British Columbia"/>
@@ -20,7 +20,7 @@
     <meta name="dcterms.creator" content=""/>
     <meta name="dcsext.creator" content=""/>
     <meta name="dcterms.language" content="eng"/>
-    <meta name="keywords" content="">
+    <meta name="keywords" content="groundwater wells, ground water, well, British Columbia, water well drilling, geoexchange well, water well, geotechnical well, water supply wells, dewatering wells, injection wells, remediation wells, monitoring wells">
     <link rel="apple-touch-icon" sizes="57x57" href="{% static 'gwells/icons/apple-icon-57x57.png' %}"/>
     <link rel="apple-touch-icon" sizes="60x60" href="{% static 'gwells/icons/apple-icon-60x60.png' %}"/>
     <link rel="apple-touch-icon" sizes="72x72" href="{% static 'gwells/icons/apple-icon-72x72.png' %}"/>

--- a/gwells/templates/gwells/groundwater_information.html
+++ b/gwells/templates/gwells/groundwater_information.html
@@ -1,5 +1,6 @@
 {% extends 'gwells/base.html' %}
 
+{% block meta %}Learn about groundwater wells in B.C.and how to find out more information about them.{% endblock %}
 {% block title %}Groundwater Information{% endblock %}
 
 {% block bodyheading_block %}Groundwater Information{% endblock %}

--- a/gwells/templates/gwells/groundwater_information.html
+++ b/gwells/templates/gwells/groundwater_information.html
@@ -1,6 +1,6 @@
 {% extends 'gwells/base.html' %}
 
-{% block meta %}Learn about groundwater wells in B.C.and how to find out more information about them.{% endblock %}
+{% block meta %}Learn about groundwater wells in B.C. and how to find out more information about them.{% endblock %}
 {% block title %}Groundwater Information{% endblock %}
 
 {% block bodyheading_block %}Groundwater Information{% endblock %}

--- a/gwells/templates/gwells/search.html
+++ b/gwells/templates/gwells/search.html
@@ -1,6 +1,7 @@
 {% extends 'gwells/base.html' %}
 {% load crispy_forms_tags %}
 
+{% block meta %}{{ block.super }}{% endblock %}
 {% block title %}Search{% endblock %}
 
 {% block bodyheading_block %}Groundwater Well Search{% endblock %}


### PR DESCRIPTION
Update HTML metadata for GWELLS search and Groundwater info pages to improve SEO and appearance in search results.

For https://apps.nrs.gov.bc.ca/gwells/search:
1. Meta description: "Search for and access details on over 100,000 groundwater wells in British Columbia by map or text."
2. Keywords: groundwater wells, ground water, well, British Columbia, water well drilling, geoexchange well, water well, geotechnical well, water supply wells, dewatering wells, injection wells, remediation wells, monitoring wells

For https://apps.nrs.gov.bc.ca/gwells/groundwater-information:
Meta description: "Learn about groundwater wells in B.C.and how to find out more information about them."