### PR TITLE
Jenkinsfile changes to eliminate Node defs in Jenkins

### DIFF
--- a/Jenkinsfile-developer
+++ b/Jenkinsfile-developer
@@ -77,19 +77,19 @@ stage('API Test') {
         dir('api-tests') {
 	    sh 'npm install -g newman'
 	    try {
-		sh 'newman run registries_api_tests.json --global-var base_url="https://gwells-dev.pathfinder.gov.bc.ca/gwells/registries" --global-var test_user=$GWELLS_API_TEST_USER --global-var test_password=$GWELLS_API_TEST_PASSWORD -r cli,junit,html;'
-	    } finally {
-                junit 'newman/*.xml'
-                publishHTML (target: [
-                            allowMissing: false,
-                            alwaysLinkToLastBuild: false,
-                            keepAll: true,
-                            reportDir: 'newman',
-                            reportFiles: 'newman*.html',
-                            reportName: "API Test Report"
-                        ])
-                stash includes: 'newman/*.xml', name: 'api-tests' 
-            }
+            sh 'newman run registries_api_tests.json --global-var base_url="https://gwells-dev.pathfinder.gov.bc.ca/gwells/registries" --global-var test_user=$GWELLS_API_TEST_USER --global-var test_password=$GWELLS_API_TEST_PASSWORD -r cli,junit,html;'
+            } finally {
+                    junit 'newman/*.xml'
+                    publishHTML (target: [
+                                allowMissing: false,
+                                alwaysLinkToLastBuild: false,
+                                keepAll: true,
+                                reportDir: 'newman',
+                                reportFiles: 'newman*.html',
+                                reportName: "API Test Report"
+                            ])
+                    stash includes: 'newman/*.xml', name: 'api-tests' 
+                }
         }
     }
 }

--- a/Jenkinsfile-developer
+++ b/Jenkinsfile-developer
@@ -49,8 +49,8 @@ node('maven') {
             returnStdout: true
         ).trim()
         echo "SONARQUBE_URL: ${SONARQUBE_URL}"
-	unstash 'nodejunit'
-	unstash 'nodecoverage'
+	    unstash 'nodejunit'
+	    unstash 'nodecoverage'
         dir('sonar-runner') {
             unstash 'coverage'
             try {
@@ -94,57 +94,86 @@ stage('API Test') {
     }
 }
 
-stage('FT on Dev') {
-	node('bddstack') {
-		//the checkout is mandatory, otherwise functional test would fail
-        echo "checking out source"
-        echo "Build: ${BUILD_ID}"
-        checkout scm
-        dir('functional-tests/build/test-results') {
-            unstash 'coverage'
-            sh 'rm coverage.xml'
-	    unstash 'api-tests'
-	    unstash 'nodejunit'
-        }
-        dir('functional-tests') {
-            try {
-                    sh './gradlew chromeHeadlessTest'
-            } finally {
-                    archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/geb/**/*'
-                    junit 'build/test-results/**/*.xml'
-                    publishHTML (target: [
-                                allowMissing: false,
-                                alwaysLinkToLastBuild: false,
-                                keepAll: true,
-                                reportDir: 'build/reports/spock',
-                                reportFiles: 'index.html',
-                                reportName: "BDD Spock Report"
-                            ])
-                    publishHTML (target: [
-                                allowMissing: false,
-                                alwaysLinkToLastBuild: false,
-                                keepAll: true,
-                                reportDir: 'build/reports/tests/chromeHeadlessTest',
-                                reportFiles: 'index.html',
-                                reportName: "Full Test Report"
-                            ])
-	            perfReport compareBuildPrevious: true, excludeResponseTime: true, ignoreFailedBuilds: true, ignoreUnstableBuilds: true, modeEvaluation: true, modePerformancePerTestCase: true, percentiles: '0,50,90,100', relativeFailedThresholdNegative: 80.0, relativeFailedThresholdPositive: 20.0, relativeUnstableThresholdNegative: 50.0, relativeUnstableThresholdPositive: 50.0, sourceDataFiles: 'build/test-results/**/*.xml'
+podTemplate(label: 'bddstack', name: 'bddstack', serviceAccount: 'jenkins', cloud: 'openshift', containers: [
+  containerTemplate(
+    name: 'jnlp',
+    image: '172.50.0.2:5000/openshift/jenkins-slave-bddstack',
+    resourceRequestCpu: '500m',
+    resourceLimitCpu: '1000m',
+    resourceRequestMemory: '1Gi',
+    resourceLimitMemory: '4Gi',
+    workingDir: '/home/jenkins',
+    command: '',
+    args: '${computer.jnlpmac} ${computer.name}'
+  )
+])       
+{
+    stage('FT on Dev') {
+        node('bddstack') {
+            //the checkout is mandatory, otherwise functional test would fail
+            echo "checking out source"
+            echo "Build: ${BUILD_ID}"
+            checkout scm
+            dir('functional-tests/build/test-results') {
+                unstash 'coverage'
+                sh 'rm coverage.xml'
+            unstash 'api-tests'
+            unstash 'nodejunit'
+            }
+            dir('functional-tests') {
+                try {
+                        sh './gradlew chromeHeadlessTest'
+                } finally {
+                        archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/geb/**/*'
+                        junit 'build/test-results/**/*.xml'
+                        publishHTML (target: [
+                                    allowMissing: false,
+                                    alwaysLinkToLastBuild: false,
+                                    keepAll: true,
+                                    reportDir: 'build/reports/spock',
+                                    reportFiles: 'index.html',
+                                    reportName: "BDD Spock Report"
+                                ])
+                        publishHTML (target: [
+                                    allowMissing: false,
+                                    alwaysLinkToLastBuild: false,
+                                    keepAll: true,
+                                    reportDir: 'build/reports/tests/chromeHeadlessTest',
+                                    reportFiles: 'index.html',
+                                    reportName: "Full Test Report"
+                                ])
+                    perfReport compareBuildPrevious: true, excludeResponseTime: true, ignoreFailedBuilds: true, ignoreUnstableBuilds: true, modeEvaluation: true, modePerformancePerTestCase: true, percentiles: '0,50,90,100', relativeFailedThresholdNegative: 80.0, relativeFailedThresholdPositive: 20.0, relativeUnstableThresholdNegative: 50.0, relativeUnstableThresholdPositive: 50.0, sourceDataFiles: 'build/test-results/**/*.xml'
+                }
             }
         }
     }
-}
+}    
 
-stage('ZAP Security Scan') {
-    node('zap') {
-        //the checkout is mandatory
-        echo "checking out source"
-        echo "Build: ${BUILD_ID}"
-        checkout scm
-        dir('zap') {
-            def retVal = sh returnStatus: true, script: './runzap.sh'
-            publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: '/zap/wrk', reportFiles: 'index.html', reportName: 'ZAP Full Scan', reportTitles: 'ZAP Full Scan'])
-            echo "Return value is: ${retVal}"
-            }
+podTemplate(label: 'owasp-zap', name: 'owasp-zap', serviceAccount: 'jenkins', cloud: 'openshift', containers: [
+  containerTemplate(
+    name: 'jnlp',
+    image: '172.50.0.2:5000/openshift/jenkins-slave-zap',
+    resourceRequestCpu: '500m',
+    resourceLimitCpu: '1000m',
+    resourceRequestMemory: '3Gi',
+    resourceLimitMemory: '4Gi',
+    workingDir: '/home/jenkins',
+    command: '',
+    args: '${computer.jnlpmac} ${computer.name}'
+  )
+]) {
+    stage('ZAP Security Scan') {
+        node('owasp-zap') {
+            //the checkout is mandatory
+            echo "checking out source"
+            echo "Build: ${BUILD_ID}"
+            checkout scm
+            dir('zap') {
+                def retVal = sh returnStatus: true, script: './runzap.sh'
+                publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: '/zap/wrk', reportFiles: 'index.html', reportName: 'ZAP Full Scan', reportTitles: 'ZAP Full Scan'])
+                echo "Return value is: ${retVal}"
+                }
+        }
     }
 }
 


### PR DESCRIPTION
The nodes that we are using are now defined in the Jenkinsfile instead of needing a definition in Jenkins.