### PR TITLE
Enable USE_X_FORWARDED_HOST if SECURE_SSL_REDIRECT

### DIFF
--- a/app/backend/gwells/settings/__init__.py
+++ b/app/backend/gwells/settings/__init__.py
@@ -307,3 +307,6 @@ class DisableMigrations(object):
         return None
 if get_env_variable('DISABLE_MIGRATIONS', None, strict=False, warn=False) == 'DISABLE_MIGRATIONS':
     MIGRATION_MODULES = DisableMigrations()
+
+SECURE_SSL_REDIRECT = bool(int(os.environ.get('SECURE_SSL_REDIRECT', 0)))
+USE_X_FORWARDED_HOST = SECURE_SSL_REDIRECT


### PR DESCRIPTION
This _should_ fix a problem where the application reports back the deployed hostname (gwells-prod.pathfinder.gov.bc.ca) when it should be using the host name of the proxy (apps.nrs.gov.bc.ca).

We can see the problem on the swagger api page: https://apps.nrs.gov.bc.ca/gwells/api/#tag/wells

If you expand the "[GET] /wells/" dropdown, it displays

Server URL: http://gwells-prod.pathfinder.gov.bc.ca/gwells/api/v1/wells/

It should respond with:

Server URL: http://app.nrs.gov.bc.ca/gwells/api/v1/wells/