### PR TITLE
Update Sonar-runner to correctly show version numbers. (date.build)

### DIFF
--- a/sonar-runner/README.md
+++ b/sonar-runner/README.md
@@ -2,14 +2,14 @@ This example demonstrates how to analyze a simple Java project with Gradle.
 
 Prerequisites
 =============
-* [SonarQube](http://www.sonarqube.org/downloads/) 4.5+
+* [SonarQube](http://www.sonarqube.org/downloads/) 6.7+
 * [Gradle](http://www.gradle.org/) 2.1 or higher
 
 Usage
 =====
 * Analyze the project with SonarQube using Gradle:
 
-        gradle sonarqube [-Dsonar.host.url=... -Dsonar.jdbc.url=... -Dsonar.jdbc.username=... -Dsonar.jdbc.password=...]
+        ./gradlew sonarqube [-Dsonar.host.url=... -Dsonar.jdbc.url=... -Dsonar.jdbc.username=... -Dsonar.jdbc.password=...]
         
 Local Install
 =============
@@ -20,9 +20,3 @@ To install SonarQube locally do the following:
 * Review your build.gradle, you need to add the following property: ```property "sonar.host.url", "http://localhost:9000"```
 * run ./gradlew sonarqube from this directory
 * Go to web browser and review result
-
-Caveat
-======
-If you want to run this on windows on your machine you need to set the version in build.gradle to:
-```id "org.sonarqube" version "2.6.1".```
-Version 1.2 actually causes issues in Windows but not in Linux.       

--- a/sonar-runner/build.gradle
+++ b/sonar-runner/build.gradle
@@ -7,6 +7,7 @@ plugins {
 
 sonarqube {
     properties {
+        //property "sonar.host.url", "http://localhost:9000"        
         property "sonar.projectName", "GWells"
         property "sonar.projectKey", "org.sonarqube:bcgov-gwells"
         property "sonar.projectBaseDir", "../"
@@ -23,7 +24,11 @@ sonarqube {
 }
 
 allprojects {
-  ext.baseVersion = "0.1"
+  def env = System.getenv()
+  TimeZone.getTimeZone('UTC')
+  Date date= new Date()
+  String newdate=date.format("YYYYMMDD")
+  ext.baseVersion = newdate + "." + env['BUILD_NUMBER']
   ext.snapshotVersion = false
 
   group = "org.sonarqube"


### PR DESCRIPTION
Current sonar-runner does not update build numbers, so a historical trend is not built up.
With this change we create a version based on Date and the Jenkins Build number.
YYYYMMDD.XXX example 20180123.132.