### PR TITLE
fix for bug deleting rows of lithology, casings etc

### DIFF
--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -342,11 +342,11 @@ export default {
     formChanges () {
       let differences = diff(this.compareForm, this.form)
       if (differences) {
-        differences.forEach((d) => {
-          if (d.lhs == null && d.rhs === '') {
-            this.form[d.path[0]] = null
-          }
-        })
+        // differences.forEach((d) => {
+        //   if (d.lhs == null && d.rhs === '') {
+        //     this.form[d.path[0]] = null
+        //   }
+        // })
         return true
       }
       return false


### PR DESCRIPTION
The code is commented temporarily because we may need to implement the intent of the code (prevent saving a change a field's value from `null` to `""` empty string when the user didn't intend to change anything) in a different way.