### PR TITLE
Increase the timeout to 60 seconds to allow for query to complete.

### DIFF
--- a/app/backend/gunicorn.cfg
+++ b/app/backend/gunicorn.cfg
@@ -46,6 +46,8 @@
 # workers = 18
 worker_class = 'gevent'
 worker_connections = 1000
-timeout = 30
+# api/v1/gis/lithology & api/v1/gis/wells are very slow, so increasing the timeout until such
+# time as they can be optimized.
+timeout = 60
 keepalive = 2
 chdir = 'backend'


### PR DESCRIPTION
The queries run much slower on our pods than on local - I'm increasing the timeout to find out just how much slower.
Hopefully we can get the time down by optimizing a few things on the database.