### PR TITLE
Refactored Minio Access to public S3

### DIFF
--- a/gwells/minioClient.py
+++ b/gwells/minioClient.py
@@ -1,18 +1,16 @@
 import os
 from minio import Minio
 
-# NOTE 's3-ca-central-1.amazonaws.com' didn't work:
-# minio.error.ResponseError: ResponseError: code: AuthorizationHeaderMalformed, message: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'ca-central-1', bucket_name: None, object_name: None, request_id: 3841822DCB7F7FC6, host_id: dk3GUWHqhX6gEiE6iONYAIfIpQNvbzExauHhCCoE4uTQOW6NygKY6yPdEsODXmChlO8Auk14ftg=, region:
+# NOTE Well Summary page uses publicly-viewable S3 bucket, so no credentials are needed
 #
 
 class MinioClient():
 
     def __init__(self):
-        self.minio_access_key = os.getenv('MINIO_ACCESS_KEY')
-        self.minio_secret_key = os.getenv('MINIO_SECRET_KEY')
+        self.access_key = ""
+        self.secret_key = ""
         self.host = os.getenv('S3_HOST')
-        self.link_host = os.getenv('S3_LINK_HOST')
-        self.minio_client = Minio(self.link_host, access_key=self.minio_access_key, secret_key=self.minio_secret_key, secure=True)
+        self.minio_client = Minio(self.host, access_key=self.access_key, secret_key=self.secret_key, secure=True)
         self.top_bucket = os.getenv('S3_ROOT_BUCKET')
 
     def get_documents(self, well_tag_number):

--- a/gwells/templates/gwells/well_detail.html
+++ b/gwells/templates/gwells/well_detail.html
@@ -868,7 +868,7 @@
                 <tbody>
                     {% for document in documents %}
                     <td>
-                        <a href="https://{{link_host}}/{{document.bucket_name}}/{{document.object_name}}" target="_blank">{{document.display_name}}</a>
+                        <a href="https://{{host}}/{{document.bucket_name}}/{{document.object_name}}" target="_blank">{{document.display_name}}</a>
                     </td>
                     {% endfor %}
                 </tbody>

--- a/gwells/views/WellDetailView.py
+++ b/gwells/views/WellDetailView.py
@@ -24,7 +24,7 @@ class WellDetailView(generic.DetailView):
 
                 minio_client = MinioClient()
 
-                context['link_host'] = minio_client.link_host;
+                context['host'] = minio_client.host;
                 context['documents'] = [];
 
                 documents = minio_client.get_documents(context['well'].well_tag_number)


### PR DESCRIPTION
To not use any credentials.  Reserve MINIO_ACCESS_KEY and MINIO_SECRET_KEY for authenticated access to our internal Minio S3 Server.   Edits/Additions from our (not yet built) Admin screens to the "publicly viewable S3" will be authenticated via this internal Minio S3 Server, and it will have stored proxy IAM credentials to the cloud S3.