### PR TITLE
[1000] Replaced cert_no of grand-parent with N/A

### DIFF
--- a/app/registries/fixtures/registries.json
+++ b/app/registries/fixtures/registries.json
@@ -28545,7 +28545,7 @@
             "registrar_notes": null,
             "reason_denied": null,
             "primary_certificate": "e368e066-137b-491a-af2a-da3bf2936e6d",
-            "primary_certificate_no": "grand-parent",
+            "primary_certificate_no": "N/A",
             "current_status": "A",
             "application_recieved_date": null,
             "application_outcome_date": "2006-09-06",


### PR DESCRIPTION
So that the test fixtures line up with the new cert_no ('N/A' instead of 'grand-parent').