### PR TITLE
[1030] Pipeline abort on mid-cycle fail (Deploy - DEV)

### DIFF
--- a/openshift/backend.dc.json
+++ b/openshift/backend.dc.json
@@ -194,7 +194,7 @@
                             }
                         },
                         "mid": {
-                            "failurePolicy": "Retry",
+                            "failurePolicy": "Abort",
                             "execNewPod": {
                                 "command": [
                                     "/usr/bin/container-entrypoint",


### PR DESCRIPTION
Fail not causing pipeline to stop.  "Deploy - DEV" has been waiting for 45 minutes on a silently failing script, which is definitely not good feedback for a developer.