### PR TITLE
[1227] change error alert to exclamation mark icon

### DIFF
--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -38,7 +38,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           variant="danger"
           class="mt-3">
 
-        <i class="fa fa-2x fa-times-circle text-danger mr-2 alert-icon" aria-hidden="true"></i>
+        <i class="fa fa-2x fa-exclamation-circle text-danger mr-2 alert-icon" aria-hidden="true"></i>
         <div class="alert-message">
           <div v-if="isStaffEdit">
             Your changes were not saved.


### PR DESCRIPTION
Changed the submission error icon from `X` to `!` as requested.