### PR TITLE
[1825] Ground Elevation Zero Values

### DIFF
--- a/app/backend/submissions/serializers.py
+++ b/app/backend/submissions/serializers.py
@@ -483,6 +483,8 @@ class WellStaffEditSubmissionSerializer(WellSubmissionSerializerBase):
         response['person_responsible'] = PersonNameSerializer(instance.person_responsible).data
         response['company_of_person_responsible'] = OrganizationNameListSerializer(
             instance.company_of_person_responsible).data
+        # this allows a 0 elevation value to be viewable as '' on the client
+        response['ground_elevation'] = '' if float(response['ground_elevation']) <= 0 else response['ground_elevation']
         return response
 
     def get_well_activity_type(self):

--- a/app/backend/wells/serializers.py
+++ b/app/backend/wells/serializers.py
@@ -541,6 +541,12 @@ class WellDetailAdminSerializer(AuditModelSerializer):
     # well vs. well_tag_number ; on submissions, we refer to well
     well = serializers.IntegerField(source='well_tag_number')
 
+    def to_representation(self, instance):
+        response = super().to_representation(instance)
+        # this allows a 0 elevation value to be viewable as '' on the client
+        response['ground_elevation'] = '' if float(response['ground_elevation']) <= 0 else response['ground_elevation']
+        return response
+
     class Meta:
         model = Well
         fields = '__all__'

--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -220,6 +220,12 @@ export default {
         data.company_of_person_responsible = data.company_of_person_responsible.org_guid
       }
 
+      // if ground_elevation is empty we set it to 0,
+      // so that the decimal value will allow it to be saved
+      if (data.ground_elevation === '') {
+        data.ground_elevation = 0
+      }
+
       if (data.well && data.well.well_tag_number) {
         data.well = data.well.well_tag_number
       }


### PR DESCRIPTION
- Due to our stacker not allowing the save of a null field, and the fact that ground_elevation is a decimal field that can’t be saved as an empty string, this PR swaps the ‘’ value for a 0 value and then the server swaps it back. This allows us saving an empty string field on a decimal input field.