### PR TITLE
Fix dupe removal migration

### DIFF
--- a/app/backend/wells/migrations/0110_delete_legacy_dupes_20200401_2244.py
+++ b/app/backend/wells/migrations/0110_delete_legacy_dupes_20200401_2244.py
@@ -41,11 +41,11 @@ def delete_entire_submission(activity_submission):
     activity_submission.development_methods.clear()
     activity_submission.water_quality_characteristics.clear()
 
-    activity_submission.lithologydescription_set.clear()
-    activity_submission.casing_set.clear()
-    activity_submission.decommission_description_set.clear()
-    activity_submission.screen_set.clear()
-    activity_submission.linerperforation_set.clear()
+    activity_submission.lithologydescription_set.all().delete()
+    activity_submission.casing_set.all().delete()
+    activity_submission.decommission_description_set.all().delete()
+    activity_submission.screen_set.all().delete()
+    activity_submission.linerperforation_set.all().delete()
 
     activity_submission.fields_provided.delete()
 


### PR DESCRIPTION
https://apps.nrs.gov.bc.ca/int/jira/browse/WATER-1012

Now the migration will remove the lithology, etc data associated with the duped activity submission instead of just setting the `filing_number` to `NULL`.