### PR TITLE
[1104] Re-factor: form and preview split apart

### DIFF
--- a/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
@@ -1,0 +1,474 @@
+<template>
+  <div>
+    <h1 class="card-title">
+      <b-row>
+        <b-col cols="12">
+          <div v-if="activityType === 'STAFF_EDIT'">Well Edit Page</div>
+          <div v-else>Well Activity Submission</div>
+          <b-form-group v-if="activityType !== 'STAFF_EDIT'">
+            <b-form-radio-group button-variant="outline-primary" size="sm" buttons v-model="formIsFlatInput" label="Form layout" class="float-right">
+              <b-form-radio v-bind:value="true" id="flat">Single page</b-form-radio>
+              <b-form-radio v-bind:value="false">Multi page</b-form-radio>
+            </b-form-radio-group>
+          </b-form-group>
+        </b-col>
+      </b-row>
+    </h1>
+    <b-row v-if="activityType === 'STAFF_EDIT'">
+        <b-col lg="3" v-for="step in formSteps[activityType]" :key='step'>
+          <a :href="'#' + step">{{formStepDescriptions[step] ? formStepDescriptions[step] : step}}</a>
+        </b-col>
+      </b-row>
+    <p v-if="activityType !== 'STAFF_EDIT'">Submit activity on a well. <a href="/gwells/">Try a search</a> to see if the well exists in the system before submitting a report.</p>
+
+    <!-- Form load/save -->
+    <b-row v-if="activityType !== 'STAFF_EDIT'">
+      <b-col class="text-right">
+        <b-btn size="sm" variant="outline-primary" @click="saveForm">
+          Save report progress
+          <transition name="bounce" mode="out-in">
+              <i v-show="saveFormSuccess" class="fa fa-check text-success"></i>
+          </transition>
+        </b-btn>
+        <b-btn size="sm" variant="outline-primary" @click="loadConfirmation" ref="confirmLoadBtn" :disabled="isLoadFormDisabled">
+          Load saved report
+          <transition name="bounce">
+              <i v-show="loadFormSuccess" class="fa fa-check text-success"></i>
+          </transition>
+        </b-btn>
+      </b-col>
+    </b-row>
+
+    <!-- Type of work performed -->
+    <activity-type class="my-3"
+      v-if="currentStep === 'activityType' || (formIsFlat && sections.activityType)"
+      id="activityType"
+      :wellActivityType.sync="activityTypeInput"
+    />
+
+    <!-- Type of well -->
+    <well-type class="my-3"
+      v-if="currentStep === 'wellType' || (formIsFlat && sections.wellType)"
+      id="wellType"
+      :wellTagNumber.sync="form.well"
+      :wellActivityType.sync="activityType"
+      :wellClass.sync="form.well_class"
+      :wellSubclass.sync="form.well_subclass"
+      :intendedWaterUse.sync="form.intended_water_use"
+      :units.sync="units"
+      :idPlateNumber.sync="form.identification_plate_number"
+      :wellPlateAttached.sync="form.well_plate_attached"
+      :workStartDate.sync="form.work_start_date"
+      :workEndDate.sync="form.work_end_date"
+      :errors="errors"
+      :fieldsLoaded="fieldsLoaded"
+    />
+
+    <!-- Person responsible for work -->
+    <person-responsible class="my-3"
+      v-if="currentStep === 'personResponsible' || (formIsFlat && sections.personResponsible)"
+      id="personResponsible"
+      :drillerName.sync="form.driller_name"
+      :consultantName.sync="form.consultant_name"
+      :consultantCompany.sync="form.consultant_company"
+      :personResponsible.sync="form.driller_responsible"
+      :drillerSameAsPersonResponsible.sync="form.meta.drillerSameAsPersonResponsible"
+      :errors="errors"
+      :fieldsLoaded="fieldsLoaded"
+    />
+
+    <!-- Owner information -->
+    <owner class="my-3"
+      v-if="currentStep === 'wellOwner' || (formIsFlat && sections.wellOwner)"
+      id="wellOwner"
+      :ownerFullName.sync="form.owner_full_name"
+      :ownerMailingAddress.sync="form.owner_mailing_address"
+      :ownerProvinceState.sync="form.owner_province_state"
+      :ownerCity.sync="form.owner_city"
+      :ownerPostalCode.sync="form.owner_postal_code"
+      :errors="errors"
+      :fieldsLoaded="fieldsLoaded"
+    />
+
+    <!-- Well location -->
+    <location class="my-3"
+      v-if="currentStep === 'wellLocation' || (formIsFlat && sections.wellLocation)"
+      id="wellLocation"
+      :ownerMailingAddress.sync="form.owner_mailing_address"
+      :ownerProvinceState.sync="form.owner_province_state"
+      :ownerCity.sync="form.owner_city"
+      :ownerPostalCode.sync="form.owner_postal_code"
+      :streetAddress.sync="form.street_address"
+      :city.sync="form.city"
+      :legalLot.sync="form.legal_lot"
+      :legalPlan.sync="form.legal_plan"
+      :legalDistrictLot.sync="form.legal_district_lot"
+      :legalBlock.sync="form.legal_block"
+      :legalSection.sync="form.legal_section"
+      :legalTownship.sync="form.legal_township"
+      :legalRange.sync="form.legal_range"
+      :landDistrict.sync="form.land_district"
+      :legalPID.sync="form.legal_pid"
+      :wellLocationDescription.sync="form.well_location_description"
+    />
+
+    <!-- Coords -->
+    <coords class="my-3"
+      v-if="currentStep === 'wellCoords' || (formIsFlat && sections.wellCoords)"
+      id="wellCoords"
+      :latitude.sync="form.latitude"
+      :longitude.sync="form.longitude"
+    />
+
+    <!-- Method of Drilling -->
+    <method-of-drilling class="my-3"
+      v-if="currentStep === 'method' || (formIsFlat && sections.method)"
+      id="method"
+      :groundElevation.sync="form.ground_elevation"
+      :groundElevationMethod.sync="form.ground_elevation_method"
+      :drillingMethod.sync="form.drilling_method"
+      :otherDrillingMethod.sync="form.other_drilling_method"
+      :wellOrientation.sync="form.well_orientation"
+    />
+
+    <!-- Closure/Decommission Description -->
+    <closure-description class="my-3"
+      v-if="currentStep === 'closureDescription' || (formIsFlat && sections.closureDescription)"
+      id="closureDescription"
+      :closureDescriptionSet.sync="form.decommission_description_set">
+
+    </closure-description>
+
+    <!-- Lithology -->
+    <lithology class="my-3"
+      v-if="currentStep === 'lithology' || (formIsFlat && sections.lithology)"
+      id="lithology"
+      :lithology.sync="form.lithologydescription_set"
+    />
+
+    <!-- Casings -->
+    <casings class="my-3"
+      :key="`casingsComponent${componentUpdateTrigger}`"
+      v-if="currentStep === 'casings' || (formIsFlat && sections.casings)"
+      id="casings"
+      :casings.sync="form.casing_set"
+      :errors="errors"
+      :fieldsLoaded="fieldsLoaded"
+    />
+
+    <!-- Surface Seal / Backfill Material -->
+    <backfill class="my-3"
+      v-if="currentStep === 'backfill' || (formIsFlat && sections.backfill)"
+      id="backfill"
+      :surfaceSealMaterial.sync="form.surface_seal_material"
+      :surfaceSealDepth.sync="form.surface_seal_depth"
+      :surfaceSealThickness.sync="form.surface_seal_thickness"
+      :surfaceSealMethod.sync="form.surface_seal_method"
+      :backfillAboveSurfaceSeal.sync="form.backfill_above_surface_seal"
+      :backfillDepth.sync="form.backfill_above_surface_seal_depth"
+    />
+
+    <!-- Liner Information -->
+    <liner class="my-3"
+      v-if="currentStep === 'liner' || (formIsFlat && sections.liner)"
+      id="liner"
+      :linerMaterial.sync="form.liner_material"
+      :linerDiameter.sync="form.liner_diameter"
+      :linerThickness.sync="form.liner_thickness"
+      :linerFrom.sync="form.liner_from"
+      :linerTo.sync="form.liner_to"
+      :linerPerforations.sync="form.linerperforation_set"
+      :errors="errors"
+      :fieldsLoaded="fieldsLoaded"
+    />
+
+    <!-- Screens -->
+    <screens class="my-3"
+      v-if="currentStep === 'screens' || (formIsFlat && sections.screens)"
+      id="screens"
+      :screenIntakeMethod.sync="form.screen_intake_method"
+      :screenType.sync="form.screen_type"
+      :screenMaterial.sync="form.screen_material"
+      :otherScreenMaterial.sync="form.other_screen_material"
+      :screenOpening.sync="form.screen_opening"
+      :screenBottom.sync="form.screen_bottom"
+      :screens.sync="form.screen_set"
+      :errors="errors"
+      :fieldsLoaded="fieldsLoaded"
+    />
+
+    <!-- Filter Pack -->
+    <filterPack class="my-3"
+      v-if="currentStep === 'filterPack' || (formIsFlat && sections.filterPack)"
+      id="filterPack"
+      :filterPackFrom.sync="form.filter_pack_from"
+      :filterPackTo.sync="form.filter_pack_to"
+      :filterPackThickness.sync="form.filter_pack_thickness"
+      :filterPackMaterial.sync="form.filter_pack_material"
+      :filterPackMaterialSize.sync="form.filter_pack_material_size"
+    />
+
+    <!-- Well Development -->
+    <development class="my-3"
+      v-if="currentStep === 'wellDevelopment' || (formIsFlat && sections.wellDevelopment)"
+      id="wellDevelopment"
+      :developmentMethod.sync="form.development_method"
+      :developmentHours.sync="form.development_hours"
+      :developmentNotes.sync="form.development_notes"
+    />
+
+    <!-- Yield (Production Data) -->
+    <yield class="my-3"
+      v-if="currentStep === 'wellYield' || (formIsFlat && sections.wellYield)"
+      id="wellYield"
+      :productionData.sync="form.production_data_set"
+    />
+
+    <!-- Water Quality -->
+    <water-quality class="my-3"
+      v-if="currentStep === 'waterQuality' || (formIsFlat && sections.waterQuality)"
+      id="waterQuality"
+      :waterQualityCharacteristics.sync="form.water_quality_characteristics"
+      :waterQualityColour.sync="form.water_quality_colour"
+      :waterQualityOdour.sync="form.water_quality_odour"
+      :emsID.sync="form.ems_id"
+    />
+
+      <!-- Well Completion Data -->
+    <completion class="my-3"
+      v-if="currentStep === 'wellCompletion' || (formIsFlat && sections.wellCompletion)"
+      id="wellCompletion"
+      :totalDepthDrilled.sync="form.total_depth_drilled"
+      :finishedWellDepth.sync="form.finished_well_depth"
+      :finalCasingStickUp.sync="form.final_casing_stick_up"
+      :bedrockDepth.sync="form.bedrock_depth"
+      :staticWaterLevel.sync="form.static_water_level"
+      :wellYield.sync="form.well_yield"
+      :artesianFlow.sync="form.artesian_flow"
+      :artesianPressure.sync="form.artesian_pressure"
+      :wellCapType.sync="form.well_cap_type"
+      :wellDisinfected.sync="form.well_disinfected"
+    />
+
+    <decommission-information class="my-3"
+      v-if="currentStep === 'decommissionInformation' || (formIsFlat && sections.decommissionInformation)"
+      id="decommissionInformation"
+      :finishedWellDepth.sync="form.finished_well_depth"
+      :decommissionReason.sync="form.decommission_reason"
+      :decommissionMethod.sync="form.decommission_method"
+      :sealantMaterial.sync="form.sealant_material"
+      :backfillMaterial.sync="form.backfill_material"
+      :decommissionDetails.sync="form.decommission_details"
+    />
+
+    <!-- Comments -->
+    <comments class="my-3"
+      v-if="currentStep === 'comments' || (formIsFlat && sections.comments)"
+      id="comments"
+      :comments.sync="form.comments"
+      :alternativeSpecsSubmitted.sync="form.alternative_specs_submitted"
+    />
+
+    <!-- Back / Next / Submit controls -->
+    <b-row class="mt-5">
+      <b-col v-if="!formIsFlat">
+        <b-btn v-if="step > 1 && !formIsFlat" @click="step > 1 ? step-- : null" variant="primary">Back</b-btn>
+      </b-col>
+      <b-col class="pr-4 text-right">
+        <b-btn v-if="step < maxSteps && !formIsFlat" @click="step++" variant="primary">Next</b-btn>
+        <span v-else>
+          <b-btn variant="primary" @click="$emit('preview')">Preview &amp; Submit</b-btn>
+        </span>
+      </b-col>
+    </b-row>
+
+    <!-- Form reload (load from save) confirmation -->
+    <b-modal
+      v-model="confirmLoadModal"
+      centered
+      title="Confirm load submission data"
+      @shown="$refs.confirmLoadConfirmBtn.focus()"
+      :return-focus="$refs.loadFormBtn">
+      Are you sure you want to load the previously saved activity report? Your current report will be overwritten.
+      <div slot="modal-footer">
+        <b-btn variant="primary" @click="confirmLoadModal=false;loadForm()" ref="confirmLoadConfirmBtn">
+          Load
+        </b-btn>
+        <b-btn variant="light" @click="confirmLoadModal=false">
+          Cancel
+        </b-btn>
+      </div>
+    </b-modal>
+  </div>
+</template>
+
+<script>
+import ActivityType from './ActivityType.vue'
+import WellType from './WellType.vue'
+import PersonResponsible from './PersonResponsible.vue'
+import Owner from './Owner.vue'
+import Location from './Location.vue'
+import Coords from './Coords.vue'
+import MethodOfDrilling from './MethodOfDrilling.vue'
+import Lithology from './Lithology.vue'
+import Casings from './Casings.vue'
+import Backfill from './Backfill.vue'
+import Liner from './Liner.vue'
+import Screens from './Screens.vue'
+import FilterPack from './FilterPack.vue'
+import Development from './Development.vue'
+import Yield from './Yield.vue'
+import WaterQuality from './WaterQuality.vue'
+import Completion from './Completion.vue'
+import Comments from './Comments.vue'
+import ClosureDescription from './ClosureDescription.vue'
+import DecommissionInformation from './DecommissionInformation.vue'
+import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+export default {
+  name: 'SubmissionsForm',
+  mixins: [inputBindingsMixin],
+  props: {
+    form: {
+      type: Object,
+      isInput: false
+    },
+    sections: {
+      type: Object,
+      isInput: false
+    },
+    activityType: {
+      type: String
+    },
+    formIsFlat: {
+      type: Boolean
+    },
+    formSteps: {
+      type: Object,
+      isInput: false
+    },
+    errors: {
+      type: Object,
+      isInput: false
+    }
+  },
+  components: {
+    ActivityType,
+    WellType,
+    PersonResponsible,
+    Owner,
+    Location,
+    Coords,
+    MethodOfDrilling,
+    Lithology,
+    Casings,
+    Backfill,
+    Liner,
+    Screens,
+    FilterPack,
+    Development,
+    Yield,
+    WaterQuality,
+    Completion,
+    Comments,
+    ClosureDescription,
+    DecommissionInformation
+  },
+  data () {
+    return {
+      units: 'imperial',
+      saveFormSuccess: false,
+      hasHadSaveFormSuccess: false,
+      loadFormSuccess: false,
+      confirmLoadModal: false,
+      // componentUpdateTrigger can be appended to a component's key. Changing this value will cause
+      // these components to be re-created, allowing the created() and mounted() hooks to re-run.
+      componentUpdateTrigger: 0,
+      step: 1,
+      fieldsLoaded: {},
+      formStepDescriptions: {
+        'activityType': 'Type of work',
+        'wellType': 'Well class',
+        'wellOwner': 'Well owner',
+        'wellLocation': 'Well location',
+        'wellCoords': 'Geographic coordinates',
+        'method': 'Method of drilling',
+        'closureDescription': 'Decommission description',
+        'lithology': 'Lithology',
+        'casings': 'Casing details',
+        'backfill': 'Surface seal and backfill information',
+        'liner': 'Liner information',
+        'screens': 'Screen information',
+        'filterPack': 'Filter pack',
+        'wellDevelopment': 'Well development',
+        'wellYield': 'Well yield estimation',
+        'waterQuality': 'Water quality',
+        'wellCompletion': 'Well completion data',
+        'decommissionInformation': 'Well decommission information',
+        'comments': 'Comments',
+        'personResponsible': 'Person Responsible for Work'
+      }
+    }
+  },
+  computed: {
+    formStep () {
+      // the numbered step that the user is on
+      // this value is bound by the length of the list of steps for the
+      // current type of submission
+      return (this.step % (this.maxSteps + 1))
+    },
+    maxSteps () {
+      return this.formSteps[this.activityType].length
+    },
+    currentStep () {
+      // the string name of the step corresponding to formStep
+      // this will determine which step is currently displayed
+      return this.formSteps[this.activityType][this.formStep - 1]
+    },
+    isLoadFormDisabled () {
+      // During unit tests, the localStorage object might not exist, so we have to check it's existence.
+      return !window.localStorage || (window.localStorage.getItem('savedFormData') === null && !this.hasHadSaveFormSuccess)
+    }
+  },
+  methods: {
+    saveForm () {
+      // saves a copy of form data locally
+      this.saveStatusReset()
+      const data = JSON.stringify(this.form)
+      localStorage.setItem('savedFormData', data)
+      setTimeout(() => { this.saveFormSuccess = true }, 10)
+      setTimeout(() => { this.saveFormSuccess = false; this.hasHadSaveFormSuccess = true }, 1000)
+    },
+    loadForm () {
+      this.saveStatusReset()
+      const storedData = localStorage.getItem('savedFormData')
+      if (storedData) {
+        this.$emit('resetForm')
+
+        // some form features depend on watching form field values.
+        // setTimeout pushes rendering new data down execution queue
+        // to give watchers a chance to act on each set of changes
+        // (e.g. form reset, form population)
+        setTimeout(() => {
+          const parsedData = JSON.parse(storedData)
+          this.form = Object.assign(this.form, parsedData)
+          this.fieldsLoaded = Object.assign(this.fieldsLoaded, parsedData)
+          setTimeout(() => { this.loadFormSuccess = true }, 0)
+          setTimeout(() => { this.fieldsLoaded = {} }, 0)
+          setTimeout(() => { this.loadFormSuccess = false }, 1000)
+        }, 0)
+      }
+    },
+    loadConfirmation () {
+      this.confirmLoadModal = true
+    },
+    saveStatusReset () {
+      this.saveFormSuccess = false
+      this.loadFormSuccess = false
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
+++ b/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
@@ -1,5 +1,13 @@
 <template>
   <div>
+    <h1 class="card-title">
+      <b-row>
+        <b-col cols="12">
+          <div>Well Activity Submission Preview</div>
+          <b-btn class="float-right" @click="$emit('back')" variant="primary">Back to Edit</b-btn>
+        </b-col>
+      </b-row>
+    </h1>
     <fieldset class="my-3 detail-section">
       <legend>Type of Work and Well Class</legend>
       <b-row>
@@ -403,6 +411,15 @@
       </p>
     </fieldset>
 
+    <!-- Back / Next / Submit controls -->
+    <b-row class="mt-5">
+      <b-col>
+        <b-btn @click="$emit('back')" variant="primary">Back to Edit</b-btn>
+      </b-col>
+      <b-col class="pr-4 text-right">
+        <b-btn id="formSubmitButton" type="submit" variant="primary" ref="activitySubmitBtn" :disabled="formSubmitLoading">Submit</b-btn>
+      </b-col>
+    </b-row>
   </div>
 </template>
 
@@ -424,6 +441,11 @@ export default {
     'activity',
     'sections'
   ],
+  data () {
+    return {
+      formSubmitLoading: false
+    }
+  },
   computed: {
     wellSubclass () {
       let subclassCodes = []

--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -1,368 +1,78 @@
 <template>
   <div class="card" v-if="userRoles.wells.edit || userRoles.submissions.edit">
     <div class="card-body">
-      <h1 class="card-title">
-        <b-row>
-          <b-col cols="12">
-              <div v-if="activityType === 'STAFF_EDIT'">Well Edit Page</div>
-              <div v-else>Well Activity Submission <span v-if="preview"> Preview</span></div>
-            <b-form-group v-if="activityType !== 'STAFF_EDIT' && !preview">
-              <b-form-radio-group button-variant="outline-primary" size="sm" buttons v-model="formIsFlat" label="Form layout" class="float-right">
-                <b-form-radio v-bind:value="true" id="flat">Single page</b-form-radio>
-                <b-form-radio v-bind:value="false">Multi page</b-form-radio>
-              </b-form-radio-group>
-            </b-form-group>
-            <b-btn class="float-right" v-if="preview" @click="handlePreviewBackButton" variant="primary">Back to Edit</b-btn>
-          </b-col>
-        </b-row>
-      </h1>
-      <b-row v-if="!preview && activityType === 'STAFF_EDIT'">
-          <b-col lg="3" v-for="step in formSteps[activityType]" :key='step'>
-            <a :href="'#' + step">{{formStepDescriptions[step] ? formStepDescriptions[step] : step}}</a>
-          </b-col>
-        </b-row>
-      <p v-if="!preview && activityType !== 'STAFF_EDIT'">Submit activity on a well. <a href="/gwells/">Try a search</a> to see if the well exists in the system before submitting a report.</p>
 
-      <!-- Activity submission form -->
       <b-form @submit.prevent="confirmSubmit">
-        <div v-if="!preview">
-          <!-- Form load/save -->
-          <b-row v-if="activityType !== 'STAFF_EDIT'">
-            <b-col class="text-right">
-              <b-btn size="sm" variant="outline-primary" @click="saveForm">
-                Save report progress
-                <transition name="bounce" mode="out-in">
-                    <i v-show="saveFormSuccess" class="fa fa-check text-success"></i>
-                </transition>
-              </b-btn>
-              <b-btn size="sm" variant="outline-primary" @click="loadConfirmation" ref="confirmLoadBtn" :disabled="isLoadFormDisabled">
-                Load saved report
-                <transition name="bounce">
-                    <i v-show="loadFormSuccess" class="fa fa-check text-success"></i>
-                </transition>
-              </b-btn>
-            </b-col>
-          </b-row>
-
-          <!-- Type of work performed -->
-          <activity-type class="my-3"
-            v-if="currentStep === 'activityType' || (formIsFlat && displayFormSection.activityType)"
-            id="activityType"
-            :wellActivityType.sync="activityType"
+        <!-- if preview === true : Preview -->
+        <submission-preview
+          v-if="preview"
+          :form="form"
+          :activity="activityType"
+          :sections="displayFormSection"
+          :errors="errors"
+          v-on:back="handlePreviewBackButton"
+          />
+        <!-- if preview === false : Activity submission form -->
+        <activity-submission-form
+          v-else
+          :form="form"
+          :activityType.sync="activityType"
+          :sections="displayFormSection"
+          :formSteps="formSteps"
+          :errors="errors"
+          :formIsFlat.sync="formIsFlat"
+          v-on:preview="handlePreviewButton"
+          v-on:resetForm="resetForm"
           />
 
-          <!-- Type of well -->
-          <well-type class="my-3"
-            v-if="currentStep === 'wellType' || (formIsFlat && displayFormSection.wellType)"
-            id="wellType"
-            :wellTagNumber.sync="form.well"
-            :wellActivityType.sync="activityType"
-            :wellClass.sync="form.well_class"
-            :wellSubclass.sync="form.well_subclass"
-            :intendedWaterUse.sync="form.intended_water_use"
-            :units.sync="units"
-            :idPlateNumber.sync="form.identification_plate_number"
-            :wellPlateAttached.sync="form.well_plate_attached"
-            :workStartDate.sync="form.work_start_date"
-            :workEndDate.sync="form.work_end_date"
-            :errors="errors"
-            :fieldsLoaded="fieldsLoaded"
-          />
-
-          <!-- Person responsible for work -->
-          <person-responsible class="my-3"
-            v-if="currentStep === 'personResponsible' || (formIsFlat && displayFormSection.personResponsible)"
-            id="personResponsible"
-            :drillerName.sync="form.driller_name"
-            :consultantName.sync="form.consultant_name"
-            :consultantCompany.sync="form.consultant_company"
-            :personResponsible.sync="form.driller_responsible"
-            :drillerSameAsPersonResponsible.sync="form.meta.drillerSameAsPersonResponsible"
-            :errors="errors"
-            :fieldsLoaded="fieldsLoaded"
-          />
-
-          <!-- Owner information -->
-          <owner class="my-3"
-            v-if="currentStep === 'wellOwner' || (formIsFlat && displayFormSection.wellOwner)"
-            id="wellOwner"
-            :ownerFullName.sync="form.owner_full_name"
-            :ownerMailingAddress.sync="form.owner_mailing_address"
-            :ownerProvinceState.sync="form.owner_province_state"
-            :ownerCity.sync="form.owner_city"
-            :ownerPostalCode.sync="form.owner_postal_code"
-            :errors="errors"
-            :fieldsLoaded="fieldsLoaded"
-          />
-
-          <!-- Well location -->
-          <location class="my-3"
-            v-if="currentStep === 'wellLocation' || (formIsFlat && displayFormSection.wellLocation)"
-            id="wellLocation"
-            :ownerMailingAddress.sync="form.owner_mailing_address"
-            :ownerProvinceState.sync="form.owner_province_state"
-            :ownerCity.sync="form.owner_city"
-            :ownerPostalCode.sync="form.owner_postal_code"
-            :streetAddress.sync="form.street_address"
-            :city.sync="form.city"
-            :legalLot.sync="form.legal_lot"
-            :legalPlan.sync="form.legal_plan"
-            :legalDistrictLot.sync="form.legal_district_lot"
-            :legalBlock.sync="form.legal_block"
-            :legalSection.sync="form.legal_section"
-            :legalTownship.sync="form.legal_township"
-            :legalRange.sync="form.legal_range"
-            :landDistrict.sync="form.land_district"
-            :legalPID.sync="form.legal_pid"
-            :wellLocationDescription.sync="form.well_location_description"
-          />
-
-          <!-- Coords -->
-          <coords class="my-3"
-            v-if="currentStep === 'wellCoords' || (formIsFlat && displayFormSection.wellCoords)"
-            id="wellCoords"
-            :latitude.sync="form.latitude"
-            :longitude.sync="form.longitude"
-          />
-
-          <!-- Method of Drilling -->
-          <method-of-drilling class="my-3"
-            v-if="currentStep === 'method' || (formIsFlat && displayFormSection.method)"
-            id="method"
-            :groundElevation.sync="form.ground_elevation"
-            :groundElevationMethod.sync="form.ground_elevation_method"
-            :drillingMethod.sync="form.drilling_method"
-            :otherDrillingMethod.sync="form.other_drilling_method"
-            :wellOrientation.sync="form.well_orientation"
-          />
-
-          <!-- Closure/Decommission Description -->
-          <closure-description class="my-3"
-            v-if="currentStep === 'closureDescription' || (formIsFlat && displayFormSection.closureDescription)"
-            id="closureDescription"
-            :closureDescriptionSet.sync="form.decommission_description_set">
-
-          </closure-description>
-
-          <!-- Lithology -->
-          <lithology class="my-3"
-            v-if="currentStep === 'lithology' || (formIsFlat && displayFormSection.lithology)"
-            id="lithology"
-            :lithology.sync="form.lithologydescription_set"
-          />
-
-          <!-- Casings -->
-          <casings class="my-3"
-            :key="`casingsComponent${componentUpdateTrigger}`"
-            v-if="currentStep === 'casings' || (formIsFlat && displayFormSection.casings)"
-            id="casings"
-            :casings.sync="form.casing_set"
-            :errors="errors"
-            :fieldsLoaded="fieldsLoaded"
-          />
-
-          <!-- Surface Seal / Backfill Material -->
-          <backfill class="my-3"
-            v-if="currentStep === 'backfill' || (formIsFlat && displayFormSection.backfill)"
-            id="backfill"
-            :surfaceSealMaterial.sync="form.surface_seal_material"
-            :surfaceSealDepth.sync="form.surface_seal_depth"
-            :surfaceSealThickness.sync="form.surface_seal_thickness"
-            :surfaceSealMethod.sync="form.surface_seal_method"
-            :backfillAboveSurfaceSeal.sync="form.backfill_above_surface_seal"
-            :backfillDepth.sync="form.backfill_above_surface_seal_depth"
-          />
-
-          <!-- Liner Information -->
-          <liner class="my-3"
-            v-if="currentStep === 'liner' || (formIsFlat && displayFormSection.liner)"
-            id="liner"
-            :linerMaterial.sync="form.liner_material"
-            :linerDiameter.sync="form.liner_diameter"
-            :linerThickness.sync="form.liner_thickness"
-            :linerFrom.sync="form.liner_from"
-            :linerTo.sync="form.liner_to"
-            :linerPerforations.sync="form.linerperforation_set"
-            :errors="errors"
-            :fieldsLoaded="fieldsLoaded"
-          />
-
-          <!-- Screens -->
-          <screens class="my-3"
-            v-if="currentStep === 'screens' || (formIsFlat && displayFormSection.screens)"
-            id="screens"
-            :screenIntakeMethod.sync="form.screen_intake_method"
-            :screenType.sync="form.screen_type"
-            :screenMaterial.sync="form.screen_material"
-            :otherScreenMaterial.sync="form.other_screen_material"
-            :screenOpening.sync="form.screen_opening"
-            :screenBottom.sync="form.screen_bottom"
-            :screens.sync="form.screen_set"
-            :errors="errors"
-            :fieldsLoaded="fieldsLoaded"
-          />
-
-          <!-- Filter Pack -->
-          <filterPack class="my-3"
-            v-if="currentStep === 'filterPack' || (formIsFlat && displayFormSection.filterPack)"
-            id="filterPack"
-            :filterPackFrom.sync="form.filter_pack_from"
-            :filterPackTo.sync="form.filter_pack_to"
-            :filterPackThickness.sync="form.filter_pack_thickness"
-            :filterPackMaterial.sync="form.filter_pack_material"
-            :filterPackMaterialSize.sync="form.filter_pack_material_size"
-          />
-
-          <!-- Well Development -->
-          <development class="my-3"
-            v-if="currentStep === 'wellDevelopment' || (formIsFlat && displayFormSection.wellDevelopment)"
-            id="wellDevelopment"
-            :developmentMethod.sync="form.development_method"
-            :developmentHours.sync="form.development_hours"
-            :developmentNotes.sync="form.development_notes"
-          />
-
-          <!-- Yield (Production Data) -->
-          <yield class="my-3"
-            v-if="currentStep === 'wellYield' || (formIsFlat && displayFormSection.wellYield)"
-            id="wellYield"
-            :productionData.sync="form.production_data_set"
-          />
-
-          <!-- Water Quality -->
-          <water-quality class="my-3"
-            v-if="currentStep === 'waterQuality' || (formIsFlat && displayFormSection.waterQuality)"
-            id="waterQuality"
-            :waterQualityCharacteristics.sync="form.water_quality_characteristics"
-            :waterQualityColour.sync="form.water_quality_colour"
-            :waterQualityOdour.sync="form.water_quality_odour"
-            :emsID.sync="form.ems_id"
-          />
-
-            <!-- Well Completion Data -->
-          <completion class="my-3"
-            v-if="currentStep === 'wellCompletion' || (formIsFlat && displayFormSection.wellCompletion)"
-            id="wellCompletion"
-            :totalDepthDrilled.sync="form.total_depth_drilled"
-            :finishedWellDepth.sync="form.finished_well_depth"
-            :finalCasingStickUp.sync="form.final_casing_stick_up"
-            :bedrockDepth.sync="form.bedrock_depth"
-            :staticWaterLevel.sync="form.static_water_level"
-            :wellYield.sync="form.well_yield"
-            :artesianFlow.sync="form.artesian_flow"
-            :artesianPressure.sync="form.artesian_pressure"
-            :wellCapType.sync="form.well_cap_type"
-            :wellDisinfected.sync="form.well_disinfected"
-          />
-
-          <decommission-information class="my-3"
-            v-if="currentStep === 'decommissionInformation' || (formIsFlat && displayFormSection.decommissionInformation)"
-            id="decommissionInformation"
-            :finishedWellDepth.sync="form.finished_well_depth"
-            :decommissionReason.sync="form.decommission_reason"
-            :decommissionMethod.sync="form.decommission_method"
-            :sealantMaterial.sync="form.sealant_material"
-            :backfillMaterial.sync="form.backfill_material"
-            :decommissionDetails.sync="form.decommission_details"
-          />
-
-          <!-- Comments -->
-          <comments class="my-3"
-            v-if="currentStep === 'comments' || (formIsFlat && displayFormSection.comments)"
-            id="comments"
-            :comments.sync="form.comments"
-            :alternativeSpecsSubmitted.sync="form.alternative_specs_submitted"
-          />
-        </div>
-
-        <div v-if="preview">
-          <!-- Preview -->
-          <submission-preview
-            :form="form"
-            :activity="activityType"
-            :sections="displayFormSection"/>
-        </div>
-          <!-- Back / Next / Submit controls -->
-          <b-row class="mt-5">
-            <b-col v-if="!formIsFlat">
-              <b-btn v-if="step > 1 && !preview && !formIsFlat" @click="step > 1 ? step-- : null" variant="primary">Back</b-btn>
-              <b-btn v-if="preview" @click="handlePreviewBackButton" variant="primary">Back to Edit</b-btn>
-            </b-col>
-            <b-col class="pr-4 text-right">
-              <b-btn v-if="step < maxSteps && !formIsFlat && !preview" @click="step++" variant="primary">Next</b-btn>
-              <span v-else>
-                <b-btn v-if="preview" id="formSubmitButton" type="submit" variant="primary" ref="activitySubmitBtn" :disabled="formSubmitLoading">Submit</b-btn>
-                <b-btn v-else variant="primary" @click="handlePreviewButton">Preview &amp; Submit</b-btn>
-              </span>
-            </b-col>
-          </b-row>
-      </b-form>
-
-      <!-- Form submission success message -->
-      <b-alert
-          :show="formSubmitSuccess"
-          dismissible
-          @dismissed="formSubmitSuccess=false"
-          variant="success"
-          class="mt-3">Report submitted!
-        <a v-if="formSubmitSuccessWellTag" :href="`/gwells/well/${formSubmitSuccessWellTag}`">
-          View well details for well {{formSubmitSuccessWellTag}}
-        </a>
-      </b-alert>
-
-      <!-- Form submission error message -->
-      <b-alert
-          :show="formSubmitError"
-          dismissible
-          @dismissed="formSubmitError=false"
-          variant="danger"
-          class="mt-3">
-        <span v-if="errors && errors.detail">
-          {{ errors.detail }}
-        </span>
-        <div v-if="errors && errors != {}">
-          <div v-for="(field, i) in Object.keys(errors)" :key="`submissionError${i}`">
-            {{field | readable}} : <span v-for="(e, j) in errors[field]" :key="`submissionError${i}-${j}`">{{ e }}</span>
-          </div>
-        </div>
+        <!-- Form submission success message -->
+        <b-alert
+            :show="formSubmitSuccess"
+            dismissible
+            @dismissed="formSubmitSuccess=false"
+            variant="success"
+            class="mt-3">Report submitted!
+          <a v-if="formSubmitSuccessWellTag" :href="`/gwells/well/${formSubmitSuccessWellTag}`">
+            View well details for well {{formSubmitSuccessWellTag}}
+          </a>
         </b-alert>
 
-      <!-- Form submission confirmation -->
-      <b-modal
-          v-model="confirmSubmitModal"
-          id="confirmSubmitModal"
-          centered
-          title="Confirm submission"
-          @shown="$refs.confirmSubmitConfirmBtn.focus()"
-          :return-focus="$refs.activitySubmitBtn">
-        Are you sure you want to submit this activity report?
-        <div slot="modal-footer">
-          <b-btn variant="primary" @click="confirmSubmitModal=false;formSubmit()" ref="confirmSubmitConfirmBtn">
-            Save
-          </b-btn>
-          <b-btn variant="light" @click="confirmSubmitModal=false">
-            Cancel
-          </b-btn>
-        </div>
-      </b-modal>
+        <!-- Form submission error message -->
+        <b-alert
+            :show="formSubmitError"
+            dismissible
+            @dismissed="formSubmitError=false"
+            variant="danger"
+            class="mt-3">
+          <span v-if="errors && errors.detail">
+            {{ errors.detail }}
+          </span>
+          <div v-if="errors && errors != {}">
+            <div v-for="(field, i) in Object.keys(errors)" :key="`submissionError${i}`">
+              {{field | readable}} : <span v-for="(e, j) in errors[field]" :key="`submissionError${i}-${j}`">{{ e }}</span>
+            </div>
+          </div>
+        </b-alert>
 
-      <!-- Form reload (load from save) confirmation -->
-      <b-modal
-          v-model="confirmLoadModal"
-          centered
-          title="Confirm load submission data"
-          @shown="$refs.confirmLoadConfirmBtn.focus()"
-          :return-focus="$refs.loadFormBtn">
-        Are you sure you want to load the previously saved activity report? Your current report will be overwritten.
-        <div slot="modal-footer">
-          <b-btn variant="primary" @click="confirmLoadModal=false;loadForm()" ref="confirmLoadConfirmBtn">
-            Load
-          </b-btn>
-          <b-btn variant="light" @click="confirmLoadModal=false">
-            Cancel
-          </b-btn>
-        </div>
-      </b-modal>
+        <!-- Form submission confirmation -->
+        <b-modal
+            v-model="confirmSubmitModal"
+            id="confirmSubmitModal"
+            centered
+            title="Confirm submission"
+            @shown="$refs.confirmSubmitConfirmBtn.focus()"
+            :return-focus="$refs.activitySubmitBtn">
+          Are you sure you want to submit this activity report?
+          <div slot="modal-footer">
+            <b-btn variant="primary" @click="confirmSubmitModal=false;formSubmit()" ref="confirmSubmitConfirmBtn">
+              Save
+            </b-btn>
+            <b-btn variant="light" @click="confirmSubmitModal=false">
+              Cancel
+            </b-btn>
+          </div>
+        </b-modal>
+      </b-form>
     </div>
   </div>
 </template>
@@ -372,52 +82,14 @@ import { mapGetters } from 'vuex'
 import ApiService from '@/common/services/ApiService.js'
 import { FETCH_CODES } from '../store/actions.types.js'
 import inputFormatMixin from '@/common/inputFormatMixin.js'
-import ActivityType from '@/submissions/components/SubmissionForm/ActivityType.vue'
-import WellType from '@/submissions/components/SubmissionForm/WellType.vue'
-import PersonResponsible from '@/submissions/components/SubmissionForm/PersonResponsible.vue'
-import Owner from '@/submissions/components/SubmissionForm/Owner.vue'
-import Location from '@/submissions/components/SubmissionForm/Location.vue'
-import Coords from '@/submissions/components/SubmissionForm/Coords.vue'
-import MethodOfDrilling from '@/submissions/components/SubmissionForm/MethodOfDrilling.vue'
-import Lithology from '@/submissions/components/SubmissionForm/Lithology.vue'
-import Casings from '@/submissions/components/SubmissionForm/Casings.vue'
-import Backfill from '@/submissions/components/SubmissionForm/Backfill.vue'
-import Liner from '@/submissions/components/SubmissionForm/Liner.vue'
-import Screens from '@/submissions/components/SubmissionForm/Screens.vue'
-import FilterPack from '@/submissions/components/SubmissionForm/FilterPack.vue'
-import Development from '@/submissions/components/SubmissionForm/Development.vue'
-import Yield from '@/submissions/components/SubmissionForm/Yield.vue'
-import WaterQuality from '@/submissions/components/SubmissionForm/WaterQuality.vue'
-import Completion from '@/submissions/components/SubmissionForm/Completion.vue'
-import Comments from '@/submissions/components/SubmissionForm/Comments.vue'
-import ClosureDescription from '@/submissions/components/SubmissionForm/ClosureDescription.vue'
-import DecommissionInformation from '@/submissions/components/SubmissionForm/DecommissionInformation.vue'
 import SubmissionPreview from '@/submissions/components/SubmissionPreview/SubmissionPreview.vue'
 import filterBlankRows from '@/common/filterBlankRows.js'
+import ActivitySubmissionForm from '@/submissions/components/SubmissionForm/ActivitySubmissionForm.vue'
 export default {
   name: 'SubmissionsHome',
   mixins: [inputFormatMixin, filterBlankRows],
   components: {
-    ActivityType,
-    WellType,
-    PersonResponsible,
-    Owner,
-    Location,
-    Coords,
-    MethodOfDrilling,
-    Lithology,
-    Casings,
-    Backfill,
-    Liner,
-    Screens,
-    FilterPack,
-    Development,
-    Yield,
-    WaterQuality,
-    Completion,
-    Comments,
-    ClosureDescription,
-    DecommissionInformation,
+    ActivitySubmissionForm,
     SubmissionPreview
   },
   data () {
@@ -425,47 +97,14 @@ export default {
       activityType: 'CON',
       formIsFlat: false,
       preview: false,
-      units: 'imperial',
       confirmSubmitModal: false,
-      formSubmitLoading: false,
       formSubmitSuccess: false,
       formSubmitSuccessWellTag: null,
       formSubmitError: false,
-      saveFormSuccess: false,
-      hasHadSaveFormSuccess: false,
-      loadFormSuccess: false,
-      confirmLoadModal: false,
-      // componentUpdateTrigger can be appended to a component's key. Changing this value will cause
-      // these components to be re-created, allowing the created() and mounted() hooks to re-run.
-      componentUpdateTrigger: 0,
-      step: 1,
       sliding: null,
       errors: {},
-      fieldsLoaded: {},
       form: {},
       formOptions: {},
-      formStepDescriptions: {
-        'activityType': 'Type of work',
-        'wellType': 'Well class',
-        'wellOwner': 'Well owner',
-        'wellLocation': 'Well location',
-        'wellCoords': 'Geographic coordinates',
-        'method': 'Method of drilling',
-        'closureDescription': 'Decommission description',
-        'lithology': 'Lithology',
-        'casings': 'Casing details',
-        'backfill': 'Surface seal and backfill information',
-        'liner': 'Liner information',
-        'screens': 'Screen information',
-        'filterPack': 'Filter pack',
-        'wellDevelopment': 'Well development',
-        'wellYield': 'Well yield estimation',
-        'waterQuality': 'Water quality',
-        'wellCompletion': 'Well completion data',
-        'decommissionInformation': 'Well decommission information',
-        'comments': 'Comments',
-        'personResponsible': 'Person Responsible for Work'
-      },
       formSteps: {
         CON: [
           'activityType',
@@ -543,20 +182,6 @@ export default {
     }
   },
   computed: {
-    formStep () {
-      // the numbered step that the user is on
-      // this value is bound by the length of the list of steps for the
-      // current type of submission
-      return (this.step % (this.maxSteps + 1))
-    },
-    maxSteps () {
-      return this.formSteps[this.activityType].length
-    },
-    currentStep () {
-      // the string name of the step corresponding to formStep
-      // this will determine which step is currently displayed
-      return this.preview ? 'preview' : this.formSteps[this.activityType][this.formStep - 1]
-    },
     displayFormSection () {
       // returns an object describing which components should be displayed
       // when in "flat form" mode
@@ -569,10 +194,6 @@ export default {
       })
 
       return components
-    },
-    isLoadFormDisabled () {
-      // During unit tests, the localStorage object might not exist, so we have to check it's existence.
-      return !window.localStorage || (window.localStorage.getItem('savedFormData') === null && !this.hasHadSaveFormSuccess)
     },
     ...mapGetters(['codes', 'userRoles'])
   },
@@ -720,41 +341,7 @@ export default {
       }
       this.componentUpdateTrigger = Date.now()
     },
-    saveForm () {
-      // saves a copy of form data locally
-      this.saveStatusReset()
-      const data = JSON.stringify(this.form)
-      localStorage.setItem('savedFormData', data)
-      setTimeout(() => { this.saveFormSuccess = true }, 10)
-      setTimeout(() => { this.saveFormSuccess = false; this.hasHadSaveFormSuccess = true }, 1000)
-    },
-    loadForm () {
-      this.saveStatusReset()
-      const storedData = localStorage.getItem('savedFormData')
-      if (storedData) {
-        this.resetForm()
 
-        // some form features depend on watching form field values.
-        // setTimeout pushes rendering new data down execution queue
-        // to give watchers a chance to act on each set of changes
-        // (e.g. form reset, form population)
-        setTimeout(() => {
-          const parsedData = JSON.parse(storedData)
-          this.form = Object.assign(this.form, parsedData)
-          this.fieldsLoaded = Object.assign(this.fieldsLoaded, parsedData)
-          setTimeout(() => { this.loadFormSuccess = true }, 0)
-          setTimeout(() => { this.fieldsLoaded = {} }, 0)
-          setTimeout(() => { this.loadFormSuccess = false }, 1000)
-        }, 0)
-      }
-    },
-    loadConfirmation () {
-      this.confirmLoadModal = true
-    },
-    saveStatusReset () {
-      this.saveFormSuccess = false
-      this.loadFormSuccess = false
-    },
     setWellTagNumber (well) {
       // setWellTagNumber is used to link an activity report to a well other than through the dropdown menu.
       // the dropdown menu returns an object so this method also does.

--- a/app/frontend/test/unit/specs/submissions/SubmissionsHome.spec.js
+++ b/app/frontend/test/unit/specs/submissions/SubmissionsHome.spec.js
@@ -1,8 +1,9 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils'
+import { shallowMount, createLocalVue, mount } from '@vue/test-utils'
 import Vuex from 'vuex'
 import VueRouter from 'vue-router'
 import SubmissionsHome from '@/submissions/views/SubmissionsHome.vue'
 import Yield from '@/submissions/components/SubmissionForm/Yield.vue'
+// import ActivitySubmissionForm from '@/submissions/components/SubmissionForm/ActivitySubmissionForm.vue'
 
 import { FETCH_CODES } from '@/submissions/store/actions.types.js'
 
@@ -56,12 +57,12 @@ describe('SubmissionsHome.vue', () => {
   })
 
   it('renders components based on the activity selected (Yield exists on construction report', (done) => {
-    const wrapper = shallowMount(SubmissionsHome, {
+    const wrapper = mount(SubmissionsHome, {
       localVue,
       store,
       router
     })
-    wrapper.setData({ activityType: 'CON', formIsFlat: true })
+    wrapper.setData({ activityType: 'CON' })
     wrapper.vm.$nextTick(() => {
       expect(wrapper.find(Yield).exists()).toBe(true)
       done()


### PR DESCRIPTION
# Re-factor

@stephenhillier I did a pretty big re-factor as a 1st step before starting edit. I ripped out everything specific to the submission form into it's own component. I think this is a cleaner/better approach. It has some downsides, but I think it's better.

We should merge this bit before I finish the rest, otherwise merging in your changes is going to become very difficult.

# The good:
- More focused objects
- This approach simplifies things a bit - we don't have as many if this and that and the otherthing and not this thing, e.g.
```
<b-row v-if="!preview && activityType === 'STAFF_EDIT'">
```
becomes:
<b-row v-if="activityType === 'STAFF_EDIT'">

# The bad:
- More events, e.g:
```
          v-on:preview="handlePreviewButton"
          v-on:resetForm="resetForm"
```
- Thing happening all over the place.
