### PR TITLE
Added serialization for RegistrationApplication

### DIFF
--- a/registries/models.py
+++ b/registries/models.py
@@ -1,7 +1,24 @@
+"""
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
 import uuid
 import datetime
+import logging
 from django.db import models
 from gwells.models import AuditModel, ProvinceStateCode
+
+
+logger = logging.getLogger(__name__)
 
 
 class ActivityCode(AuditModel):
@@ -349,6 +366,26 @@ class Register(AuditModel):
         )
 
 
+class ApplicationStatusCode(AuditModel):
+    """
+    Status of Applications for the Well Driller and Pump Installer Registries
+    """
+    registries_application_status_code = models.CharField(
+        primary_key=True, max_length=10, editable=False)
+    description = models.CharField(max_length=100)
+    display_order = models.PositiveIntegerField()
+    effective_date = models.DateField(default=datetime.date.today)
+    expired_date = models.DateField(blank=True, null=True)
+
+    class Meta:
+        db_table = 'registries_application_status_code'
+        ordering = ['display_order', 'description']
+        verbose_name_plural = 'Application Status Codes'
+
+    def __str__(self):
+        return self.description
+
+
 class RegistriesApplication(AuditModel):
     """
     Application from a well driller or pump installer to be on the GWELLS Register.
@@ -393,6 +430,14 @@ class RegistriesApplication(AuditModel):
         verbose_name="Certificate")
     primary_certificate_no = models.CharField(max_length=50)
 
+    @property
+    def current_status(self):
+        try:
+            return RegistriesApplicationStatus.objects.get(application=self.application_guid, expired_date=None)
+        except:
+            logger.error('Could not find the current status for application', self.application_guid)
+            return None
+
     class Meta:
         db_table = 'registries_application'
         verbose_name_plural = 'Applications'
@@ -401,26 +446,6 @@ class RegistriesApplication(AuditModel):
         return '%s : %s' % (
             self.registration,
             self.file_no)
-
-
-class ApplicationStatusCode(AuditModel):
-    """
-    Status of Applications for the Well Driller and Pump Installer Registries
-    """
-    registries_application_status_code = models.CharField(
-        primary_key=True, max_length=10, editable=False)
-    description = models.CharField(max_length=100)
-    display_order = models.PositiveIntegerField()
-    effective_date = models.DateField(default=datetime.date.today)
-    expired_date = models.DateField(blank=True, null=True)
-
-    class Meta:
-        db_table = 'registries_application_status_code'
-        ordering = ['display_order', 'description']
-        verbose_name_plural = 'Application Status Codes'
-
-    def __str__(self):
-        return self.description
 
 
 class RegistriesApplicationStatus(AuditModel):

--- a/registries/serializers.py
+++ b/registries/serializers.py
@@ -1,3 +1,18 @@
+"""
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+from django.utils import timezone
 from rest_framework import serializers
 from gwells.models.ProvinceStateCode import ProvinceStateCode
 from registries.models import (
@@ -235,6 +250,7 @@ class ApplicationAdminSerializer(AuditModelSerializer):
     """
 
     status_set = ApplicationStatusSerializer(many=True, read_only=True)
+    current_status = ApplicationStatusSerializer()
     cert_authority = serializers.ReadOnlyField(
         source="primary_certificate.cert_auth.cert_auth_code")
     qualifications = serializers.StringRelatedField(
@@ -258,7 +274,8 @@ class ApplicationAdminSerializer(AuditModelSerializer):
             'reason_denied',
             'subactivity',
             'qualifications',
-            'status_set'
+            'status_set',
+            'current_status'
         )
 
     def create(self, validated_data):
@@ -271,6 +288,7 @@ class ApplicationAdminSerializer(AuditModelSerializer):
             raise TypeError('A field may need to be made read only.')
 
         # make a status record to go with the new application
+        # by default we set the ApplicationStatus to P(ending).
         pending = ApplicationStatusCode.objects.get(
             registries_application_status_code='P')
         RegistriesApplicationStatus.objects.create(
@@ -278,6 +296,37 @@ class ApplicationAdminSerializer(AuditModelSerializer):
             status=pending)
 
         return app
+
+    def update(self, instance, validated_data):
+        current_status = instance.current_status
+        validated_status = validated_data.get('current_status', current_status)
+
+        # We have to handle the current_status seperately because django
+        # isn't smart enough to handle this kind of db relation.
+
+        # Validated_status is an OrderedDict at this point
+        validated_status_code = validated_status.get('status').registries_application_status_code
+        if current_status:
+            current_status_code = current_status.status.registries_application_status_code
+        else:
+            logger.error('RegistryApplication should always have a current status', instance)
+            current_status_code = None
+
+        if validated_status_code != current_status_code:
+            # Change the status
+            # Expire existing status
+            if current_status:
+                current_status.expired_date = timezone.now()
+                current_status.save()
+            new_status = ApplicationStatusCode.objects.get(
+                registries_application_status_code=validated_status_code)
+            RegistriesApplicationStatus.objects.create(
+                application=instance,
+                status=new_status)
+
+        # Pop off current_status since it's already handeled
+        validated_data.pop('current_status')
+        return super().update(instance, validated_data)
 
 
 class RegistrationAdminSerializer(AuditModelSerializer):

--- a/registries/views.py
+++ b/registries/views.py
@@ -1,3 +1,17 @@
+"""
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
 from collections import OrderedDict
 from django.http import HttpResponse
 from django.utils import timezone


### PR DESCRIPTION
- Added update to ApplicationAdminSerializer to allow for put/patch requests.
- Added Apache license to a few files.

Example post body to {{base_url}}/api/v1/applications/{{created_application_guid}}/?format=json:
`{
	"subactivity": "GEOTECH",
	"current_status": {
		"status": "P"
	}
}`
