### PR TITLE
[1037] Fix for Python unit tests and false positive pipeline status at test stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,7 +167,7 @@ _stage('Unit Test', context) {
                         npm --version
 
                         (cd /opt/app-root/src && python manage.py migrate)
-                        (cd /opt/app-root/src && export ENABLE_DATA_ENTRY="True" && export NOSE_PROCESSES=4 && python manage.py test -c nose.cfg)
+                        (cd /opt/app-root/src && export ENABLE_DATA_ENTRY="True" && python manage.py test -c nose.cfg)
                         (cd /opt/app-root/src/frontend && npm test)
                         mkdir -p frontend/test/
                         cp -R /opt/app-root/src/frontend/test/unit ./frontend/test/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ _stage('Unit Test', context) {
             try {
                 container('app') {
                     sh script: '''#!/usr/bin/container-entrypoint /bin/sh
-                        set -euo nounset
+                        set -eou pipefail
                         python --version
                         pip --version
                         node --version

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ _stage('Unit Test', context) {
             try {
                 container('app') {
                     sh script: '''#!/usr/bin/container-entrypoint /bin/sh
-                        set -x
+                        set -euo nounset
                         python --version
                         pip --version
                         node --version


### PR DESCRIPTION
* disabled parallel testing for Python unit tests
* added `set -e` to script that kicks off tests (exit with error on failing tests)