### PR TITLE
Revert to bounding box style geom filter

### DIFF
--- a/app/backend/wells/views.py
+++ b/app/backend/wells/views.py
@@ -52,10 +52,7 @@ from gwells.settings.base import get_env_variable
 from submissions.serializers import WellSubmissionListSerializer
 from submissions.models import WellActivityCode
 
-from wells.filters import (
-    WellListAdminFilter,
-    WellListFilter,
-    WellListFilterBackend)
+from wells.filters import BoundingBoxFilterBackend, WellListFilterBackend
 from wells.models import Well, ActivitySubmission
 from wells.serializers import (
     WellListAdminSerializer,
@@ -221,8 +218,8 @@ class WellListAPIView(ListAPIView):
     queryset = Well.objects.all()  # exclude(well_publication_status='Unpublished')
     pagination_class = APILimitOffsetPagination
 
-    filter_backends = (WellListFilterBackend, filters.SearchFilter,
-                       filters.OrderingFilter)
+    filter_backends = (WellListFilterBackend, BoundingBoxFilterBackend,
+                       filters.SearchFilter, filters.OrderingFilter)
     ordering = ('well_tag_number',)
     search_fields = ('well_tag_number', 'identification_plate_number',
                      'street_address', 'city', 'owner_full_name')
@@ -298,8 +295,8 @@ class WellLocationListAPIView(ListAPIView):
     serializer_class = WellLocationSerializer
 
     # Allow searching on name fields, names of related companies, etc.
-    filter_backends = (WellListFilterBackend, filters.SearchFilter,
-                       filters.OrderingFilter)
+    filter_backends = (WellListFilterBackend, BoundingBoxFilterBackend,
+                       filters.SearchFilter, filters.OrderingFilter)
     ordering = ('well_tag_number',)
     filterset_class = WellLocationFilter
     pagination_class = None

--- a/tests/api-tests/wells_search_api_tests.json
+++ b/tests/api-tests/wells_search_api_tests.json
@@ -2972,7 +2972,7 @@
 							"response": []
 						},
 						{
-							"name": "sw_long and sw_lat params (valid)",
+							"name": "sw_long, sw_lat and ne_long params (missing ne_lat)",
 							"event": [
 								{
 									"listen": "test",
@@ -2998,7 +2998,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{base_url}}/api/v1/wells?sw_long=-122.60&sw_lat=49.24",
+									"raw": "{{base_url}}/api/v1/wells?sw_long=-122.60&sw_lat=49.24&ne_long=-122.58",
 									"host": [
 										"{{base_url}}"
 									],
@@ -3015,6 +3015,10 @@
 										{
 											"key": "sw_lat",
 											"value": "49.24"
+										},
+										{
+											"key": "ne_long",
+											"value": "-122.58"
 										}
 									]
 								}
@@ -3022,12 +3026,12 @@
 							"response": []
 						},
 						{
-							"name": "ne_long and ne_lat params (valid)",
+							"name": "sw_long, sw_lat, ne_long and ne_lat param (invalid)",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
-										"id": "11f7946c-15e1-41ea-bcc8-ed7d121f5761",
+										"id": "19dcd02f-9e31-4876-9102-fe274f4d678e",
 										"exec": [
 											"pm.test(\"Response status ok\", function () {",
 											"  pm.response.to.be.ok;",
@@ -3048,104 +3052,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{base_url}}/api/v1/wells?ne_long=-122.58&ne_lat=49.26",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"v1",
-										"wells"
-									],
-									"query": [
-										{
-											"key": "ne_long",
-											"value": "-122.58"
-										},
-										{
-											"key": "ne_lat",
-											"value": "49.26"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "ne_long param (missing ne_lat)",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "19dcd02f-9e31-4876-9102-fe274f4d678e",
-										"exec": [
-											"pm.test(\"Response code 400\", function () {",
-											"  pm.response.to.be.clientError;",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{base_url}}/api/v1/wells?ne_long=-122.58",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"v1",
-										"wells"
-									],
-									"query": [
-										{
-											"key": "ne_long",
-											"value": "-122.58"
-										},
-										{
-											"key": "",
-											"value": "",
-											"disabled": true
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "sw_lat and sw_long param (invalid point)",
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "19dcd02f-9e31-4876-9102-fe274f4d678e",
-										"exec": [
-											"pm.test(\"Response code 400\", function () {",
-											"  pm.response.to.be.clientError;",
-											"});",
-											""
-										],
-										"type": "text/javascript"
-									}
-								}
-							],
-							"request": {
-								"method": "GET",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": ""
-								},
-								"url": {
-									"raw": "{{base_url}}/api/v1/wells?sw_lat=bar&sw_long=foo",
+									"raw": "{{base_url}}/api/v1/wells?sw_lat=bar&sw_long=foo&ne_long=test&ne_lat=avalue",
 									"host": [
 										"{{base_url}}"
 									],
@@ -3162,6 +3069,14 @@
 										{
 											"key": "sw_long",
 											"value": "foo"
+										},
+										{
+											"key": "ne_long",
+											"value": "test"
+										},
+										{
+											"key": "ne_lat",
+											"value": "avalue"
 										}
 									]
 								}


### PR DESCRIPTION
Previously I used two point fields (sw and ne) to implement the bounding box widget, because that fits in with Django filter nicely, but it generates more complex queries. E.g.

```
SELECT
COUNT(*) AS "__count"
FROM "well" WHERE (
"well"."geom" |&> ST_GeomFromEWKB('\x0101000020e61000006666666666a65ec09a99999999994840'::bytea) 
AND "well"."geom" &> ST_GeomFromEWKB('\x0101000020e61000006666666666a65ec09a99999999994840'::bytea) 
AND "well"."geom" &<| ST_GeomFromEWKB('\x0101000020e610000085eb51b81ea55ec06666666666a64840'::bytea) 
AND "well"."geom" &< ST_GeomFromEWKB('\x0101000020e610000085eb51b81ea55ec06666666666a64840'::bytea))
```

vs using a bounding box filter, which does:

```
SELECT COUNT(*) AS "__count"
FROM "well" WHERE "well"."geom" && ST_GeomFromEWKB('\x0103000020e610000001000000050000006666666666a65ec09a999999999948406666666666a65ec06666666666a6484085eb51b81ea55ec06666666666a6484085eb51b81ea55ec09a999999999948406666666666a65ec09a99999999994840'::bytea)
```

I was thinking that Postgres/PostGIS would optimize them into the same thing, but it seems like it isn't.

This approach also dodges the match_any problem we were having because it's not part of the same filter backend. And, it's less code.
