### PR TITLE
[1480] Added presigned URL endpoints for S3 uploading

### DIFF
--- a/api-tests/aquifers_api_tests.json
+++ b/api-tests/aquifers_api_tests.json
@@ -916,7 +916,7 @@
 					"raw": ""
 				},
 				"url": {
-					"raw": "{{base_url}}/gwells/api/v1/aquifers/presigned_put_url?filename=file.pdf",
+					"raw": "{{base_url}}/gwells/api/v1/aquifers/{{aquifer_id}}/presigned_put_url?filename=file.pdf",
 					"host": [
 						"{{base_url}}"
 					],
@@ -925,6 +925,7 @@
 						"api",
 						"v1",
 						"aquifers",
+						"{{aquifer_id}}",
 						"presigned_put_url"
 					],
 					"query": [

--- a/api-tests/aquifers_api_tests.json
+++ b/api-tests/aquifers_api_tests.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "3d69ef7c-a30f-42a5-a557-2caa5b78504b",
+		"_postman_id": "df578d2e-cb24-47ab-8c2b-754c870e53c3",
 		"name": "GWELLS Aquifers",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -878,6 +878,60 @@
 						"aquifers",
 						"{{aquifer_id}}",
 						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Aquifer Get PUT_URL",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "768133b0-7dd6-4197-97ca-ddca5cb1743f",
+						"exec": [
+							"var jsonData = pm.response.json()",
+							"",
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.expect(pm.response.code).to.equal(200);",
+							"})",
+							"",
+							"pm.test(\"Response contains URL with signature\", function() {",
+							"    var jsonData = pm.response.json()",
+							"    pm.expect(jsonData.url).to.not.eql(null)",
+							"    pm.expect(jsonData.url).to.include(\"X-Amz-Signature\")",
+							"})",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{base_url}}/gwells/api/v1/aquifers/presigned_put_url?filename=file.pdf",
+					"host": [
+						"{{base_url}}"
+					],
+					"path": [
+						"gwells",
+						"api",
+						"v1",
+						"aquifers",
+						"presigned_put_url"
+					],
+					"query": [
+						{
+							"key": "filename",
+							"value": "file.pdf"
+						}
 					]
 				}
 			},

--- a/api-tests/wells_api_tests.json
+++ b/api-tests/wells_api_tests.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "4be9ad4a-ce86-484a-80b7-80065a29c930",
+		"_postman_id": "ab8bb013-d3ea-4fd2-bf23-5bfa5c2727d5",
 		"name": "GWELLS Well API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -117,7 +117,10 @@
 								"value": "JWT {{token}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{base_url}}/api/v1/wells/?format=json",
 							"host": [
@@ -227,7 +230,10 @@
 								"value": "JWT {{token}}"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{base_url}}/api/v1/wells/{{well_tag_number}}",
 							"host": [
@@ -241,6 +247,64 @@
 							]
 						},
 						"description": "Request a list of wells"
+					},
+					"response": []
+				},
+				{
+					"name": "Wells Get PUT_URL",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "768133b0-7dd6-4197-97ca-ddca5cb1743f",
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.expect(pm.response.code).to.equal(200);",
+									"})",
+									"",
+									"pm.test(\"Response contains URL with signature\", function() {",
+									"    var jsonData = pm.response.json()",
+									"    pm.expect(jsonData.url).to.not.eql(null)",
+									"    pm.expect(jsonData.url).to.include(\"X-Amz-Signature\")",
+									"})",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "JWT {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{base_url}}/api/v1/wells/presigned_put_url?filename=file.pdf",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"wells",
+								"presigned_put_url"
+							],
+							"query": [
+								{
+									"key": "filename",
+									"value": "file.pdf"
+								}
+							]
+						}
 					},
 					"response": []
 				}

--- a/app/backend/aquifers/permissions.py
+++ b/app/backend/aquifers/permissions.py
@@ -14,6 +14,7 @@
 from rest_framework.permissions import BasePermission, SAFE_METHODS
 from gwells.roles import AQUIFERS_EDIT_ROLE
 
+
 class HasAquiferEditRoleOrReadOnly(BasePermission):
     """
     Grants permission to users with Aquifer Edit Roles, or is a read-only request

--- a/app/backend/aquifers/urls.py
+++ b/app/backend/aquifers/urls.py
@@ -43,6 +43,10 @@ urlpatterns = [
     url(r'^api/v1/aquifers/(?P<aquifer_id>[0-9]+)/history/$',
         never_cache(views.AquiferHistory.as_view()), name='aquifer-history'),
 
+    # Document Uploading (aquifer records)
+    url(r'^api/v1/aquifers/presigned_put_url$',
+        never_cache(views.PreSignedDocumentKey.as_view()), name='aquifer-pre-signed-url'),
+
     url(r'^api/v1/aquifer-codes/materials/$',
         cache_page(CACHE_TTL)(views.AquiferMaterialListAPIView.as_view()),
         name='aquifer-material-list'

--- a/app/backend/aquifers/urls.py
+++ b/app/backend/aquifers/urls.py
@@ -44,7 +44,7 @@ urlpatterns = [
         never_cache(views.AquiferHistory.as_view()), name='aquifer-history'),
 
     # Document Uploading (aquifer records)
-    url(r'^api/v1/aquifers/presigned_put_url$',
+    url(r'^api/v1/aquifers/(?P<aquifer_id>[0-9]+)/presigned_put_url$',
         never_cache(views.PreSignedDocumentKey.as_view()), name='aquifer-pre-signed-url'),
 
     url(r'^api/v1/aquifer-codes/materials/$',

--- a/app/backend/aquifers/views.py
+++ b/app/backend/aquifers/views.py
@@ -27,6 +27,7 @@ from rest_framework.generics import ListAPIView, ListCreateAPIView, RetrieveUpda
 from reversion.views import RevisionMixin
 
 from gwells.documents import MinioClient
+from gwells.settings.base import get_env_variable
 
 from aquifers import models
 from aquifers import serializers
@@ -230,6 +231,6 @@ class PreSignedDocumentKey(APIView):
 
         object_name = request.GET.get("filename")
         filename = "AQ_%s_%s" % (aquifer_id, object_name)
-        url = client.get_presigned_put_url(filename)
+        url = client.get_presigned_put_url(filename, bucket_name=get_env_variable("S3_AQUIFER_BUCKET"))
 
         return JsonResponse({"object_name": object_name, "url": url})

--- a/app/backend/aquifers/views.py
+++ b/app/backend/aquifers/views.py
@@ -224,11 +224,12 @@ class PreSignedDocumentKey(APIView):
     permission_classes = (HasAquiferEditRole,)
 
     @swagger_auto_schema(auto_schema=None)
-    def get(self, request):
+    def get(self, request, aquifer_id):
         client = MinioClient(
             request=request, disable_private=True)
 
         object_name = request.GET.get("filename")
-        url = client.get_presigned_put_url(object_name)
+        filename = "AQ_%s_%s" % (aquifer_id, object_name)
+        url = client.get_presigned_put_url(filename)
 
-        return JsonResponse({"url": url})
+        return JsonResponse({"object_name": object_name, "url": url})

--- a/app/backend/gwells/documents.py
+++ b/app/backend/gwells/documents.py
@@ -57,13 +57,19 @@ class MinioClient():
                 'S3_PUBLIC_ACCESS_KEY', warn=False)
             self.public_secret_key = get_env_variable(
                 'S3_PUBLIC_SECRET_KEY', warn=False)
+            self.use_https = int(get_env_variable(
+                'S3_USE_HTTPS', 1, warn=False))
 
             self.public_client = Minio(
                 self.public_host,
                 access_key=self.public_access_key,
                 secret_key=self.public_secret_key,
-                secure=True
+                secure=self.use_https
             )
+
+        if not disable_private:
+            self.private_client = self.create_private_client()
+
         self.disable_private = disable_private
 
     def create_private_client(self):
@@ -76,7 +82,7 @@ class MinioClient():
             self.private_host,
             access_key=self.private_access_key,
             secret_key=self.private_secret_key,
-            secure=True
+            secure=self.use_https
         )
 
     def get_private_file(self, object_name: str):
@@ -150,8 +156,7 @@ class MinioClient():
             objects['public'] = pub_objects
 
         # authenticated requests also receive a "private" collection
-        self.private_client = self.create_private_client()
-        if include_private and self.private_client:
+        if include_private and not self.disable_private:
             priv_objects = []
             try:
                 priv_objects = self.create_url_list(
@@ -165,3 +170,13 @@ class MinioClient():
             objects['private'] = priv_objects
 
         return objects
+
+    def get_presigned_put_url(self, object_name, private=False):
+        if private:
+            key = self.private_client.presigned_put_object(
+                self.private_bucket, object_name, expires=timedelta(minutes=5))
+        else:
+            key = self.public_client.presigned_put_object(
+                self.public_bucket, object_name, expires=timedelta(minutes=5))
+
+        return key

--- a/app/backend/gwells/documents.py
+++ b/app/backend/gwells/documents.py
@@ -171,12 +171,18 @@ class MinioClient():
 
         return objects
 
-    def get_presigned_put_url(self, object_name, private=False):
+    def get_presigned_put_url(self, object_name, bucket_name=None, private=False):
         if private:
+            if bucket_name is None:
+                bucket_name = self.private_bucket
+
             key = self.private_client.presigned_put_object(
-                self.private_bucket, object_name, expires=timedelta(minutes=5))
+                bucket_name, object_name, expires=timedelta(minutes=5))
         else:
+            if bucket_name is None:
+                bucket_name = self.public_bucket
+
             key = self.public_client.presigned_put_object(
-                self.public_bucket, object_name, expires=timedelta(minutes=5))
+                bucket_name, object_name, expires=timedelta(minutes=5))
 
         return key

--- a/app/backend/registries/urls.py
+++ b/app/backend/registries/urls.py
@@ -62,6 +62,10 @@ urlpatterns = [
         never_cache(views.OrganizationListView.as_view()),
         name='organization-list'),
 
+    # Document Uploading (aquifer records)
+    url(r'^api/v1/organizations/presigned_put_url$',
+        never_cache(views.PreSignedDocumentKey.as_view()), name='organizations-pre-signed-url'),
+
     # Person note endpoints
     url(r'^api/v1/drillers/(?P<person_guid>[-\w]+)/notes/$',
         never_cache(views.PersonNoteListView.as_view()), name='person-note-list'),

--- a/app/backend/registries/views.py
+++ b/app/backend/registries/views.py
@@ -15,7 +15,7 @@
 import reversion
 from collections import OrderedDict
 from django.db.models import Q, Prefetch
-from django.http import HttpResponse, Http404
+from django.http import HttpResponse, Http404, JsonResponse
 from django.utils import timezone
 from django.views.generic import TemplateView
 from django_filters import rest_framework as restfilters
@@ -28,6 +28,7 @@ from rest_framework.response import Response
 from rest_framework.mixins import CreateModelMixin, UpdateModelMixin
 from rest_framework.views import APIView
 from drf_multiple_model.views import ObjectMultipleModelAPIView
+from gwells.documents import MinioClient
 from gwells.roles import REGISTRIES_VIEWER_ROLE
 from gwells.models import ProvinceStateCode
 from gwells.pagination import APILimitOffsetPagination
@@ -791,3 +792,23 @@ class PersonNameSearch(ListAPIView):
         'first_name',
         'surname',
     )
+
+
+class PreSignedDocumentKey(APIView):
+    """
+    Get a pre-signed document key to upload into an S3 compatible document store
+
+    post: obtain a URL that is pre-signed to allow client-side uploads
+    """
+
+    permission_classes = (RegistriesPermissions,)
+
+    @swagger_auto_schema(auto_schema=None)
+    def get(self, request):
+        client = MinioClient(
+            request=request, disable_private=True)
+
+        object_name = request.GET.get("filename")
+        url = client.get_presigned_put_url(object_name)
+
+        return JsonResponse({"url": url})

--- a/app/backend/submissions/urls.py
+++ b/app/backend/submissions/urls.py
@@ -16,8 +16,8 @@ from django.views.decorators.cache import never_cache
 
 from submissions.views import (SubmissionsOptions, SubmissionListAPIView, SubmissionConstructionAPIView,
                                SubmissionAlterationAPIView, SubmissionDecommissionAPIView,
-                               SubmissionsHomeView, SubmissionGetAPIView, SubmissionStaffEditAPIView
-                               )
+                               SubmissionsHomeView, SubmissionGetAPIView, SubmissionStaffEditAPIView,
+                               PreSignedDocumentKey,)
 
 
 urlpatterns = [
@@ -44,6 +44,10 @@ urlpatterns = [
     # Edit submission
     url(r'^api/v1/submissions/staff_edit',
         never_cache(SubmissionStaffEditAPIView().as_view()), name='STAFF_EDIT'),
+
+    # Document Uploading (submission records)
+    url(r'^api/v1/organizations/presigned_put_url$',
+        never_cache(PreSignedDocumentKey.as_view()), name='submissions-pre-signed-url'),
 
     # Submissions home (loads Submissions application)
     url(r'^submissions/', SubmissionsHomeView.as_view(), name='submissions-home')

--- a/app/backend/submissions/views.py
+++ b/app/backend/submissions/views.py
@@ -14,11 +14,13 @@
 
 from rest_framework.response import Response
 from posixpath import join as urljoin
+from django.http import JsonResponse
 from django.views.generic import TemplateView
 from django.urls import reverse
 from rest_framework.generics import ListAPIView, ListCreateAPIView, RetrieveUpdateAPIView, RetrieveAPIView
 from rest_framework.views import APIView
 
+from gwells.documents import MinioClient
 from gwells.urls import app_root
 from gwells.pagination import APILimitOffsetPagination
 from wells.permissions import WellsEditPermissions
@@ -346,3 +348,22 @@ class SubmissionsOptions(APIView):
 class SubmissionsHomeView(TemplateView):
     """Loads the html file containing the Submissions web app"""
     template_name = 'submissions/submissions.html'
+
+
+class PreSignedDocumentKey(APIView):
+    """
+    Get a pre-signed document key to upload into an S3 compatible document store
+
+    post: obtain a URL that is pre-signed to allow client-side uploads
+    """
+
+    permission_classes = (WellsEditPermissions,)
+
+    def get(self, request):
+        client = MinioClient(
+            request=request, disable_private=True)
+
+        object_name = request.GET.get("filename")
+        url = client.get_presigned_put_url(object_name)
+
+        return JsonResponse({"url": url})

--- a/app/backend/wells/urls.py
+++ b/app/backend/wells/urls.py
@@ -39,6 +39,10 @@ urlpatterns = [
     # Extract files
     url(r'^api/v1/wells/extracts$', views.ListExtracts.as_view(), name='extract-list'),
 
+    # Document Uploading (well records)
+    url(r'^api/v1/wells/presigned_put_url$',
+        never_cache(views.PreSignedDocumentKey.as_view()), name='well-pre-signed-url'),
+
     # Well list
     url(r'^api/v1/wells/$',
         never_cache(views.WellListAPIView.as_view()), name='well-list'),

--- a/app/backend/wells/views.py
+++ b/app/backend/wells/views.py
@@ -14,7 +14,7 @@
 from urllib.parse import quote
 
 from django.db.models import Prefetch
-from django.http import Http404
+from django.http import Http404, JsonResponse
 from django.views.generic import DetailView
 
 from rest_framework import filters
@@ -94,7 +94,7 @@ class ListExtracts(APIView):
         minioClient = Minio(host,
                             access_key=get_env_variable('S3_PUBLIC_ACCESS_KEY'),
                             secret_key=get_env_variable('S3_PUBLIC_SECRET_KEY'),
-                            secure=True)
+                            secure=get_env_variable('S3_USE_SECURE', 1))
         objects = minioClient.list_objects(get_env_variable('S3_WELL_EXPORT_BUCKET'))
         urls = list(
             map(
@@ -202,3 +202,23 @@ class WellTagSearchAPIView(ListAPIView):
             return Response([])
         else:
             return super().get(request)
+
+
+class PreSignedDocumentKey(APIView):
+    """
+    Get a pre-signed document key to upload into an S3 compatible document store
+
+    post: obtain a URL that is pre-signed to allow client-side uploads
+    """
+
+    permission_classes = (WellsEditPermissions,)
+
+    @swagger_auto_schema(auto_schema=None)
+    def get(self, request):
+        client = MinioClient(
+            request=request, disable_private=True)
+
+        object_name = request.GET.get("filename")
+        url = client.get_presigned_put_url(object_name)
+
+        return JsonResponse({"url": url})

--- a/app/frontend/src/aquifers/components/Form.vue
+++ b/app/frontend/src/aquifers/components/Form.vue
@@ -128,6 +128,21 @@
             id="aquifer-notes"
             v-model="record.notes"/>
         </b-form-group>
+
+        <b-form-group
+          horizontal
+          label-cols="4"
+          label="Documents">
+          <b-form-file
+            v-model="files"
+            multiple
+            plain/>
+          <div class="mt-3" v-if="aquifer_files.length > 0">
+            <b-list-group>
+              <b-list-group-item v-for="(f, index) in aquifer_files" :key="index">{{f.name}}</b-list-group-item>
+            </b-list-group>
+          </div>
+        </b-form-group>
       </b-col>
 
       <b-col md="6">
@@ -268,7 +283,7 @@
 
 <script>
 import { isEmpty, mapValues } from 'lodash'
-import { mapState } from 'vuex'
+import { mapMutations, mapState } from 'vuex'
 
 export default {
   computed: {
@@ -278,6 +293,14 @@ export default {
     fieldHasError () {
       return mapValues(this.fieldErrors, (messages) => isEmpty(messages))
     },
+    files: {
+      get: function () {
+        return this.aquifer_files
+      },
+      set: function (value) {
+        this.setFiles(value)
+      }
+    },
     ...mapState('aquiferCodes', [
       'demand_codes',
       'known_water_use_codes',
@@ -286,6 +309,14 @@ export default {
       'quality_concern_codes',
       'subtype_codes',
       'vulnerability_codes'
+    ]),
+    ...mapState('aquiferState', [
+      'aquifer_files'
+    ])
+  },
+  methods: {
+    ...mapMutations('aquiferState', [
+      'setFiles'
     ])
   },
   props: {

--- a/app/frontend/src/aquifers/components/New.vue
+++ b/app/frontend/src/aquifers/components/New.vue
@@ -28,7 +28,6 @@
           :record="record"
           :fieldErrors="fieldErrors"
           />
-
       </b-container>
     </b-card>
   </div>
@@ -38,11 +37,17 @@
 import ApiService from '@/common/services/ApiService.js'
 import APIErrorMessage from '@/common/components/APIErrorMessage'
 import AquiferForm from './Form'
+import { mapActions, mapState } from 'vuex'
 
 export default {
   components: {
     'api-error': APIErrorMessage,
     'aquifer-form': AquiferForm
+  },
+  computed: {
+    ...mapState('aquiferState', [
+      'aquifer_files'
+    ])
   },
   data () {
     return {
@@ -52,11 +57,18 @@ export default {
     }
   },
   methods: {
+    ...mapActions('aquiferState', [
+      'uploadFiles'
+    ]),
     navigateToView () {
       this.$router.push({ name: 'home' })
     },
     handleSuccess ({data}) {
       this.$router.push({ name: 'view', params: { id: data.aquifer_id } })
+
+      if (this.aquifer_files.length > 0) {
+        this.uploadFiles(data.aquifer_id)
+      }
     },
     handleError (error) {
       if (error.response) {

--- a/app/frontend/src/aquifers/components/View.vue
+++ b/app/frontend/src/aquifers/components/View.vue
@@ -15,6 +15,9 @@
 <template>
   <b-card no-body class="p-3 mb-4">
     <api-error v-if="error" :error="error"/>
+    <b-alert show v-if="files_uploading">File Upload In Progress...</b-alert>
+    <b-alert show v-if="!files_uploading && file_upload_error" variant="warning" >{{file_upload_error}}</b-alert>
+    <b-alert show v-if="!files_uploading && file_upload_success" variant="success" >Successfully uploaded all files</b-alert>
     <b-alert variant="success" :show="showSaveSuccess" id="aquifer-success-alert">Record successfully updated.</b-alert>
 
     <b-container>
@@ -104,7 +107,7 @@ import APIErrorMessage from '@/common/components/APIErrorMessage'
 import AquiferForm from './Form'
 import Documents from './Documents.vue'
 import ChangeHistory from '@/common/components/ChangeHistory.vue'
-import { mapGetters } from 'vuex'
+import { mapActions, mapGetters, mapState } from 'vuex'
 
 export default {
   components: {
@@ -130,17 +133,30 @@ export default {
     id () { return this.$route.params.id },
     editMode () { return this.edit },
     viewMode () { return !this.edit },
-    ...mapGetters(['userRoles'])
+    ...mapGetters(['userRoles']),
+    ...mapState('aquiferState', [
+      'aquifer_files',
+      'files_uploading',
+      'file_upload_error',
+      'file_upload_success'
+    ])
   },
   watch: {
     id () { this.fetch() }
   },
   methods: {
+    ...mapActions('aquiferState', [
+      'uploadFiles'
+    ]),
     handleSaveSuccess () {
       this.fetch()
       this.navigateToView()
       this.$refs.aquiferHistory.update()
       this.showSaveSuccess = true
+
+      if (this.aquifer_files.length > 0) {
+        this.uploadFiles(this.id)
+      }
     },
     handlePatchError (error) {
       if (error.response) {

--- a/app/frontend/src/aquifers/store/aquifers.js
+++ b/app/frontend/src/aquifers/store/aquifers.js
@@ -1,0 +1,95 @@
+/*
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+import ApiService from '@/common/services/ApiService.js'
+import axios from 'axios'
+
+export default {
+  namespaced: true,
+  state: {
+    aquifer_files: [],
+    files_uploading: false,
+    file_upload_errors: [],
+    file_upload_success: false
+  },
+  actions: {
+    uploadFiles (context, aquiferId) {
+      context.commit('setFilesUploading', true)
+
+      let uploadPromises = []
+
+      context.state.aquifer_files.forEach((file) => {
+        uploadPromises.push(
+          ApiService.presigned_put_url('aquifers', aquiferId, file.name)
+            .then((response) => {
+              let url = response.data.url
+              let objectName = response.data.object_name
+              let filename = response.data.filename
+              let file = context.state.aquifer_files.filter(file => file.name === objectName)
+
+              if (file.length !== 1) {
+                context.commit('addError', 'Error uploading file: ' + filename)
+                return
+              }
+
+              file = file[0]
+
+              let options = {
+                headers: {
+                  'Content-Type': file.type
+                }
+              }
+
+              axios.put(url, file, options)
+                .then((response) => {
+                  console.log('successfully added file: ' + objectName)
+                })
+                .catch((error) => {
+                  console.log(error)
+                  context.commit('addError', error)
+                })
+            })
+            .catch((error) => {
+              console.log(error)
+              context.commit('addError', error)
+            })
+        )
+      })
+
+      Promise.all(uploadPromises)
+        .then(function (values) {
+          context.commit('setFilesUploading', false)
+          context.commit('setFileUploadSuccess', true)
+          context.commit('setFiles', [])
+          setTimeout(() => {
+            context.commit('setFileUploadSuccess', false)
+          }, 5000)
+        })
+    }
+  },
+  mutations: {
+    addError (state, payload) {
+      state.file_upload_errors.push(payload)
+    },
+    setFilesUploading (state, payload) {
+      state.files_uploading = payload
+    },
+    setFileUploadSuccess (state, payload) {
+      state.file_upload_success = payload
+    },
+    setFiles (state, payload) {
+      state.aquifer_files = payload
+    }
+  }
+}

--- a/app/frontend/src/aquifers/store/index.js
+++ b/app/frontend/src/aquifers/store/index.js
@@ -17,9 +17,10 @@ import Vuex from 'vuex'
 import auth from '@/common/store/auth.js'
 import config from '@/common/store/config.js'
 import aquiferCodes from './codes.js'
+import aquiferState from './aquifers.js'
 
 Vue.use(Vuex)
 
 export default new Vuex.Store({
-  modules: { auth, aquiferCodes, config }
+  modules: { auth, aquiferCodes, aquiferState, config }
 })

--- a/app/frontend/src/common/services/ApiService.js
+++ b/app/frontend/src/common/services/ApiService.js
@@ -60,6 +60,9 @@ const ApiService = {
   },
   history (resource, record) {
     return axios.get(`${resource}/${record}/history/`)
+  },
+  presigned_put_url (resource, record, filename) {
+    return axios.get(`${resource}/${record}/presigned_put_url?filename=${filename}`)
   }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,17 @@
 version: '3'
 
 services:
+  minio:
+    image: minio/minio
+    hostname: minio
+    ports:
+    - "9000:9000"
+    volumes:
+    - ./.tmp/minio-files:/data
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
+    command: server /data
   db:
     image: postgres:9.6
     environment:
@@ -53,6 +64,13 @@ services:
       SSO_CLIENT: gwells-test
       SSO_AUTH_HOST: https://sso-test.pathfinder.gov.bc.ca/auth
       SSO_IDP_HINT: "undefined"
+      S3_HOST: minio:9000
+      S3_USE_HTTPS: 0
+      S3_PUBLIC_ACCESS_KEY: minio
+      S3_PUBLIC_SECRET_KEY: minio123
+      S3_WELL_EXPORT_BUCKET: gwells
+      S3_ROOT_BUCKET:  gwells
+      S3_AQUIFER_BUCKET: aquifers
     command: /bin/bash -c "sleep 3 &&
             set -x &&
             cd /app/backend &&


### PR DESCRIPTION
Added end-points for generating a presigned PUT URL for document uploading. This will allow a frontend client to request a key for uploading a document, and then be able to upload the document directly to an S3 compatible source - removing the need for the Django application to act as a middleman and handle the files / uploading directly.