### PR TITLE
[1344] changes to token/auth flow

### DIFF
--- a/app/frontend/src/common/authenticate.js
+++ b/app/frontend/src/common/authenticate.js
@@ -22,15 +22,16 @@ export default {
   },
 
   setLocalToken: function (instance) {
-    localStorage.setItem('token', instance.token)
-    localStorage.setItem('refreshToken', instance.refreshToken)
-    localStorage.setItem('idToken', instance.idToken)
+    localStorage.setItem('gwells-session-expiry', instance.refreshTokenParsed.exp)
+
     ApiService.authHeader('JWT', instance.token)
   },
   removeLocalToken: function () {
     localStorage.removeItem('token')
     localStorage.removeItem('refreshToken')
     localStorage.removeItem('idToken')
+    localStorage.removeItem('gwells-session-expiry')
+
     ApiService.authHeader()
   },
 
@@ -45,22 +46,21 @@ export default {
         resolve() // We've already authenticated, have a header, and we've not expired.
       } else {
         // Attempt to retrieve a stored token, this may avoid us having to refresh the page.
-        const token = localStorage.getItem('token')
-        const refreshToken = localStorage.getItem('refreshToken')
-        const idToken = localStorage.getItem('idToken')
+        const expiry = localStorage.getItem('gwells-session-expiry')
+        const expiryDate = expiry ? new Date(expiry * 1000) : null
+
+        store.commit('SET_KEYCLOAK_LOADING', true)
+
         instance.init({
           onLoad: 'check-sso',
           checkLoginIframe: true,
-          timeSkew: 10, // Allow for some deviation
-          token,
-          refreshToken,
-          idToken }
-        ).success((result) => {
+          timeSkew: 10 // Allow for some deviation
+        }).success((result) => {
           // assumes the store passed in includes a 'SET_KEYCLOAK' mutation.
           store.commit('SET_KEYCLOAK', instance)
-          if (instance.authenticated) {
-            // We may have been authenticated, but the token could be expired.
-            instance.updateToken(60).success(() => {
+
+          if (expiryDate && expiryDate > new Date()) {
+            instance.updateToken().success(() => {
               // Store the token to avoid future round trips
               this.setLocalToken(instance)
             }).error(() => {
@@ -80,8 +80,10 @@ export default {
           }
           // We may have failed to authenticate, for many reasons, e.g. - it may be we never logged in,
           // or have an expired token.
+          store.commit('SET_KEYCLOAK_LOADING', false)
           resolve(result)
         }).error((e) => {
+          store.commit('SET_KEYCLOAK_LOADING', false)
           reject(e)
         })
       }

--- a/app/frontend/src/common/services/ApiService.js
+++ b/app/frontend/src/common/services/ApiService.js
@@ -1,15 +1,12 @@
 import axios from 'axios'
 import qs from 'querystring'
 
-const logging = process.env.NODE_ENV !== 'production'
-
 const ApiService = {
   init () {
     axios.defaults.baseURL = process.env.AXIOS_BASE_URL
 
     axios.interceptors.request.use(function (request) {
       // log requests to console while logging is on
-      logging && console.log(request)
 
       if (request.method === 'POST') {
         // send data as x-www-form-urlencoded
@@ -17,14 +14,11 @@ const ApiService = {
       }
       return request
     }, function (error) {
-      logging && console.log(error)
       return Promise.reject(error)
     })
     axios.interceptors.response.use(function (response) {
-      logging && console.log(response)
       return response
     }, function (error) {
-      logging && console.log(error)
       return Promise.reject(error)
     })
   },

--- a/app/frontend/src/common/store/auth.js
+++ b/app/frontend/src/common/store/auth.js
@@ -1,17 +1,25 @@
 export const SET_KEYCLOAK = 'SET_KEYCLOAK'
+export const SET_KEYCLOAK_LOADING = 'SET_KEYCLOAK_LOADING'
 
 const auth = {
   state: {
-    keycloak: {}
+    keycloak: {},
+    keycloakLoading: false
   },
   mutations: {
     [SET_KEYCLOAK] (state, payload) {
       state.keycloak = payload
+    },
+    [SET_KEYCLOAK_LOADING] (state, payload) {
+      state.keycloakLoading = payload
     }
   },
   getters: {
     keycloak (state) {
       return state.keycloak
+    },
+    keycloakLoading (state) {
+      return state.keycloakLoading
     },
     userRoles (state) {
       if (state.keycloak && state.keycloak.authenticated) {

--- a/app/frontend/src/common/store/auth.js
+++ b/app/frontend/src/common/store/auth.js
@@ -1,25 +1,25 @@
 export const SET_KEYCLOAK = 'SET_KEYCLOAK'
-export const SET_KEYCLOAK_LOADING = 'SET_KEYCLOAK_LOADING'
+export const SET_KEYCLOAK_READY = 'SET_KEYCLOAK_READY'
 
 const auth = {
   state: {
     keycloak: {},
-    keycloakLoading: false
+    keycloakReady: false
   },
   mutations: {
     [SET_KEYCLOAK] (state, payload) {
       state.keycloak = payload
     },
-    [SET_KEYCLOAK_LOADING] (state, payload) {
-      state.keycloakLoading = payload
+    [SET_KEYCLOAK_READY] (state, payload) {
+      state.keycloakReady = payload
     }
   },
   getters: {
     keycloak (state) {
       return state.keycloak
     },
-    keycloakLoading (state) {
-      return state.keycloakLoading
+    keycloakReady (state) {
+      return state.keycloakReady
     },
     userRoles (state) {
       if (state.keycloak && state.keycloak.authenticated) {

--- a/app/frontend/src/submissions/router/index.js
+++ b/app/frontend/src/submissions/router/index.js
@@ -47,7 +47,6 @@ router.beforeEach((to, from, next) => {
     // this route requires auth, check if logged in
     // if not, redirect to login page.
 
-    console.log('need auth')
     const waitForLogin = () => {
       setTimeout(() => {
         if (store.getters.keycloakReady && store.getters.keycloak && store.getters.keycloak.authenticated) next()

--- a/app/frontend/src/submissions/router/index.js
+++ b/app/frontend/src/submissions/router/index.js
@@ -47,18 +47,16 @@ router.beforeEach((to, from, next) => {
     // this route requires auth, check if logged in
     // if not, redirect to login page.
 
-    const expiry = localStorage.getItem('gwells-session-expiry')
-    const expiryDate = expiry ? new Date(expiry * 1000) : null
-
-    if (router.app.$keycloak.authenticated) {
-      next()
-    } else if (expiryDate && expiryDate < new Date()) {
-      // while (true) {
-      //   if (router.app.$keycloak.authenticated) {
-
-      //   }
-      // }
+    console.log('need auth')
+    const waitForLogin = () => {
+      setTimeout(() => {
+        if (store.getters.keycloakReady && store.getters.keycloak && store.getters.keycloak.authenticated) next()
+        else if (store.getters.keycloakReady && store.getters.keycloak && !store.getters.keycloak.authenticated) next({ path: '/', replace: true })
+        else waitForLogin()
+      }, 50)
     }
+
+    waitForLogin()
   } else {
     next()
   }

--- a/app/frontend/src/submissions/router/index.js
+++ b/app/frontend/src/submissions/router/index.js
@@ -13,12 +13,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 import Vue from 'vue'
 import Router from 'vue-router'
+import { store } from '../store/index.js'
 
 import SubmissionsHome from '@/submissions/views/SubmissionsHome.vue'
 
 Vue.use(Router)
 
-export default new Router({
+const router = new Router({
   routes: [
     {
       path: '/:id/edit',
@@ -40,3 +41,27 @@ export default new Router({
     return { x: 0, y: 0 }
   }
 })
+
+router.beforeEach((to, from, next) => {
+  if (to.matched.some(record => record.meta.edit)) {
+    // this route requires auth, check if logged in
+    // if not, redirect to login page.
+
+    const expiry = localStorage.getItem('gwells-session-expiry')
+    const expiryDate = expiry ? new Date(expiry * 1000) : null
+
+    if (router.app.$keycloak.authenticated) {
+      next()
+    } else if (expiryDate && expiryDate < new Date()) {
+      // while (true) {
+      //   if (router.app.$keycloak.authenticated) {
+
+      //   }
+      // }
+    }
+  } else {
+    next()
+  }
+})
+
+export default router


### PR DESCRIPTION
* make use of keycloak's sessions/cookies (to the https://sso-test domains) to get a new token transparently. Tokens are no longer put in local storage
* router will not proceed to guarded routes if keycloak isn't ready (still testing/refining)