### PR TITLE
Switch app deploy strategy from rolling back to recreate

### DIFF
--- a/openshift/backend.dc.json
+++ b/openshift/backend.dc.json
@@ -145,7 +145,7 @@
             },
             "spec": {
                 "strategy": {
-                    "type": "Rolling",
+                    "type": "Recreate",
                     "recreateParams": {
                         "timeoutSeconds": 180,
                         "pre": {


### PR DESCRIPTION
Rolling update strategy doesn't work with our mid hook deploy scripts, migrations, etc.