### PR TITLE
Pins leaflet-gesture-handling npm module

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -10207,9 +10207,7 @@
       }
     },
     "leaflet-gesture-handling": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/leaflet-gesture-handling/-/leaflet-gesture-handling-1.1.8.tgz",
-      "integrity": "sha512-QnKNAqZxaO4nzCsHA9l/vPazF15TILkSaYNoDqMtiVXrsWMWh6fWD4phRuftPC+kvY9OBzVKuTfKlLdhZ/2oIg=="
+      "version": "github:mrleblanc101/Leaflet.GestureHandling#c78f7414c8615a56d4eab54f4be5b9b34149afec"
     },
     "leaflet-lasso": {
       "version": "1.1.3",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -24,7 +24,7 @@
     "leaflet-edgebuffer": "^1.0.6",
     "leaflet-fullscreen": "^1.0.2",
     "leaflet-geosearch": "^2.7.0",
-    "leaflet-gesture-handling": "^1.1.8",
+    "leaflet-gesture-handling": "mrleblanc101/Leaflet.GestureHandling#c78f7414c8615a56d4eab54f4be5b9b34149afec",
     "leaflet-lasso": "^1.1.3",
     "leaflet.locatecontrol": "^0.66.2",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
https://apps.nrs.gov.bc.ca/int/jira/browse/WATER-749

Fixes a bug where you can no longer drag when on a non-vector layer part of the map if you initially click down on a vector layer.