### PR TITLE
Link up Registries survey display to survey admin tool

### DIFF
--- a/app/frontend/src/registry/components/people/PersonDetail.vue
+++ b/app/frontend/src/registry/components/people/PersonDetail.vue
@@ -172,7 +172,9 @@
                       class="btn btn-light btn-sm registries-edit-btn"
                       type="button"
                       @click="editCompany = (editCompany === (index + 1) ? 0 : (index + 1))"
-                      v-if="currentDriller.person_guid"><i class="fa fa-refresh"></i> Add/Change</button>
+                      v-if="currentDriller.person_guid"><i class="fa fa-refresh"></i>
+                      <span v-if="!registration.organization">Add</span><span v-else>Change</span>
+                      </button>
                   </div>
                 </div>
                 <person-edit

--- a/app/frontend/src/registry/components/people/PersonDetail.vue
+++ b/app/frontend/src/registry/components/people/PersonDetail.vue
@@ -172,8 +172,9 @@
                       class="btn btn-light btn-sm registries-edit-btn"
                       type="button"
                       @click="editCompany = (editCompany === (index + 1) ? 0 : (index + 1))"
-                      v-if="currentDriller.person_guid"><i class="fa fa-refresh"></i>
-                      <span v-if="!registration.organization">Add</span><span v-else>Change</span>
+                      v-if="currentDriller.person_guid">
+                      <span v-if="!registration.organization"><i class="fa fa-plus"></i> Add</span>
+                      <span v-else><i class="fa fa-refresh"></i> Change</span>
                       </button>
                   </div>
                 </div>

--- a/app/frontend/src/registry/components/search/SearchHome.vue
+++ b/app/frontend/src/registry/components/search/SearchHome.vue
@@ -1,8 +1,21 @@
 <template>
   <div>
-    <b-card no-body class="container p-0 mb-3">
-      <b-alert show variant="info" class="m-0"><p class="m-0">Please take a moment to complete our <a href="https://www.surveymonkey.com/r/Y8DHVPX">short survey</a> to let us know about your Register search page experience.</p></b-alert>
-    </b-card>
+
+    <!-- Active surveys -->
+    <b-alert
+        show
+        variant="info"
+        class="container mb-3"
+        v-for="(survey, index) in surveys"
+        :key="`survey ${index}`">
+      <p class="m-0">
+        <a :href="survey.survey_link">
+          {{ survey.survey_introduction_text }}
+        </a>
+      </p>
+    </b-alert>
+
+    <!-- Admin options -->
     <b-card v-if="userIsAdmin" no-body class="container p-1 mb-3">
       <b-card-header header-tag="header" class="p-1" role="tab">
         <b-btn block href="#" v-b-toggle.adminPanel variant="light" class="text-left">Administrator options</b-btn>
@@ -28,6 +41,8 @@
         </b-card-body>
       </b-collapse>
     </b-card>
+
+    <!-- Main Registries content -->
     <b-card class="container p-1" title="Register of Well Drillers and Well Pump Installers">
       <p>To update contact information or for general enquiries email <a href="mailto:Groundwater@gov.bc.ca">groundwater@gov.bc.ca</a>.</p>
       <p>
@@ -35,6 +50,7 @@
         Learn more about registering as a well driller or well pump installer in B.C.
         </a>
       </p>
+      <!-- Search options -->
       <b-card no-body class="p-3 mb-4">
         <h5>Search for a Well Driller or Well Pump Installer</h5>
         <b-form @submit.prevent="drillerSearch" @reset.prevent="drillerSearchReset({clearDrillers: true})" id="drillerSearchForm">
@@ -124,6 +140,7 @@
           </b-form-row>
         </b-form>
       </b-card>
+      <!-- Search results table -->
       <div ref="registryTableResults">
         <template v-if="!searchLoading">
           <b-row>
@@ -157,6 +174,7 @@
 </template>
 
 <script>
+import ApiService from '@/common/services/ApiService.js'
 import SearchTable from '@/registry/components/search/SearchTable.vue'
 import LegalText from '@/registry/components/Legal.vue'
 import APIErrorMessage from '@/common/components/APIErrorMessage.vue'
@@ -195,7 +213,8 @@ export default {
         ordering: ''
       },
       searchLoading: false,
-      lastSearchedParams: {}
+      lastSearchedParams: {},
+      surveys: []
     }
   },
   computed: {
@@ -293,6 +312,15 @@ export default {
   created () {
     // send request for city list when app is loaded
     this.$store.dispatch(FETCH_CITY_LIST, this.formatActivityForCityList)
+
+    // Fetch current surveys and add 'registries' surveys (if any) to this.surveys to be displayed
+    ApiService.query('surveys/').then((response) => {
+      response.data.forEach((survey) => {
+        if (survey.survey_page === 'r') {
+          this.surveys.push(survey)
+        }
+      })
+    })
   }
 }
 </script>

--- a/app/gwells/serializers.py
+++ b/app/gwells/serializers.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+from gwells.models.Survey import Survey
+
+
+class SurveySerializer(serializers.ModelSerializer):
+    """ Serializes Survey model fields """
+
+    class Meta:
+        model = Survey
+        fields = (
+            'survey_guid',
+            'survey_introduction_text',
+            'survey_link',
+            'survey_page'
+        )

--- a/app/gwells/urls.py
+++ b/app/gwells/urls.py
@@ -21,6 +21,7 @@ from django.views.generic import TemplateView
 from . import views
 from gwells.views import *
 from gwells.views.admin import *
+from gwells.views import APIViews
 from gwells.settings.base import get_env_variable
 
 # Creating 2 versions of the app_root. One without and one with trailing slash
@@ -42,22 +43,28 @@ DJANGO_ADMIN_URL = get_env_variable(
 urlpatterns = [
     # url(r'^'+ app_root +'$', views.HomeView.as_view(), name='home'),
     url(r'^' + app_root_slash + 'robots\.txt$',
-        TemplateView.as_view(template_name='robots.txt', content_type='text/plain'),
+        TemplateView.as_view(template_name='robots.txt',
+                             content_type='text/plain'),
         name='robots'),
     url(r'^' + app_root_slash + '$', SearchView.well_search, name='home'),
-    url(r'^' + app_root_slash + 'search$', SearchView.well_search, name='search'),
+    url(r'^' + app_root_slash + 'search$',
+        SearchView.well_search, name='search'),
     # url(r'^(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/$',
     #     views.DetailView.as_view(), name='detail'),
-    url(r'^' + app_root_slash + 'well/(?P<pk>[0-9]+)$', WellDetailView.as_view(), name='well_detail'),
-    url(r'^' + app_root_slash + 'registry-legacy$', RegistryView.as_view(), name='registry-legacy'),
+    url(r'^' + app_root_slash + \
+        'well/(?P<pk>[0-9]+)$', WellDetailView.as_view(), name='well_detail'),
+    url(r'^' + app_root_slash + 'registry-legacy$',
+        RegistryView.as_view(), name='registry-legacy'),
     url(r'^' + app_root_slash + 'submission/(?P<pk>[0-9]+)$',
         ActivitySubmissionDetailView.as_view(),
         name='activity_submission_detail'),
     url(r'^' + app_root_slash + 'health$', HealthView.health, name='health'),
     url(r'^' + app_root_slash + 'groundwater-information',
-        TemplateView.as_view(template_name='gwells/groundwater_information.html'),
+        TemplateView.as_view(
+            template_name='gwells/groundwater_information.html'),
         name='groundwater_information'),
-    url(r'^' + app_root_slash + 'ajax/map_well_search/$', SearchView.map_well_search, name='map_well_search'),
+    url(r'^' + app_root_slash + 'ajax/map_well_search/$',
+        SearchView.map_well_search, name='map_well_search'),
     url(r'^' +
         app_root_slash +
         'site_admin/survey/(?P<pk>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$',
@@ -67,8 +74,11 @@ urlpatterns = [
     url(r'^' + app_root_slash + 'site_admin',
         AdminView.as_view(),
         name='site_admin'),  # editable list view of surveys and other site admin features
+    url(r'^' + app_root_slash + 'api/v1/surveys/$',
+        APIViews.SurveyListView.as_view(), name='survey-list'),
     url(r'^' + app_root_slash + DJANGO_ADMIN_URL + '/', admin.site.urls),
-    url(r'^' + app_root_slash + 'accounts/', include('django.contrib.auth.urls')),
+    url(r'^' + app_root_slash + 'accounts/',
+        include('django.contrib.auth.urls')),
     url(r'^' + app_root_slash, include('registries.urls')),
 ]
 

--- a/app/gwells/views/APIViews.py
+++ b/app/gwells/views/APIViews.py
@@ -1,0 +1,13 @@
+from rest_framework.generics import ListAPIView
+from gwells.serializers import SurveySerializer
+from gwells.models.Survey import Survey
+
+
+class SurveyListView(ListAPIView):
+    """
+    get: returns a list of active surveys
+    """
+
+    serializer_class = SurveySerializer
+    queryset = Survey.objects.filter(survey_enabled=True)
+    pagination_class = None


### PR DESCRIPTION
Backend: 

* added a read-only API endpoint at gwells/api/v1/surveys/ that returns a list of currently enabled surveys

Frontend:

* Registries search page checks for active surveys and displays them at the top of the page.
* Minor fix: The company "add/change" button on the driller profile page now only says "add" or "change" depending on if the person has a company or not.