### PR TITLE
540 fix obs wells not displaying inactive wells bug

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+API_TARGET=docker

--- a/app/frontend/src/aquifers/components/View.vue
+++ b/app/frontend/src/aquifers/components/View.vue
@@ -200,11 +200,13 @@
               <div class="observational-wells" v-if="section.key === 'obs-wells'">
                 <dt class="text-right">Observation wells</dt>
                 <dd class="m-0">
-                  <div v-if="active_obs_wells.length > 0">
+                  <div v-if="activeObsWells.length > 0">
                     <h6 class="border-bottom">Active</h6>
                     <ul class="p-0 m-0">
-                      <li v-for="owell in active_obs_wells" :key="owell.observation_well_number" :data-water-level="owell.waterLevels">
-                        <a :href="getObservationWellLink(owell.observation_well_number)" target="_blank">{{ owell.observation_well_number }}</a>
+                      <li v-for="owell in activeObsWells" :key="owell.observation_well_number" :data-water-level="owell.waterLevels">
+                        <a :href="getObservationWellLink(owell.observation_well_number)" target="_blank">
+                          {{ owell.observation_well_number }}
+                        </a>
                         <span v-if="owell.waterLevels">
                           Water Level Analysis:
                           <a :href="owell.hasLevelAnalysis ? 'http://www.env.gov.bc.ca/soe/indicators/water/groundwater-levels.html' : false" target="_blank">
@@ -214,11 +216,13 @@
                       </li>
                     </ul>
                   </div>
-                  <div v-else-if="inactive_obs_wells.length > 0">
+                  <div v-if="inactiveObsWellsWithWaterLevel.length > 0 || inativeObsWellsWithOutWaterLevel.length > 0">
                     <h6 class="border-bottom mt-2">Inactive<br><small>(data may not be available)</small></h6>
                     <ul class="p-0 m-0">
-                      <li v-for="owell in inactive_obs_wells" :key="owell.observation_well_number" :data-water-level="owell.waterLevels">
-                        <a :href="getObservationWellLink(owell.observation_well_number)" target="_blank">{{ owell.observation_well_number }}</a>
+                      <li v-for="owell in inactiveObsWellsWithWaterLevel" :key="owell.observation_well_number" :data-water-level="owell.waterLevels">
+                        <a :href="getObservationWellLink(owell.observation_well_number)" target="_blank">
+                          {{ owell.observation_well_number }}
+                        </a>
                         <div v-if="owell.waterLevels">
                           Water Level Analysis:
                           <a :href="owell.hasLevelAnalysis ? 'http://www.env.gov.bc.ca/soe/indicators/water/groundwater-levels.html' : false" target="_blank">
@@ -226,9 +230,15 @@
                           </a>
                         </div>
                       </li>
+                      <li v-if="inativeObsWellsWithOutWaterLevel.length > 0" class="obs-wells-wo-well-level">
+                        No Water Level Analysis:
+                        <span v-for="owell in inativeObsWellsWithOutWaterLevel" :key="owell.observation_well_number">
+                          <a :href="getObservationWellLink(owell.observation_well_number)" target="_blank">{{ owell.observation_well_number }}</a>
+                        </span>
+                      </li>
                     </ul>
                   </div>
-                  <div v-else>
+                  <div v-if="noObsWells">
                     No information available.
                   </div>
                 </dd>
@@ -340,18 +350,6 @@ a {
   padding-left: 2rem;
 }
 
-.observational-wells li:not([data-water-level]) {
-  display: inline;
-}
-
-.observational-wells li:not([data-water-level]):after {
-  content: ", ";
-}
-
-.observational-wells li:last-child:not([data-water-level]):after {
-  content: "";
-}
-
 .pie-chart-title {
   font-weight: bold !important;
   font-size: 1rem !important;
@@ -367,6 +365,10 @@ a {
 .aquifer-main-information-list .row > :nth-child(odd) {
   font-weight: bold;
   border-right: 1px solid rgba(0,0,0,0.1);
+}
+
+.observational-wells .obs-wells-wo-well-level span:not(:last-child):after {
+  content: ", ";
 }
 
 @media print {
@@ -455,8 +457,10 @@ export default {
         { code: 'I', name: 'Other information' }
       ],
       wells: [],
-      active_obs_wells: [],
-      inactive_obs_wells: [],
+      activeObsWells: [],
+      inactiveObsWellsWithWaterLevel: [],
+      inativeObsWellsWithOutWaterLevel: [],
+      noObsWells: false,
       waterWithdrawlVolume: ''
     }
   },
@@ -597,11 +601,19 @@ export default {
           const obsWells = response.data.licence_details.obs_wells
 
           return this.getWaterLevels(obsWells).then(() => {
-            const sortedWells = orderBy(obsWells, ['waterLevel']) // sorts so wells with waterLevels are at the top.
-            const wellsByStatus = groupBy(sortedWells, 'observation_well_status')
+            const sortedWells = orderBy(obsWells, ['hasLevelAnalysis', 'waterLevels'], ['desc', 'asc']) // sorts so wells with waterLevels are at the top.
+            const wellsByStatus = groupBy(sortedWells, 'observation_well_status') // groups wells into active and inactive categories
 
-            this.active_obs_wells = wellsByStatus.Active
-            this.inactive_obs_wells = wellsByStatus.Inactive
+            this.activeObsWells = wellsByStatus.Active || []
+
+            const inactiveObsWells = wellsByStatus.Inactive || []
+
+            // split inactive wells into those with water level analysis and those without
+            this.inactiveObsWellsWithWaterLevel = inactiveObsWells.filter((w) => w.waterLevels)
+            this.inativeObsWellsWithOutWaterLevel = inactiveObsWells.filter((w) => !w.waterLevels)
+
+            // Show the "No information available." message when there are no obs wells to show
+            this.noObsWells = this.activeObsWells.length === 0 && inactiveObsWells.length === 0
           })
         }).catch((error) => {
           console.error(error)
@@ -619,6 +631,7 @@ export default {
     getWaterLevels (obsWells) {
       return Promise.all(
         obsWells.map((owell) => {
+          owell.hasLevelAnalysis = false
           let wellNumber = owell.observation_well_number
           const url = `https://catalogue.data.gov.bc.ca/api/3/action/datastore_search?resource_id=a8933793-eadb-4a9c-992c-da4f6ac8ca51&fields=EMS_ID,Well_Num,trend_line_slope,category&filters=%7b%22Well_Num%22:%22${wellNumber}%22%7d`
           return ApiService.query(url).then((response) => {

--- a/app/frontend/vue.config.js
+++ b/app/frontend/vue.config.js
@@ -1,3 +1,7 @@
+if (process.env.API_TARGET === 'staging') {
+  console.log('Targetting the STAGING API')
+}
+
 module.exports = {
   lintOnSave: false,
   runtimeCompiler: true,
@@ -7,6 +11,16 @@ module.exports = {
       watchOptions: {
         ignored: /node_modules/,
         poll: 1000
+      }
+    }
+  },
+  devServer: {
+    proxy: {
+      '^/api/': {
+        target: process.env.API_TARGET === 'staging' ? 'https://gwells-staging.pathfinder.gov.bc.ca/' : 'http://backend:8000/',
+        pathRewrite: {
+          '^/api': '/gwells/api/v2'
+        }
       }
     }
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,9 @@ services:
     working_dir: /app/frontend
     environment:
       DEBUG: "True"
-      VUE_APP_AXIOS_BASE_URL: http://127.0.0.1:8000/gwells/api/v2/
+      VUE_APP_AXIOS_BASE_URL: /api/
       CHOKIDAR_USEPOLLING: "True"
+      API_TARGET: "${API_TARGET}"
     command: /bin/bash -c "
         set -x &&
         cd /app/frontend &&


### PR DESCRIPTION
Verifying [WATER-540](https://apps.nrs.gov.bc.ca/int/jira/browse/WATER-540) with staging data I saw that the algorithm I was using wasn't working for aquifers with only inactive observation well data (e.g. aquifer #612). I have fixed the algorithm so the display of active and inactive wells shows up for any obs wells data.

![image](https://user-images.githubusercontent.com/1957566/70662480-22b1e500-1c1b-11ea-82ff-dbe5ad3bd91e.png)
