### PR TITLE
[650] epicwellsummary jump links 3

### DIFF
--- a/app/backend/gwells/static/gwells/css/main.css
+++ b/app/backend/gwells/static/gwells/css/main.css
@@ -1686,8 +1686,6 @@ img.back-to-top:hover {
     .contentPageMainColumn .no-print {
         display: none;
     }
-    
-
 }
 
 .alert-success:before {
@@ -2338,4 +2336,3 @@ h5.twitterUserName a {
 .contentPageMainColumn .jump_link {
     text-decoration: none;
 }
-

--- a/app/backend/gwells/static/gwells/css/main.css
+++ b/app/backend/gwells/static/gwells/css/main.css
@@ -1682,6 +1682,12 @@ img.back-to-top:hover {
     .back-to-top {
         display: none !important;
     }
+    /* hidden for print */
+    .contentPageMainColumn .no-print {
+        display: none;
+    }
+    
+
 }
 
 .alert-success:before {
@@ -2328,3 +2334,8 @@ h5.twitterUserName a {
 .print-button {
     line-height: 38px
 }
+
+.contentPageMainColumn .jump_link {
+    text-decoration: none;
+}
+

--- a/app/backend/wells/templates/wells/well_detail.html
+++ b/app/backend/wells/templates/wells/well_detail.html
@@ -113,6 +113,90 @@
     &nbsp;
 </fieldset>
 
+<fieldset id="jump_links_fieldset" class="no-print">
+    <legend>Quick Links</legend>
+    <div class="row no-gutters">
+        <div class="col-md-4">
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#location_information_fieldset">Location Information</a>
+                </div>
+            </div>
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#well_activity_fieldset">Well Activity</a>
+                </div>
+            </div>
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#well_completion_data_fieldset">Well Completion Data</a>
+                </div>
+            </div>
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#lithology_fieldset">Lithology</a>
+                </div>
+            </div>
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#casing_fieldset">Casing Details</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#surface_seal_fieldset">Surface Seal and Backfill Details</a>
+                </div>
+            </div>
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#perforations_fieldset">Liner Details</a>
+                </div>
+            </div>
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#screen_details_fieldset">Screen Details</a>
+                </div>
+            </div>
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#well_development_fieldset">Well Development</a>
+                </div>
+            </div>
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#well_yield_fieldset">Well Yield</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#well_decommissioning_fieldset">Well Decommissioning</a>
+                </div>
+            </div>
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#well_comments_fieldset">Comments</a>
+                </div>
+            </div>
+            {% if settings.ENABLE_ADDITIONAL_DOCUMENTS %}
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#documents_fieldset">Documentation</a>
+                </div>
+            </div>
+            {% endif %}
+            <div class="row no-gutters">
+                <div class="col-md-12">
+                    <a class="jump_link" href="#disclaimer_fieldset">Disclaimer</a>
+                </div>
+            </div>
+        </div>
+    </div>        
+</fieldset>
+
 <fieldset id="location_information_fieldset">
     <legend>Location Information</legend>
     <div class="row pt-3 print-compressed">


### PR DESCRIPTION
Hi,

I have added the quick links on the wells details page. I did my best for it to look ok and to add as minimum as I could. it was not specified anything for mobile so I left it resized as the other columns...

Couple of suggestion:
* lots of repetition in the well-details template (I've added more 😄 ), could be refactored to create small reusable elements...
* the main.css file is huge, I have put my changes at the bottom, there is also lot of repetition that makes it hard to follow.
* the css should be applied by classes, it is difficult when it changes the rendering of base elements. e.g. bootstrap behavior is changed...

Let me know what you think ;-)
Alex