### PR TITLE
Moving post-deploy SQL to out-of-the-box Django RunSQL

### DIFF
--- a/gwells/migrations/0001_initial.py
+++ b/gwells/migrations/0001_initial.py
@@ -1161,4 +1161,8 @@ class Migration(migrations.Migration):
             name='well_yield_unit',
             field=models.ForeignKey(blank=True, db_column='well_yield_unit_guid', null=True, on_delete=django.db.models.deletion.CASCADE, to='gwells.WellYieldUnit'),
         ),
+        migrations.RunSQL( /* Index on lat/long until PostGIS implementation */
+            "CREATE INDEX gwells_well_latlong ON gwells_well (latitude, longitude)",
+            "DROP INDEX IF EXISTS gwells_well_latlong CASCADE"
+        )
     ]


### PR DESCRIPTION
This allows 'reverseSQL' to rollback the SQL.