### PR TITLE
Upgrades axios to 0.19.1 to fix Chrome cancellation bug

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -2330,12 +2330,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.1.tgz",
+      "integrity": "sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "2.0.3"
+        "follow-redirects": "1.5.10"
       },
       "dependencies": {
         "debug": {
@@ -2353,11 +2352,6 @@
           "requires": {
             "debug": "3.1.0"
           }
-        },
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
         },
         "ms": {
           "version": "2.0.0",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -15,7 +15,7 @@
     "@sentry/browser": "^5.7.1",
     "@sentry/integrations": "^5.7.1",
     "@types/leaflet": "^1.2.11",
-    "axios": "^0.18.1",
+    "axios": "^0.19.1",
     "bootstrap-vue": "^2.0.0-rc.2",
     "browser-update": "^3.3.8",
     "chart.js": "^2.8.0",

--- a/app/frontend/src/aquifers/components/View.vue
+++ b/app/frontend/src/aquifers/components/View.vue
@@ -255,7 +255,7 @@
                       </li>
                       <li v-if="inativeObsWellsWithOutWaterLevel.length > 0" class="obs-wells-wo-well-level">
                         No Water Level Analysis:
-                        <span v-for="owell in inativeObsWellsWithOutWaterLevel" :key="owell.observation_well_number">
+                        <span v-for="owell in inativeObsWellsWithOutWaterLevel" :key="owell.observation_well_number" :class="owell.errorFetching ? 'error' : ''">
                           <a :href="getObservationWellLink(owell.observation_well_number)" target="_blank">{{ owell.observation_well_number }}</a>
                         </span>
                       </li>
@@ -731,7 +731,10 @@ export default {
               owell.hasLevelAnalysis = category.toUpperCase() !== 'N/A'
               owell.waterLevels = category
             }
-          }, () => {}) // Swallow any API error from https://catalogue.data.gov.bc.ca/api
+          }, () => {
+            // Swallow any API error from https://catalogue.data.gov.bc.ca/api
+            owell.errorFetching = true
+          })
         })
       )
     },


### PR DESCRIPTION
https://apps.nrs.gov.bc.ca/int/jira/browse/WATER-790

While testing the fix for WATER-790 the map would show a spinner forever.
https://gwells-staging.pathfinder.gov.bc.ca/gwells/aquifers/20

It turns out [Axios had a bug](https://github.com/axios/axios/issues/537) which was still a problem for us even though we were using Axios 0.18.1. Upgrading to 0.19.1 fixes the issue.