### PR TITLE
[1086] Fix display of contact info if contact_detail table is empty

### DIFF
--- a/app/frontend/src/registry/components/search/SearchTable.vue
+++ b/app/frontend/src/registry/components/search/SearchTable.vue
@@ -37,7 +37,7 @@
               <driller-org-address :driller="driller" :activity="activity"></driller-org-address>
             </td>
             <td :id="`personContact${index}`">
-              <div v-if="driller.contact_info && driller.contact_info.length">
+              <div>
                 <driller-contact-info :driller="driller"/>
               </div>
             </td>

--- a/app/frontend/src/registry/components/search/table-helpers/DrillerContactInfo.vue
+++ b/app/frontend/src/registry/components/search/table-helpers/DrillerContactInfo.vue
@@ -19,6 +19,7 @@ export default {
   methods: {
     contactSort (driller) {
       // sort a person's contact info into groups (tel numbers followed by emails)
+      // for old contact info only (will be removed at a later date)
       const tel = []
       const email = []
       if (driller.contact_info) {

--- a/app/frontend/src/registry/components/search/table-helpers/DrillerContactInfo.vue
+++ b/app/frontend/src/registry/components/search/table-helpers/DrillerContactInfo.vue
@@ -21,20 +21,22 @@ export default {
       // sort a person's contact info into groups (tel numbers followed by emails)
       const tel = []
       const email = []
-      driller.contact_info.forEach((item) => {
-        if (item.contact_tel) {
-          tel.push({
-            type: 'tel',
-            value: item.contact_tel
-          })
-        }
-        if (item.contact_email) {
-          email.push({
-            type: 'email',
-            value: item.contact_email
-          })
-        }
-      })
+      if (driller.contact_info) {
+        driller.contact_info.forEach((item) => {
+          if (item.contact_tel) {
+            tel.push({
+              type: 'tel',
+              value: item.contact_tel
+            })
+          }
+          if (item.contact_email) {
+            email.push({
+              type: 'email',
+              value: item.contact_email
+            })
+          }
+        })
+      }
       return tel.concat(email)
     }
   }


### PR DESCRIPTION
* remove conditional check for the contact_info array on the contact info display component (we no longer store contact info as an array)