### PR TITLE
Fixes Django Debug Toolbar

### DIFF
--- a/app/backend/gwells/settings/__init__.py
+++ b/app/backend/gwells/settings/__init__.py
@@ -132,6 +132,10 @@ MIDDLEWARE = (
 ROOT_URLCONF = 'gwells.urls'
 INTERNAL_IPS = '127.0.0.1'
 
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_TOOLBAR_CALLBACK': lambda request: DEBUG,
+}
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
It now will show up when the back-end is running inside a container.