### PR TITLE
[947] epicregistry-jump-after-next-button-selected-1

### DIFF
--- a/app/frontend/src/registry/components/search/SearchTable.vue
+++ b/app/frontend/src/registry/components/search/SearchTable.vue
@@ -63,23 +63,13 @@
       <div v-if="drillers.results && drillers.results.length" class="col-xs-12 col-sm-4 offset-sm-4 offset-md-5 col-md-3">
         <nav aria-label="List navigation" v-if="drillers.results && drillers.results.length">
           <ul class="pagination">
-            <li v-if="drillers.previous">
-              <button type="button" @click="paginationPrev" class="btn btn-default" aria-label="Previous" id="table-pagination-prev">
+            <li>
+              <button type="button" @click="paginationPrev" class="btn btn-default" aria-label="Previous" id="table-pagination-prev" :disabled="!drillers.previous">
                 <span aria-hidden="true">Previous</span>
               </button>
             </li>
-            <li v-else>
-              <button type="button" class="btn btn-default" aria-hidden="true" disabled>
-                <span aria-hidden="true">Previous</span>
-              </button>
-            </li>
-            <li v-if="drillers.next">
-              <button type="button" @click="paginationNext" class="btn btn-default" aria-label="Next" id="table-pagination-next">
-                <span aria-hidden="true">Next</span>
-              </button>
-            </li>
-            <li v-else>
-              <button type="button" class="btn btn-default" aria-hidden="true" disabled>
+            <li>
+              <button type="button" @click="paginationNext" class="btn btn-default" aria-label="Next" id="table-pagination-next" :disabled="!drillers.next">
                 <span aria-hidden="true">Next</span>
               </button>
             </li>
@@ -181,22 +171,44 @@ export default {
       'activity'
     ])
   },
+  watch: {
+    // When drillers has a new state, scroll to the top of the searchTable.
+    drillers () {
+      this.scrollToTableTop()
+    }
+  },
   methods: {
+    /**
+     * Gets called when the user clicks on the next button, load the next result page.
+     */
     paginationNext () {
       // API provides 'next' and 'previous' links with query strings for the current search
-      if (this.drillers.next && ~this.drillers.next.indexOf('?')) {
-        const q = this.drillers.next.split('?')[1]
-        this.$store.dispatch(FETCH_DRILLER_LIST, querystring.parse(q))
-      }
+      if (this.drillers.next && ~this.drillers.next.indexOf('?'))
+        this.getPage(this.drillers.next.split('?')[1])
     },
+    /**
+     * Gets called when the user clicks on the previous button, load the previous result page.
+     */
     paginationPrev () {
-      if (this.drillers.previous && ~this.drillers.previous.indexOf('?')) {
-        const q = this.drillers.previous.split('?')[1]
-        this.$store.dispatch(FETCH_DRILLER_LIST, querystring.parse(q))
-      }
+      if (this.drillers.previous && ~this.drillers.previous.indexOf('?'))
+        this.getPage(this.drillers.previous.split('?')[1])
+    },
+    /**
+     * Triggers FETCH_DRILLER_LIST store action.
+     * @param {string} query QueryString of the new page to be loaded.
+     */
+    getPage (query) {
+      if(!query) throw new Error('query parameter is required.')
+      this.$store.dispatch(FETCH_DRILLER_LIST, querystring.parse(query))
     },
     sortBy (sortCode) {
       this.$emit('sort', sortCode)
+    },
+    /**
+     * Scrolls user's screen to the top of the SearchTable component.
+     */
+    scrollToTableTop () {
+      this.$SmoothScroll(this.$el, 100)
     }
   }
 }

--- a/app/frontend/test/unit/specs/search/SearchTable.spec.js
+++ b/app/frontend/test/unit/specs/search/SearchTable.spec.js
@@ -80,29 +80,89 @@ describe('SearchTable.vue', () => {
     })
     expect(wrapper.find('#table-pagination-prev').text()).toEqual('Previous')
   })
-  it('dispatches fetch driller list with correct querystring when pagination next clicked', () => {
+  it('shows the paganation button disabled for previous page when no previous link is present in payload', () => {
+    let fakePersonListCopy = Object.assign({}, fakePersonList)
+    fakePersonListCopy.previous = null
+    getters = {
+      loading: () => false,
+      listError: () => null,
+      drillers: jest.fn().mockReturnValue(fakePersonListCopy),
+      userRoles: () => ({ registry: { edit: false, view: false, approve: false } }),
+      activity: () => 'DRILL'
+    }
+    store = new Vuex.Store({
+      getters,
+      actions
+    })
     const wrapper = shallowMount(SearchTable, {
       store,
       localVue,
       stubs: ['router-link', 'router-view']
     })
-    wrapper.find('#table-pagination-next').trigger('click')
-    expect(actions.FETCH_DRILLER_LIST.mock.calls[0][1]).toEqual({
-      limit: '30',
-      offset: '60'
-    })
+    expect(wrapper.find('#table-pagination-prev').attributes().disabled).toBe('disabled')
   })
-  it('dispatches fetch driller list with correct querystring when pagination prev clicked', () => {
+  it('shows the paganation button disabled for next page when no next link is present in payload', () => {
+    let fakePersonListCopy = Object.assign({}, fakePersonList)
+    fakePersonListCopy.next = null
+    getters = {
+      loading: () => false,
+      listError: () => null,
+      drillers: jest.fn().mockReturnValue(fakePersonListCopy),
+      userRoles: () => ({ registry: { edit: false, view: false, approve: false } }),
+      activity: () => 'DRILL'
+    }
+    store = new Vuex.Store({
+      getters,
+      actions
+    })
     const wrapper = shallowMount(SearchTable, {
       store,
       localVue,
       stubs: ['router-link', 'router-view']
     })
+    expect(wrapper.find('#table-pagination-next').attributes().disabled).toBe('disabled')
+  })
+  it('should call getPage when pagination next clicked', () => {
+    const wrapper = shallowMount(SearchTable, {
+      store,
+      localVue,
+      stubs: ['router-link', 'router-view']
+    })
+    let spy = jest.spyOn(wrapper.vm, 'getPage')
+    wrapper.find('#table-pagination-next').trigger('click')
+    expect(spy).toBeCalledWith('limit=30&offset=60')
+    spy.mockRestore()
+  })
+  it('should call getPage when pagination previous is clicked', () => {
+    const wrapper = shallowMount(SearchTable, {
+      store,
+      localVue,
+      stubs: ['router-link', 'router-view']
+    })
+    let spy = jest.spyOn(wrapper.vm, 'getPage')
     wrapper.find('#table-pagination-prev').trigger('click')
+    expect(spy).toBeCalledWith('limit=30&offset=0')
+    spy.mockRestore()
+  })
+  it('should dispatch fetch driller when getPage is called', () => {
+    const wrapper = shallowMount(SearchTable, {
+      store,
+      localVue,
+      stubs: ['router-link', 'router-view']
+    })
+    wrapper.vm.getPage('limit=30&offset=0')
     expect(actions.FETCH_DRILLER_LIST.mock.calls[0][1]).toEqual({
       limit: '30',
       offset: '0'
     })
+  })
+  it('should throw an error when getPage is called without required parameters', () => {
+    const wrapper = shallowMount(SearchTable, {
+      store,
+      localVue,
+      stubs: ['router-link', 'router-view']
+    })
+    expect(() => { wrapper.vm.getPage(null) }).toThrow(new Error('query parameter is required.'))
   })
   it('emits the column code (e.g. surname) to be sorted when column sort button clicked', () => {
     const wrapper = shallowMount(SearchTable, {


### PR DESCRIPTION
Hi, 
I have added a watch on the drillers to scroll to the top of the table using $smoothScroll ext lib as it is already part of the solution packages.
I know watch should be avoided but in that case I found it suitable to use (learning vue)
also I did a bit of refactoring on the paginationNext/Previous as my first attempt to do the scroll was in the methods...
I'm not sure of the behavior and whether user will like it.
I could not figure out yet how to unit test the watch, I tried multiple approach with spy but couldn't make it trigger...
Let me know what you think...