### PR TITLE
Hot Patch - break out db_replicate() into two distinct steps

### DIFF
--- a/database/scripts/db_replicate.sql
+++ b/database/scripts/db_replicate.sql
@@ -1,4 +1,4 @@
-DROP FUNCTION IF EXISTS db_replicate(boolean);
+DROP FUNCTION IF EXISTS db_replicate_step1(boolean);
 
 /*** NOTE: There is no refresh of the static Code Tables, as that is dependent upon, and done during 
            GWELLS Application code deployment.
@@ -12,16 +12,16 @@ DROP FUNCTION IF EXISTS db_replicate(boolean);
 		   false: replicate all rows (analogous to $DB_REPLICATE="Full") 
 
 	On the Postgres DB Pod:
-	psql -t -d $POSTGRESQL_DATABASE -U $POSTGRESQL_USER -c 'SELECT db_replicate(_subset_ind=>true);'
+	psql -t -d $POSTGRESQL_DATABASE -U $POSTGRESQL_USER -c 'SELECT db_replicate_step1(_subset_ind=>true);'
 
 	As a remote task:
-	oc exec postgresql-80-04n7h -- /bin/bash -c 'psql -t -d $POSTGRESQL_DATABASE -U $POSTGRESQL_USER -c "SELECT db_replicate(_subset_ind=>false);"' 
+	oc exec postgresql-80-04n7h -- /bin/bash -c 'psql -t -d $POSTGRESQL_DATABASE -U $POSTGRESQL_USER -c "SELECT db_replicate_step1(_subset_ind=>false);"' 
 
     If run on local Developer workstation, ensure that you have Environment variables set
     for $POSTGRESQL_DATABASE, $POSTGRESQL_USER
 
  ***/
-CREATE OR REPLACE FUNCTION db_replicate(_subset_ind boolean default true) RETURNS void AS $$
+CREATE OR REPLACE FUNCTION db_replicate_step1(_subset_ind boolean default true) RETURNS void AS $$
 BEGIN
 	PERFORM populate_xform(_subset_ind);
 	TRUNCATE TABLE bcgs_number CASCADE;	
@@ -30,6 +30,34 @@ BEGIN
 	PERFORM populate_well();	
 	PERFORM migrate_screens();
 	PERFORM migrate_production();
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION db_replicate_step1 (boolean) IS 'SQL Driver script to run replication, without code table refresh (step 1).'; 
+
+
+DROP FUNCTION IF EXISTS db_replicate_step2();
+
+/*** NOTE: This db_replicate is broken into steps, as the full all-at-once version was causing DB corruption errors ("past EOF").  
+           Running as two separate psql sessions seems to help avoid this error.
+
+		   This driver SQL script is meant to be run from the Database Pod, during scheduled nightly
+		   replications or on an ad-hoc fashion. It is not part of an application deployment.
+
+		   Therefore, there is a dependency on having all static code tables populated.
+
+	On the Postgres DB Pod:
+	psql -t -d $POSTGRESQL_DATABASE -U $POSTGRESQL_USER -c 'SELECT db_replicate_step2 ();'
+
+	As a remote task:
+	oc exec postgresql-80-04n7h -- /bin/bash -c 'psql -t -d $POSTGRESQL_DATABASE -U $POSTGRESQL_USER -c "SELECT db_replicate_step2 ();"' 
+
+    If run on local Developer workstation, ensure that you have Environment variables set
+    for $POSTGRESQL_DATABASE, $POSTGRESQL_USER
+
+ ***/
+CREATE OR REPLACE FUNCTION db_replicate_step2 () RETURNS void AS $$
+BEGIN
 	PERFORM migrate_casings();
 	PERFORM migrate_perforations();
 	PERFORM migrate_aquifers();
@@ -38,5 +66,4 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-COMMENT ON FUNCTION db_replicate (boolean) IS 'SQL Driver script to run replication, without code table refresh.'; 
-
+COMMENT ON FUNCTION db_replicate_step2 () IS 'SQL Driver script to run replication, without code table refresh (step 2).'; 


### PR DESCRIPTION
To avoid 'Past EOF' database error.