### PR TITLE
add version to Registries API urls

### DIFF
--- a/api-tests/registries_api_tests.json
+++ b/api-tests/registries_api_tests.json
@@ -59,11 +59,13 @@
 									]
 								},
 								"url": {
-									"raw": "{{base_url}}/api-token-auth/?format=json",
+									"raw": "{{base_url}}/api/v1/api-token-auth/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"api-token-auth",
 										""
 									],
@@ -194,11 +196,13 @@
 									]
 								},
 								"url": {
-									"raw": "{{base_url}}/organizations/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										""
 									],
@@ -273,11 +277,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/organizations/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										""
 									],
@@ -343,11 +349,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/organizations/{{created_guid}}/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/{{created_guid}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										"{{created_guid}}",
 										""
@@ -416,11 +424,13 @@
 									]
 								},
 								"url": {
-									"raw": "{{base_url}}/organizations/{{created_guid}}/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/{{created_guid}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										"{{created_guid}}",
 										""
@@ -478,11 +488,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/organizations/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										""
 									],
@@ -534,11 +546,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/organizations/{{created_guid}}/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/{{created_guid}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										"{{created_guid}}",
 										""
@@ -582,11 +596,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/organizations/{{created_guid}}/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/{{created_guid}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										"{{created_guid}}",
 										""
@@ -635,11 +651,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/organizations/{{created_guid}}/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/{{created_guid}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										"{{created_guid}}",
 										""
@@ -698,11 +716,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/organizations/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										""
 									],
@@ -819,11 +839,13 @@
 									]
 								},
 								"url": {
-									"raw": "{{base_url}}/organizations/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										""
 									],
@@ -941,11 +963,13 @@
 									]
 								},
 								"url": {
-									"raw": "{{base_url}}/organizations/{{created_guid_bad_input}}/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/{{created_guid_bad_input}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										"{{created_guid_bad_input}}",
 										""
@@ -1007,11 +1031,13 @@
 									]
 								},
 								"url": {
-									"raw": "{{base_url}}/organizations/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										""
 									],
@@ -1053,11 +1079,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/organizations/{{created_guid_bad_input}}/?format=json",
+									"raw": "{{base_url}}/api/v1/organizations/{{created_guid_bad_input}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"organizations",
 										"{{created_guid_bad_input}}",
 										""
@@ -1152,11 +1180,13 @@
 									]
 								},
 								"url": {
-									"raw": "{{base_url}}/drillers/?format=json",
+									"raw": "{{base_url}}/api/v1/drillers/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"drillers",
 										""
 									],
@@ -1227,11 +1257,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/drillers/?format=json",
+									"raw": "{{base_url}}/api/v1/drillers/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"drillers",
 										""
 									],
@@ -1295,11 +1327,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/drillers/{{created_driller_guid}}/?format=json",
+									"raw": "{{base_url}}/api/v1/drillers/{{created_driller_guid}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"drillers",
 										"{{created_driller_guid}}",
 										""
@@ -1368,11 +1402,13 @@
 									]
 								},
 								"url": {
-									"raw": "{{base_url}}/drillers/{{created_driller_guid}}/?format=json",
+									"raw": "{{base_url}}/api/v1/drillers/{{created_driller_guid}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"drillers",
 										"{{created_driller_guid}}",
 										""
@@ -1446,11 +1482,13 @@
 									]
 								},
 								"url": {
-									"raw": "{{base_url}}/drillers/{{created_driller_guid}}/?format=json",
+									"raw": "{{base_url}}/api/v1/drillers/{{created_driller_guid}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"drillers",
 										"{{created_driller_guid}}",
 										""
@@ -1508,11 +1546,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/drillers/?format=json",
+									"raw": "{{base_url}}/api/v1/drillers/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"drillers",
 										""
 									],
@@ -1564,11 +1604,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/drillers/{{created_driller_guid}}/?format=json",
+									"raw": "{{base_url}}/api/v1/drillers/{{created_driller_guid}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"drillers",
 										"{{created_driller_guid}}",
 										""
@@ -1612,11 +1654,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/drillers/{{created_driller_guid}}/?format=json",
+									"raw": "{{base_url}}/api/v1/drillers/{{created_driller_guid}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"drillers",
 										"{{created_driller_guid}}",
 										""
@@ -1665,11 +1709,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/drillers/{{created_driller_guid}}/?format=json",
+									"raw": "{{base_url}}/api/v1/drillers/{{created_driller_guid}}/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"drillers",
 										"{{created_driller_guid}}",
 										""
@@ -1728,11 +1774,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/drillers/?format=json",
+									"raw": "{{base_url}}/api/v1/drillers/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"drillers",
 										""
 									],
@@ -1784,11 +1832,13 @@
 								],
 								"body": {},
 								"url": {
-									"raw": "{{base_url}}/drillers/?format=json",
+									"raw": "{{base_url}}/api/v1/drillers/?format=json",
 									"host": [
 										"{{base_url}}"
 									],
 									"path": [
+										"api",
+										"v1",
 										"drillers",
 										""
 									],

--- a/frontend/src/common/services/gwells.js
+++ b/frontend/src/common/services/gwells.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-const BASE_URL = '/gwells/registries/'
+const BASE_URL = '/gwells/registries/api/v1/'
 
 const logging = false
 

--- a/registries/urls.py
+++ b/registries/urls.py
@@ -18,21 +18,24 @@ from . import views
 
 urlpatterns = [
     # Organization resource endpoints
-    url(r'^organizations/(?P<org_guid>[-\w]+)/$', views.APIOrganizationRetrieveUpdateDestroyView.as_view(), name='organization-detail'),
-    url(r'^organizations/$', views.APIOrganizationListCreateView.as_view(), name='organization-list'),
+    url(r'^api/v1/organizations/(?P<org_guid>[-\w]+)/$', views.APIOrganizationRetrieveUpdateDestroyView.as_view(), name='organization-detail'),
+    url(r'^api/v1/organizations/$', views.APIOrganizationListCreateView.as_view(), name='organization-list'),
 
     # Person resource endpoints (drillers, well installers, and other instances of Person model)
-    url(r'^drillers/(?P<person_guid>[-\w]+)/$', views.APIPersonRetrieveUpdateDestroyView.as_view(), name='person-detail'),
-    url(r'^drillers/$', views.APIPersonListCreateView.as_view(), name='person-list'),
+    url(r'^api/v1/drillers/(?P<person_guid>[-\w]+)/$', views.APIPersonRetrieveUpdateDestroyView.as_view(), name='person-detail'),
+    url(r'^api/v1/drillers/$', views.APIPersonListCreateView.as_view(), name='person-list'),
 
     # List of cities that currently have registered drillers, pump installers etc.
-    url(r'^cities/drillers/$', views.APICitiesList.as_view(), {'activity':'drill'}, name='city-list-drillers'),
-    url(r'^cities/installers/$', views.APICitiesList.as_view(), {'activity': 'install'}, name='city-list-installers'),
+    url(r'^api/v1/cities/drillers/$', views.APICitiesList.as_view(), {'activity':'drill'}, name='city-list-drillers'),
+    url(r'^api/v1/cities/installers/$', views.APICitiesList.as_view(), {'activity': 'install'}, name='city-list-installers'),
 
     # Temporary JWT Auth endpoint
-    url(r'^api-token-auth/', obtain_jwt_token, name='get-token'),
+    url(r'^api/v1/api-token-auth/', obtain_jwt_token, name='get-token'),
 
     # Swagger documentation endpoint
+    url(r'^api/v1/$', get_swagger_view(title='GWELLS Driller registry'), name='api-docs'),
+
+    # Deprecated API docs link
     url(r'^docs/$', get_swagger_view(title='GWELLS Driller registry'), name='api-docs'),
 
     # Registries frontend webapp loader (html page that contains header, footer, and a SPA in between)


### PR DESCRIPTION
Add version 'v1' to registries API urls. Any future breaking changes to API endpoints will be under a new version.

Also updated API tests and frontend app to use the new URLs.