### PR TITLE
change name of PVC in Minio template to match prod environment

### DIFF
--- a/openshift/minio.dc.yaml
+++ b/openshift/minio.dc.yaml
@@ -39,7 +39,7 @@ objects:
     metadata:
       finalizers:
       - kubernetes.io/pvc-protection
-      name: "${NAME}-config-vol"
+      name: "${NAME}-config-vol-v2"
       labels:
         app: "${NAME}"
     spec:
@@ -121,7 +121,7 @@ objects:
           volumes:
           - name: config-vol
             persistentVolumeClaim:
-              claimName: "${NAME}-config-vol"
+              claimName: "${NAME}-config-vol-v2"
           - name: data-vol
             persistentVolumeClaim:
               claimName: "${NAME}-data-vol"


### PR DESCRIPTION
We needed to provision a new PVC for our prod Minio configuration (`s3/config` directory in the Minio deployment).  I appended v2 to the name of the old PVC.  This PR adds `-v2` to the name of the PVC in the Minio deployment template to keep it consistent with the prod environment.