### PR TITLE
Reference updated postgres image (postgis).

### DIFF
--- a/openshift/postgresql.bc.json
+++ b/openshift/postgresql.bc.json
@@ -30,7 +30,7 @@
                         "annotations": null,
                         "from": {
                             "kind": "ImageStreamTag",
-                            "name": "postgresql-oracle-fdw:9.5-2"
+                            "name": "postgis-oracle-fdw:96-24-1"
                         },
                         "importPolicy": {},
                         "name": "${ENV_NAME}",

--- a/openshift/postgresql.dc.json
+++ b/openshift/postgresql.dc.json
@@ -63,8 +63,20 @@
             "displayName": "Version of PostgreSQL Image",
             "name": "IMAGE_STREAM_VERSION",
             "required": true,
-            "value": "9.5"
+            "value": "9.6"
         },
+        {
+            "description": "Indicator to enable pgcrypto extension (provided out-of-the-box with PostgreSQL).",
+            "displayName": "Flag to enable pgcrypto PostgreSQL extension.",
+            "name": "PGCRYPTO_EXTENSION",
+            "value": "Y"
+        },
+        {
+            "description": "Indicator to enable postgis extension (from official PostgeSQL YUM repo).",
+            "displayName": "Flag to enable postgis PostgreSQL extension.",
+            "name": "POSTGIS_EXTENSION",
+            "value": "Y"
+        },          
         {
             "name": "NAME_SUFFIX",
             "required": true
@@ -262,6 +274,14 @@
                                         "name": "FDW_SCHEMA",
                                         "value": "wells"
                                     },
+                                    {
+                                        "name": "PGCRYPTO_EXTENSION",
+                                        "value": "Y"
+                                    },
+                                    {
+                                        "name": "POSTGIS_EXTENSION",
+                                        "value": "Y"
+                                    },                                    
                                     {
                                         "name": "PGOPTIONS",
                                         "value": "-c maintenance_work_mem=128MB"


### PR DESCRIPTION
- set PGCRYPTO_EXTENSION=Y by default
- set POSTGIS_EXTENSION=Y by default

NOTE that I ran the build step separately  (i.e. from a cloned local repo of https://github.com/bcgov/openshift-postgresql-oracle_fdw):

```
oc -n moe-gwells-tools create -f openshift/postgresql96-postgis24-oracle-fdw.sample.bc.json
```