### PR TITLE
Environment variables - 

### DIFF
--- a/gwells/database.py
+++ b/gwells/database.py
@@ -26,11 +26,15 @@ engines = {
 
 
 def config():
-    service_name = get_env_variable('DATABASE_SERVICE_NAME').upper().replace('-', '_')
-    engine = engines.get(get_env_variable('DATABASE_ENGINE'))
+    service_name = get_env_variable('DATABASE_SERVICE_NAME', '').upper().replace('-', '_')
+    # Default to using sqlite if no database engine is specified
+    engine = engines.get(get_env_variable('DATABASE_ENGINE'), engines['sqlite'])
+    name = os.getenv('DATABASE_NAME')
+    if not name and engine == engines['sqlite']:
+        name = os.path.join(settings.BASE_DIR, 'db.sqlite3')
     return {
         'ENGINE': engine,
-        'NAME': get_env_variable('DATABASE_NAME'),
+        'NAME': name,
         'USER': get_env_variable('DATABASE_USER'),
         'PASSWORD': get_env_variable('DATABASE_PASSWORD'),
         'HOST': get_env_variable('{}_SERVICE_HOST'.format(service_name)),

--- a/gwells/settings/__init__.py
+++ b/gwells/settings/__init__.py
@@ -29,7 +29,7 @@ BASE_DIR = str(Path(__file__).parents[2])
 # The SECRET_KEY is provided via an environment variable in OpenShift
 # safe value used for development when DJANGO_SECRET_KEY might not be set:
 # '9e4@&tw46$l31)zrqe3wi+-slqm(ruvz&se0^%9#6(_w3ui!c0'
-SECRET_KEY = get_env_variable('DJANGO_SECRET_KEY', '9e4@&tw46$l31)zrqe3wi+-slqm(ruvz&se0^%9#6(_w3ui!c0')
+SECRET_KEY = get_env_variable('DJANGO_SECRET_KEY', '7e4@&tw46$l31)zrqe3wi+-slqm(ruvz&se0^%9#6(_w3ui!c0')
 
 # Security Settings
 SECURE_BROWSER_XSS_FILTER = True

--- a/gwells/settings/base.py
+++ b/gwells/settings/base.py
@@ -28,8 +28,8 @@ if not ENFORCE_ENV_VARIABLES:
 def get_env_variable(var_name, default_value=None):
     result = getenv(var_name)
     if not result:
-        msg = 'Set the {} environment variable'.format(var_name)
-        if ENFORCE_ENV_VARIABLES:
+        msg = 'Environment variable "{}" not set'.format(var_name)
+        if ENFORCE_ENV_VARIABLES or default_value is None:
             raise ImproperlyConfigured(msg)
         else:
             logger.debug(msg)

--- a/gwells/urls.py
+++ b/gwells/urls.py
@@ -31,7 +31,7 @@ if app_root:
 else:
     app_root_slash = app_root
 
-DJANGO_ADMIN_URL = get_env_variable('DJANGO_ADMIN_URL', 'admin')
+DJANGO_ADMIN_URL = get_env_variable('DJANGO_ADMIN_URL')
 
 urlpatterns = [
     # url(r'^'+ app_root +'$', views.HomeView.as_view(), name='home'),


### PR DESCRIPTION
Reverted DATABASE_NAME logic, accepting default values, but not None values.

The following is required (no default values allowed):
DJANGO_ADMIN_URL
DJANGO_ADMIN_USER
ENABLE_DATA_ENTRY
ENABLE_GOOGLE_ANALYTICS
ENABLE_ADDITIONAL_DOCUMENTS
S3_HOST
S3_ROOT_BUCKET