### PR TITLE
[1192] Update Registries fixture to have new Accreditation.

### DIFF
--- a/app/registries/fixtures/registries-codetables.json
+++ b/app/registries/fixtures/registries-codetables.json
@@ -247,6 +247,22 @@
     },
     {
         "model": "registries.accreditedcertificatecode",
+        "pk": "55911754-e547-4ca0-aad4-29592285f55d",
+        "fields": {
+            "create_user": "DATALOAD_USER",
+            "create_date": "2018-01-01T08:00:00Z",
+            "update_user": "DATALOAD_USER",
+            "update_date": "2018-01-01T08:00:00Z",
+            "cert_auth": "AB",
+            "registries_activity": "DRILL",
+            "name": "Earth Loop Technician, Alberta Journeyman Certificate",
+            "description": null,
+            "effective_date": "1970-01-01",
+            "expired_date": null
+        }
+    },
+    {
+        "model": "registries.accreditedcertificatecode",
         "pk": "7bf968aa-c6e0-4f57-b4f4-58723214de80",
         "fields": {
             "create_user": "DATALOAD_USER",


### PR DESCRIPTION
Next time, we'll include such new code table values to a Django migration step.  For now, we'll update in-place the existing code table fixture and run on TEST and then PROD:

```
INSERT INTO registries_accredited_certificate_code (
 acc_cert_guid,name
,description
,cert_auth_code
,registries_activity_code
,create_user
,create_date
,update_user
,update_date
,effective_date
)
VALUES (
 '55911754-e547-4ca0-aad4-29592285f55d'
,'Earth Loop Technician, Alberta Journeyman Certificate'
,null
,'AB'
,'DRILL'
,'DATALOAD_USER'
,'2018-07-27T08:00:00Z'
,'DATALOAD_USER'
,'2018-07-27T08:00:00Z'  
,'1970-01-01')
;
```