### PR TITLE
better error messages for submissions/staff edit

### DIFF
--- a/app/frontend/src/common/helpers/formatField.js
+++ b/app/frontend/src/common/helpers/formatField.js
@@ -1,0 +1,43 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+// a map of difficult-to-read API field names to friendly descriptions
+const fieldMap = {
+  'lithologydescription_set': 'Lithology',
+  'lithology_from': 'depth from',
+  'lithology_to': 'depth to',
+  'lithology_raw_data': 'raw_data',
+  'lithology_colour': 'colour',
+  'lithology_hardness': 'hardness',
+  'lithology_moisture': 'moisture',
+  'lithology_description': 'description',
+  'lithology_observation': 'observations',
+  'decommission_description_set': 'Decommission descriptions',
+  'casing_set': 'Casings',
+  'screen_set': 'Screens',
+  'linerperforation_set': 'Liner perforations'
+}
+
+/**
+ * Formats an API field name into a readable description (using fieldMap), or if the key
+ * isn't present in fieldMap, returns the original key.
+ *
+ * @param {string} key - an API field key to format
+ * @return {string} returns either the friendly description (if in fieldMap) or the original key
+ */
+const formatField = (key) => {
+  return fieldMap[key] || key
+}
+
+export default formatField

--- a/app/frontend/src/common/helpers/parseErrors.js
+++ b/app/frontend/src/common/helpers/parseErrors.js
@@ -1,3 +1,5 @@
+import formatField from './formatField.js'
+
 // Returns formatted errors for notifications
 export default function (data) {
   let clean = Object.entries(JSON.parse(JSON.stringify(data)))
@@ -52,6 +54,7 @@ function flatten (arr) {
   let flt = []
   arr.forEach(r => {
     for (var i = 0; i < r.length; i++) {
+      r[i] = formatField(r[i])
       r[i] = jsUcfirst(r[i])
     }
   })
@@ -62,7 +65,9 @@ function flatten (arr) {
 }
 // Capitalizes first letter of a string
 function jsUcfirst (string) {
-  return string.charAt(0).toUpperCase() + string.slice(1)
+  let formattedString = string.charAt(0).toUpperCase() + string.slice(1)
+  formattedString = formattedString.replace(/_/g, ' ')
+  return formattedString
 }
 // Left commented out for future use
 // Flattens any dimension array into one single array of values

--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -346,7 +346,6 @@ export default {
         // Error notifications
         this.$noty.error('<div class="errorTitle">' + errTxt + '</div>', { timeout: 2000, killer: true })
         cleanErrors.forEach(e => {
-          console.log(e)
           this.$noty.error('<div aria-label="Close" class="closeBtn">x</div><div class="errorText"><b>Error: </b>' + e + '</div>', { timeout: false })
         })
       }).finally((response) => {

--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -90,6 +90,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </b-form>
         </div>
       </div>
+      <div class="card" v-else-if="!$keycloak.authenticated">
+        <div class="card-body">
+          <p>Please log in to continue.</p>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -341,6 +346,7 @@ export default {
         // Error notifications
         this.$noty.error('<div class="errorTitle">' + errTxt + '</div>', { timeout: 2000, killer: true })
         cleanErrors.forEach(e => {
+          console.log(e)
           this.$noty.error('<div aria-label="Close" class="closeBtn">x</div><div class="errorText"><b>Error: </b>' + e + '</div>', { timeout: false })
         })
       }).finally((response) => {


### PR DESCRIPTION
This PR includes a map of the most unreadable API field names, and displays a friendlier name to users (in error messages) if possible.