### PR TITLE
Switch back to hardcoded url for API tests

### DIFF
--- a/Jenkinsfile-developer
+++ b/Jenkinsfile-developer
@@ -113,7 +113,7 @@ podTemplate(label: 'nodejs', name: 'nodejs', serviceAccount: 'jenkins', cloud: '
             dir('api-tests') {
             sh 'npm install -g newman'
             try {
-                sh 'newman run ./registries_api_tests.json --global-var test_user=$GWELLS_API_TEST_USER --global-var test_password=$GWELLS_API_TEST_PASSWORD --global-var base_url=$GWELLS_API_BASE_URL --global-var auth_server=$GWELLS_API_TEST_AUTH_SERVER --global-var client_id=$GWELLS_API_TEST_CLIENT_ID --global-var client_secret=$GWELLS_API_TEST_CLIENT_SECRET -r cli,junit,html;'
+                sh 'newman run ./registries_api_tests.json --global-var test_user=$GWELLS_API_TEST_USER --global-var test_password=$GWELLS_API_TEST_PASSWORD --global-var base_url="https://gwells-dev.pathfinder.gov.bc.ca/gwells" --global-var auth_server=$GWELLS_API_TEST_AUTH_SERVER --global-var client_id=$GWELLS_API_TEST_CLIENT_ID --global-var client_secret=$GWELLS_API_TEST_CLIENT_SECRET -r cli,junit,html;'
                 } finally {
                         junit 'newman/*.xml'
                         publishHTML (target: [


### PR DESCRIPTION
Switching to an environment variable GWELLS_API_BASE_URL (used only for Postman API tests) caused API tests to fail. Reverted back to hardcoded url (the old way) until we fix the environment variable