### PR TITLE
[1043] Added additional provinces and U.S. states 

### DIFF
--- a/app/gwells/fixtures/gwells-codetables.json
+++ b/app/gwells/fixtures/gwells-codetables.json
@@ -1,1 +1,242 @@
-[{"model": "gwells.provincestatecode", "pk": "AB", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Alberta", "display_order": 4}}, {"model": "gwells.provincestatecode", "pk": "BC", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "British Colmubia", "display_order": 2}}, {"model": "gwells.provincestatecode", "pk": "MB", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Manitoba", "display_order": 8}}, {"model": "gwells.provincestatecode", "pk": "NB", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "New Brunswick", "display_order": 10}}, {"model": "gwells.provincestatecode", "pk": "NL", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Newfoundland and Labrador", "display_order": 12}}, {"model": "gwells.provincestatecode", "pk": "NS", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Nova Scotia", "display_order": 14}}, {"model": "gwells.provincestatecode", "pk": "NT", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Northwest Territories", "display_order": 16}}, {"model": "gwells.provincestatecode", "pk": "NU", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Nunavut", "display_order": 18}}, {"model": "gwells.provincestatecode", "pk": "ON", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Ontario", "display_order": 6}}, {"model": "gwells.provincestatecode", "pk": "OTHER", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Other", "display_order": 90}}, {"model": "gwells.provincestatecode", "pk": "PE", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Prince Edward Island", "display_order": 20}}, {"model": "gwells.provincestatecode", "pk": "QC", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Quebec", "display_order": 22}}, {"model": "gwells.provincestatecode", "pk": "SK", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Saskatchewan", "display_order": 24}}, {"model": "gwells.provincestatecode", "pk": "WA", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Washington State", "display_order": 30}}, {"model": "gwells.provincestatecode", "pk": "YT", "fields": {"create_user": "ETL_USER", "create_date": "2017-07-01T08:00:00Z", "update_user": "ETL_USER", "update_date": "2017-07-01T08:00:00Z", "description": "Yukon", "display_order": 26}}]
+[
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "BC",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "British Colmubia",
+            "display_order": 2
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "AB",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Alberta",
+            "display_order": 4
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "ON",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Ontario",
+            "display_order": 6
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "MB",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Manitoba",
+            "display_order": 8
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "SK",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Saskatchewan",
+            "display_order": 10
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "NL",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Newfoundland and Labrador",
+            "display_order": 12
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "NS",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Nova Scotia",
+            "display_order": 14
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "NT",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Northwest Territories",
+            "display_order": 16
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "NU",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Nunavut",
+            "display_order": 18
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "PE",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Prince Edward Island",
+            "display_order": 20
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "QC",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Quebec",
+            "display_order": 22
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "NB",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "New Brunswick",
+            "display_order": 24
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "YT",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Yukon",
+            "display_order": 26
+        }
+    },
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "WA",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Washington State",
+            "display_order": 30
+        }
+    },    
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "OR",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Oregon",
+            "display_order": 32
+        }
+    },    
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "CA",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "California",
+            "display_order": 34
+        }
+    },  
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "ID",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Idaho",
+            "display_order": 34
+        }
+    },  
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "NV",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Nevada",
+            "display_order": 36
+        }
+    },  
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "ID",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Idaho",
+            "display_order": 38
+        }
+    },  
+    {
+        "model": "gwells.provincestatecode",
+        "pk": "OTHER",
+        "fields": {
+            "create_user": "ETL_USER",
+            "create_date": "2017-07-01T08:00:00Z",
+            "update_user": "ETL_USER",
+            "update_date": "2017-07-01T08:00:00Z",
+            "description": "Other",
+            "display_order": 90
+        }
+    }
+]

--- a/app/gwells/fixtures/gwells-codetables.json
+++ b/app/gwells/fixtures/gwells-codetables.json
@@ -7,7 +7,7 @@
             "create_date": "2017-07-01T08:00:00Z",
             "update_user": "ETL_USER",
             "update_date": "2017-07-01T08:00:00Z",
-            "description": "British Colmubia",
+            "description": "British Columbia",
             "display_order": 2
         }
     },


### PR DESCRIPTION
To the province state code table, via the fixture.  DB will have these entries:
```
gwells=> select province_state_code, description, display_order from province_state_code order by display_order;
 province_state_code |        description        | display_order 
---------------------+---------------------------+---------------
 BC                  | British Columbia          |             2
 AB                  | Alberta                   |             4
 ON                  | Ontario                   |             6
 MB                  | Manitoba                  |             8
 SK                  | Saskatchewan              |            10
 NL                  | Newfoundland and Labrador |            12
 NS                  | Nova Scotia               |            14
 NT                  | Northwest Territories     |            16
 NU                  | Nunavut                   |            18
 PE                  | Prince Edward Island      |            20
 QC                  | Quebec                    |            22
 NB                  | New Brunswick             |            24
 YT                  | Yukon                     |            26
 WA                  | Washington State          |            30
 OR                  | Oregon                    |            32
 CA                  | California                |            34
 NV                  | Nevada                    |            36
 ID                  | Idaho                     |            38
 OTHER               | Other                     |            90
(19 rows)
```