### PR TITLE
[947] jump after next button selected

### DIFF
--- a/app/gwells/templates/gwells/search.html
+++ b/app/gwells/templates/gwells/search.html
@@ -54,7 +54,7 @@
 {% if well_list %}
 
 <div class="table-responsive">
-    <table id="results" class="table table-striped">
+    <table id="results" class="table table-striped nowrap">
         <thead>
             <tr style="text-align: left;">
                 <th class="numeric">


### PR DESCRIPTION
I have just set the datatable options to nowrap. It fixes the height of the column so you don't get the jumping effect, but you need to scroll laterally to see the full content of the table...(to test ;-)) I don't think it should put you back to the top of the grid if you have more records, staying on the paging control seems more appropriate...