### PR TITLE
Always scroll to aquifers table after a search completes

### DIFF
--- a/app/frontend/src/aquifers/components/Search.vue
+++ b/app/frontend/src/aquifers/components/Search.vue
@@ -314,13 +314,11 @@ export default {
           })
           this.response = response.data
           this.loading = false
-          if (this.aquifers_search_results.length > 0) {
-            // Note: Aquifer <table> might not be in the DOM yet if this is a new search after a page load.
-            // Wait until next tick before searching the DOM for the #aquifers-results
-            this.$nextTick(() => {
-              this.scrollToResults()
-            })
-          }
+          // Note: Aquifer <table> might not be in the DOM yet if this is a new search after a page load.
+          // Wait until next tick before searching the DOM for the #aquifers-results
+          this.$nextTick(() => {
+            this.scrollToResults()
+          })
         })
     },
     downloadCSV (filterOnly) {


### PR DESCRIPTION
Updated with feedback from Kailee:
>  Testing the enhanced search results works as requested -the page automatically scrolls to the top of the list. However, a search that returns no results leaves the user at the top of the page when there's the opportunity for the same feature; i.e. consistent UX so the page automatically scrolls down to show the "No aquifers could be found" text.