### PR TITLE
python-gdal (GEOS, PROJ.4, GDAL)

### DIFF
--- a/docker-images/python-gdal/Dockerfile
+++ b/docker-images/python-gdal/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhscl/python-36-rhel7:1-21
+FROM python-36-rhel7:1-21
 
 # Install and configure GDAL for Python, as GeoDjango depends on these external libraries
 # (without SFCGAL as we aren't using "CREATE EXTENSION postgis_sfcgal;"")

--- a/docker-images/python-gdal/Dockerfile
+++ b/docker-images/python-gdal/Dockerfile
@@ -1,4 +1,4 @@
-FROM python-36-rhel7:1-21
+FROM registry.access.redhat.com/rhscl/python-36-rhel7:1-21
 
 USER root
 

--- a/docker-images/python-gdal/Dockerfile
+++ b/docker-images/python-gdal/Dockerfile
@@ -1,7 +1,5 @@
 FROM python-36-rhel7:1-21
 
-# Install and configure GDAL for Python, as GeoDjango depends on these external libraries
-# (without SFCGAL as we aren't using "CREATE EXTENSION postgis_sfcgal;"")
 USER root
 
 # Install and configure GEOS, as GeoDjango depends on these external libraries
@@ -18,6 +16,8 @@ RUN cd /tmp && wget https://download.osgeo.org/proj/proj-5.2.0.tar.gz && \
     cd .. && ./configure && make && make install && ldconfig && \
     rm -rf /tmp/proj-5.2.0 /tmp/proj-5.2.0.tar.gz /tmp/proj-datumgrid-north-america-1.1.tar.gz
 
+# Install and configure GDAL for Python, as GeoDjango depends on these external libraries
+# (without SFCGAL as we aren't using "CREATE EXTENSION postgis_sfcgal;"")
 RUN cd /tmp && wget http://download.osgeo.org/gdal/2.4.0/gdal-2.4.0.tar.gz && \
     tar zxvf gdal-2.4.0.tar.gz && cd gdal-2.4.0/ && \
     ./configure --with-python --with-sfcgal=no && \

--- a/docker-images/python-gdal/Dockerfile
+++ b/docker-images/python-gdal/Dockerfile
@@ -1,0 +1,27 @@
+FROM registry.access.redhat.com/rhscl/python-36-rhel7:1-21
+
+# Install and configure GDAL for Python, as GeoDjango depends on these external libraries
+# (without SFCGAL as we aren't using "CREATE EXTENSION postgis_sfcgal;"")
+USER root
+
+# Install and configure GEOS, as GeoDjango depends on these external libraries
+RUN cd /tmp && wget https://download.osgeo.org/geos/geos-3.7.1.tar.bz2 && \
+    tar xjf geos-3.7.1.tar.bz2 && cd geos-3.7.1/ && \
+    ./configure && make && make install && ldconfig && \
+    rm -rf /tmp/geos-3.7.1 /tmp/geos-3.7.1.tar.bz2
+
+# Install and configure Proj4, as GeoDjango depends on these external libraries
+RUN cd /tmp && wget https://download.osgeo.org/proj/proj-5.2.0.tar.gz && \
+    wget https://download.osgeo.org/proj/proj-datumgrid-north-america-1.1.tar.gz && \
+    tar xzf proj-5.2.0.tar.gz && cd proj-5.2.0/nad && \
+    tar xzf ../../proj-datumgrid-north-america-1.1.tar.gz && \
+    cd .. && ./configure && make && make install && ldconfig && \
+    rm -rf /tmp/proj-5.2.0 /tmp/proj-5.2.0.tar.gz /tmp/proj-datumgrid-north-america-1.1.tar.gz
+
+RUN cd /tmp && wget http://download.osgeo.org/gdal/2.4.0/gdal-2.4.0.tar.gz && \
+    tar zxvf gdal-2.4.0.tar.gz && cd gdal-2.4.0/ && \
+    ./configure --with-python --with-sfcgal=no && \
+    make -j4 && make install && ldconfig && \
+    rm -rf /tmp/gdal-2.4.0 /tmp/gdal-2.4.0.tar.gz
+
+USER 1001

--- a/docker-images/python-gdal/README.md
+++ b/docker-images/python-gdal/README.md
@@ -1,0 +1,5 @@
+oc -n csnr-devops-lab-tools new-build .  --name python-36-rhel7-gdal --context-dir=docker-images/python-gdal
+
+oc -n csnr-devops-lab-tools logs -f bc/python-36-rhel7-gdal
+
+oc -n csnr-devops-lab-tools tag python-36-rhel7-gdal:latest python-36-rhel7-gdal:v1

--- a/docker-images/python-gdal/README.md
+++ b/docker-images/python-gdal/README.md
@@ -1,5 +1,10 @@
 oc -n csnr-devops-lab-tools new-build .  --name python-36-rhel7-gdal --context-dir=docker-images/python-gdal
 
+(or `oc -n csnr-devops-lab-tools new-build https://github.com/bcgov/gwells.git#feature/python-gdal --name python-36-rhel7-gdal --context-dir=docker-images/python-gdal` to reference a specific branch)
+
+To reset:
+oc -n moe-gwells-tools delete bc/tst-python-gdal istag/tst-python-gdal:latest is/tst-python-gdal
+
 oc -n csnr-devops-lab-tools logs -f bc/python-36-rhel7-gdal
 
 oc -n csnr-devops-lab-tools tag python-36-rhel7-gdal:latest python-36-rhel7-gdal:v1


### PR DESCRIPTION
To support the backend to use GeoDjango and PostGIS, building the external libraries from source.