### PR TITLE
[1522] PostGIS in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   db:
-    image: kartoza/postgis:9.6-2.4
+    image: postgres:9.6
     environment:
       POSTGRES_USER: gwells
       POSTGRES_PASSWORD: test1


### PR DESCRIPTION
This is currently failing in Docker, so we're temporarily using postgres:9.6.