### PR TITLE
Moving Django command execution for post-lifecycle from mid-lifecycle

### DIFF
--- a/database/cron/post-deploy.sh
+++ b/database/cron/post-deploy.sh
@@ -71,7 +71,4 @@ else
     echo ". Skipping DB Replication from Legacy Database, as per DB_REPLICATION flag"
 fi
 
-cd /opt/app-root/src/
-python manage.py createtestuser
-
 echo "Completed Post-Deploy tasks."

--- a/gwells/management/commands/post-deploy.py
+++ b/gwells/management/commands/post-deploy.py
@@ -1,0 +1,9 @@
+from django.core import management
+from django.core.management.base import BaseCommand
+
+class Command(BaseCommand):
+    help = 'Creates a test user to assist with API testing'
+
+    def handle(self, *args, **options):
+        management.call_command('createtestuser', verbosity=0, interactive=False)
+        management.call_command('creategroups', verbosity=0, interactive=False)


### PR DESCRIPTION
As putting it in the mid-lifecycle hook returned:
python: error while loading shared libraries: libpython3.5m.so.rh-python35-1.0: cannot open shared object file: No such file or directory