### PR TITLE
up'ing gunicorn workers 

### DIFF
--- a/gunicorn.cfg
+++ b/gunicorn.cfg
@@ -43,7 +43,7 @@
 #       A positive integer. Generally set in the 1-5 seconds range.
 #
 
-workers = 8
+workers = 18
 worker_class = 'gevent'
 worker_connections = 1000
 timeout = 30


### PR DESCRIPTION
as the Code Quality check was still running after 3 hours, instead of the usual 2 minutes.  https://jenkins-moe-gwells-tools.pathfinder.gov.bc.ca/job/moe-gwells-tools-gwells-pipeline-developer/494/console