### PR TITLE
aquifer select now returns aquifer ID, not an object

### DIFF
--- a/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
@@ -33,6 +33,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             id="aquiferSelect"
             :filterable="false"
             :options="aquiferList"
+            :reduce="aquifer => aquifer.aquifer_id"
             label="description"
             index="aquifer_id"
             @search="onAquiferSearch">


### PR DESCRIPTION
this fixes a bug that was preventing users from selecting an aquifer on the Well edit page