### PR TITLE
[1517] Major re-factor of common/authenticate.js

### DIFF
--- a/app/backend/gwells/views/api.py
+++ b/app/backend/gwells/views/api.py
@@ -14,7 +14,8 @@ class KeycloakConfig(APIView):
             "ssl-required": "external",
             "resource": get_env_variable("SSO_CLIENT"),
             "public-client": True,
-            "confidential-port": int(get_env_variable("SSO_PORT", "0"))
+            "confidential-port": int(get_env_variable("SSO_PORT", "0")),
+            "clientId": get_env_variable("SSO_CLIENT")
         }
         return Response(config)
 

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -8127,11 +8127,6 @@
         }
       }
     },
-    "keycloak-js": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-4.8.1.tgz",
-      "integrity": "sha512-LTVp4Slo7vW0LvaqwBY3A2PSH8HHy5t3fF+/TzEQu2U2xlpeoMGaF+IQ1WYOzcScdNWRARxoDySOwt2ALrQR/Q=="
-    },
     "killable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -20,7 +20,6 @@
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
     "bootstrap-vue": "^2.0.0-rc.2",
-    "keycloak-js": "^4.8.1",
     "lodash.isempty": "^4.4.0",
     "npm": "^5.6.0",
     "proj4": "^2.4.4",

--- a/app/frontend/src/common/authenticate.js
+++ b/app/frontend/src/common/authenticate.js
@@ -9,16 +9,45 @@
   See the License for the specific language governing permissions and
   limitations under the License.
  */
-import Keycloak from 'keycloak-js'
 import ApiService from '@/common/services/ApiService.js'
 import Vue from 'vue'
 
 export default {
   getInstance: function () {
-    if (!Vue.prototype.$keycloak) {
-      Vue.prototype.$keycloak = Keycloak(`${process.env.AXIOS_BASE_URL}keycloak`)
-    }
-    return Vue.prototype.$keycloak
+    /**
+     * Returns a promise that resolves to an instance of Keycloak.
+     */
+    return new Promise((resolve, reject) => {
+      if (!Vue.prototype.$keycloak) {
+        // Keycloak has not yet been loaded, get Keycloak configuration from the server.
+        ApiService.query('keycloak', {})
+          .then(response => {
+            /*
+            "A best practice is to load the JavaScript adapter directly from Keycloak Server as it will
+            automatically be updated when you upgrade the server. If you copy the adapter to your web
+            application instead, make sure you upgrade the adapter only after you have upgraded the server.";
+            source : https://www.keycloak.org/docs/latest/securing_apps/index.html#_javascript_adapter:
+            */
+            const jsUrl = `${response.data['auth-server-url']}/js/keycloak.js`
+            // Inject the Keycloak javascript into the DOM.
+            const keyCloakScript = document.createElement('script')
+            keyCloakScript.onload = () => {
+              // Construct the Keycloak object and resolve the promise.
+              const keycloak = window.Keycloak(response.data)
+              resolve(keycloak)
+            }
+            keyCloakScript.async = true
+            keyCloakScript.setAttribute('src', jsUrl)
+            document.head.appendChild(keyCloakScript)
+          })
+          .catch(error => {
+            reject(error)
+          })
+      } else {
+        // Keycloak has already been loaded, so just resolve the object.
+        resolve(Vue.prototype.$keycloak)
+      }
+    })
   },
 
   setLocalToken: function (instance) {
@@ -46,56 +75,61 @@ export default {
 
   authenticate: function (store) {
     /**
-     * authenticates a user and then stores a reference to the keycloak instance in the store
-     * passed into the function
+     * Return a promise that resolves on completion of authentication.
      */
     return new Promise((resolve, reject) => {
-      const instance = this.getInstance()
-      if (instance.authenticated && ApiService.hasAuthHeader() && !instance.isTokenExpired(0)) {
-        resolve() // We've already authenticated, have a header, and we've not expired.
-      } else {
-        // Attempt to retrieve a stored token, this may avoid us having to refresh the page.
-        const token = localStorage.getItem('token')
-        const refreshToken = localStorage.getItem('refreshToken')
-        const idToken = localStorage.getItem('idToken')
-        instance.init({
-          onLoad: 'check-sso',
-          checkLoginIframe: true,
-          timeSkew: 10, // Allow for some deviation
-          token,
-          refreshToken,
-          idToken }
-        ).success((result) => {
-          // Assumes the store passed in includes a 'SET_KEYCLOAK' mutation.
-          if (instance.authenticated) {
-            // We may have been authenticated, but the token could be expired.
-            instance.updateToken(60).success(() => {
-              // Store the token to avoid future round trips, and wire up the API
-              this.setLocalToken(instance)
-              this.setTokenExpireAction(instance)
-              // We update the store reference only after wiring up the API. (Someone might be waiting
-              // for login to complete before taking some action. )
-              store.commit('SET_KEYCLOAK', instance)
-              resolve()
-            }).error(() => {
-              // The refresh token is expired or was rejected
-              this.removeLocalToken()
-              instance.clearToken()
-              // We update the store reference only after wiring up the API. (Someone might be waiting
-              // for login to complete before taking some action. )
-              store.commit('SET_KEYCLOAK', instance)
-              resolve()
-            })
-          } else {
-            // We may have failed to authenticate, for many reasons, e.g. - it may be we never logged in,
-            // or have an expired token.
-            store.commit('SET_KEYCLOAK', instance)
+      this.getInstance()
+        .then((instance) => {
+          if (instance.authenticated && ApiService.hasAuthHeader() && !instance.isTokenExpired(0)) {
+            // We've already authenticated, have a header, and we've not expired.
             resolve()
+          } else {
+            // Attempt to retrieve a stored token, this may avoid us having to refresh the page.
+            const token = localStorage.getItem('token')
+            const refreshToken = localStorage.getItem('refreshToken')
+            const idToken = localStorage.getItem('idToken')
+            instance.init({
+              onLoad: 'check-sso',
+              checkLoginIframe: true,
+              timeSkew: 10, // Allow for some deviation
+              token,
+              refreshToken,
+              idToken }
+            ).success((result) => {
+              if (instance.authenticated) {
+                // We may have been authenticated, but the token could be expired.
+                instance.updateToken(60).success(() => {
+                  // Store the token to avoid future round trips, and wire up the API
+                  this.setLocalToken(instance)
+                  this.setTokenExpireAction(instance)
+                  // We update the store reference only after wiring up the API. (Someone might be waiting
+                  // for login to complete before taking some action. )
+                  // Assumes that store passed in includes a 'SET_KEYCLOAK' mutation!
+                  store.commit('SET_KEYCLOAK', instance)
+                  resolve()
+                }).error(() => {
+                  // The refresh token is expired or was rejected
+                  this.removeLocalToken()
+                  instance.clearToken()
+                  // We update the store reference only after wiring up the API. (Someone might be waiting
+                  // for login to complete before taking some action. )
+                  store.commit('SET_KEYCLOAK', instance)
+                  resolve()
+                })
+              } else {
+                // We may have failed to authenticate, for many reasons, e.g. - it may be we never logged in,
+                // or have an expired token.
+                store.commit('SET_KEYCLOAK', instance)
+                resolve()
+              }
+            }).error((e) => {
+              reject(e)
+            })
           }
-        }).error((e) => {
-          reject(e)
         })
-      }
+        .catch((error) => {
+          reject(error)
+        })
     })
   }
 }


### PR DESCRIPTION
Resolved redirect to SSO server issue for invalid redirect URI's
Removed Keycloak from package.json (library did not match SSO server version)
Keycloak now loads from SSO server (this is best practice)
API changed to provide clientId (required for current Keycloak library version served up by SSO server)