### PR TITLE
Fixes string formatting syntax error in legacy_records command

### DIFF
--- a/app/backend/wells/management/commands/legacy_records.py
+++ b/app/backend/wells/management/commands/legacy_records.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
             try:
                 self.create_legacy_record(well)
             except Exception as err:
-                print('Error creating legacy record for well_tag_number {well.well_tag_number}')
+                print(f'Error creating legacy record for well_tag_number {well.well_tag_number}')
                 raise err
         end = timer()
 


### PR DESCRIPTION
Fixes a bug when running `python manage.py legacy_command` where the error string isn't being formatted properly.