### PR TITLE
Allow remote Python debugger to be attached to dev docker container

### DIFF
--- a/app/backend/manage.py
+++ b/app/backend/manage.py
@@ -7,4 +7,12 @@ if __name__ == "__main__":
 
     from django.core.management import execute_from_command_line
 
+    from django.conf import settings
+
+    if settings.DEBUG:
+        if os.environ.get('RUN_MAIN') or os.environ.get('WERKZEUG_RUN_MAIN'):
+            import ptvsd
+            ptvsd.enable_attach(address = ('0.0.0.0', 3000))
+            print("Attached remote debugger")
+
     execute_from_command_line(sys.argv)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,7 @@ services:
       cd /app/backend &&
       mkdir -p .pip &&
       python3 -m pip install --upgrade pip &&
+      python3 -m pip install ptvsd &&
       python3 -m pip install --cache-dir=.pip -r requirements.txt &&
       python3 manage.py migrate --noinput &&
       ./load_fixtures.sh all &&
@@ -122,5 +123,6 @@ services:
       - ./app:/app
     ports:
       - "8000:8000"
+      - "3000:3000"
     depends_on:
       - db


### PR DESCRIPTION
Uses Python lib ptvsd to allow a remote debugger to be attached on port 3000. This can enable attaching a VSCode Python debugger to the running Django process.