### PR TITLE
Mapbox aquifer details map fixes

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -859,9 +859,7 @@
       "integrity": "sha512-8yPorlHeU63U6aT7RJbgSfXGKTZtnQz7Os8Qw96PW2lXJ+g1CRe5L/G8h5qtYHqt5VM4yCUGIhzHHYxdGzanLQ=="
     },
     "@geolonia/mbgl-gesture-handling": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@geolonia/mbgl-gesture-handling/-/mbgl-gesture-handling-1.0.11.tgz",
-      "integrity": "sha512-2/QSQhI8Fumu8dEKtKUHTSt5CVNPyaXZWjAMkoyfmgqgDNQc4yF4Oe1xOCr6VIl1ZG3cN9x5sD/xSZSMhsjG/g=="
+      "version": "github:seamus-oconnor/mbgl-gesture-handling#f99d70e34e4573ebdfdfa70bd68708178e9306d4"
     },
     "@hapi/address": {
       "version": "2.0.0",
@@ -911,8 +909,8 @@
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.0.tgz",
       "integrity": "sha512-73l/qJQgj/T/zO1JXVfuVvvKDgikD/7D/rHAD28S9BG1OTstgmftrmqfCx4U+zQAmtsB6HcDA3a7ymdnJZAQgg==",
       "requires": {
-        "concat-stream": "~2.0.0",
-        "minimist": "^1.2.5"
+        "concat-stream": "2.0.0",
+        "minimist": "1.2.5"
       },
       "dependencies": {
         "concat-stream": {
@@ -920,10 +918,10 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
           "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
           "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^3.0.2",
-            "typedarray": "^0.0.6"
+            "buffer-from": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "3.6.0",
+            "typedarray": "0.0.6"
           }
         },
         "minimist": {
@@ -936,9 +934,9 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "inherits": "2.0.3",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         }
       }
@@ -978,7 +976,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
       "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
       "requires": {
-        "@mapbox/point-geometry": "~0.1.0"
+        "@mapbox/point-geometry": "0.1.0"
       }
     },
     "@mapbox/whoots-js": {
@@ -6879,8 +6877,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6901,14 +6898,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -6923,20 +6918,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7053,8 +7045,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7066,7 +7057,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -7081,7 +7071,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
@@ -7089,14 +7078,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "5.1.2",
             "yallist": "3.0.3"
@@ -7115,7 +7102,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7196,8 +7182,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7209,7 +7194,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1.0.2"
           }
@@ -7295,8 +7279,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7332,7 +7315,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
@@ -7352,7 +7334,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
@@ -7396,14 +7377,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10274,8 +10253,7 @@
       }
     },
     "leaflet-gesture-handling": {
-      "version": "github:mrleblanc101/Leaflet.GestureHandling#c78f7414c8615a56d4eab54f4be5b9b34149afec",
-      "from": "leaflet-gesture-handling@github:mrleblanc101/Leaflet.GestureHandling#c78f7414c8615a56d4eab54f4be5b9b34149afec"
+      "version": "github:mrleblanc101/Leaflet.GestureHandling#c78f7414c8615a56d4eab54f4be5b9b34149afec"
     },
     "leaflet-lasso": {
       "version": "1.1.3",
@@ -10603,29 +10581,29 @@
       "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.0.tgz",
       "integrity": "sha512-SrJXcR9s5yEsPuW2kKKumA1KqYW9RrL8j7ZcIh6glRQ/x3lwNMfwz/UEJAJcVNgeX+fiwzuBoDIdeGB/vSkZLQ==",
       "requires": {
-        "@mapbox/geojson-rewind": "^0.5.0",
-        "@mapbox/geojson-types": "^1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.5.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.1",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^2.2.2",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.2.1",
-        "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^1.0.1",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^7.0.0",
-        "tinyqueue": "^2.0.3",
-        "vt-pbf": "^3.1.1"
+        "@mapbox/geojson-rewind": "0.5.0",
+        "@mapbox/geojson-types": "1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "2.0.2",
+        "@mapbox/mapbox-gl-supported": "1.5.0",
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/tiny-sdf": "1.1.1",
+        "@mapbox/unitbezier": "0.0.0",
+        "@mapbox/vector-tile": "1.3.1",
+        "@mapbox/whoots-js": "3.1.0",
+        "csscolorparser": "1.0.3",
+        "earcut": "2.2.2",
+        "geojson-vt": "3.2.1",
+        "gl-matrix": "3.3.0",
+        "grid-index": "1.1.0",
+        "minimist": "1.2.5",
+        "murmurhash-js": "1.0.0",
+        "pbf": "3.2.1",
+        "potpack": "1.0.1",
+        "quickselect": "2.0.0",
+        "rw": "1.3.3",
+        "supercluster": "7.0.0",
+        "tinyqueue": "2.0.3",
+        "vt-pbf": "3.1.1"
       },
       "dependencies": {
         "minimist": {
@@ -12009,8 +11987,8 @@
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
       "requires": {
-        "ieee754": "^1.1.12",
-        "resolve-protobuf-schema": "^2.1.0"
+        "ieee754": "1.1.13",
+        "resolve-protobuf-schema": "2.1.0"
       }
     },
     "pbkdf2": {
@@ -13484,7 +13462,7 @@
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
       "requires": {
-        "protocol-buffers-schema": "^3.3.1"
+        "protocol-buffers-schema": "3.4.0"
       }
     },
     "resolve-url": {
@@ -13589,8 +13567,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
@@ -14740,7 +14717,7 @@
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.0.0.tgz",
       "integrity": "sha512-8VuHI8ynylYQj7Qf6PBMWy1PdgsnBiIxujOgc9Z83QvJ8ualIYWNx2iMKyKeC4DZI5ntD9tz/CIwwZvIelixsA==",
       "requires": {
-        "kdbush": "^3.0.0"
+        "kdbush": "3.0.0"
       }
     },
     "supports-color": {
@@ -15666,8 +15643,8 @@
       "integrity": "sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==",
       "requires": {
         "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "pbf": "^3.0.5"
+        "@mapbox/vector-tile": "1.3.1",
+        "pbf": "3.2.1"
       }
     },
     "vue": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -12,7 +12,7 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {
-    "@geolonia/mbgl-gesture-handling": "^1.0.11",
+    "@geolonia/mbgl-gesture-handling": "seamus-oconnor/mbgl-gesture-handling#f99d70e34e4573ebdfdfa70bd68708178e9306d4",
     "@sentry/browser": "^5.7.1",
     "@sentry/integrations": "^5.7.1",
     "@types/leaflet": "^1.2.11",

--- a/app/frontend/src/aquifers/components/SingleAquiferMap.vue
+++ b/app/frontend/src/aquifers/components/SingleAquiferMap.vue
@@ -172,7 +172,7 @@ export default {
       }
 
       this.map = new mapboxgl.Map(mapConfig)
-      new GestureHandling().addTo(this.map)
+      new GestureHandling({ modifierKey: 'ctrl' }).addTo(this.map)
 
       /* Add controls */
 
@@ -311,7 +311,7 @@ export default {
     }
   }
 
-  #mbgl-gesture-handling-help-container-0 {
+  [id^=mbgl-gesture-handling-help-container-] {
     font-size: 25px;
   }
 

--- a/app/frontend/src/aquifers/popup.js
+++ b/app/frontend/src/aquifers/popup.js
@@ -34,7 +34,7 @@ export function createWellPopupElement ($router, wellFeatureProperties, options 
   const url = $router.resolve(routes.wellDetail)
 
   const items = [
-    `<a href="${url.href}" data-route-name="wellDetail">Well Tag Number ${wellTagNumber}</a>`,
+    `Well Tag Number: <a href="${url.href}" data-route-name="wellDetail">${wellTagNumber}</a>`,
     `Identification Plate Number: ${identificationPlateNumber || '—'}`,
     `Address: ${streetAddress || '—'}`,
     correlatedAquiferItem,
@@ -100,27 +100,31 @@ export function setupMapTooltips (map, $router, options = {}) {
   const aquifersTooltip = new mapboxgl.Popup()
   let overAquifer = false
 
-  map.on('mousemove', 'wells', (e) => {
-    map.getCanvas().style.cursor = 'pointer'
+  const wellsLayerIds = options.wellsLayerIds || [ 'wells', 'wells-ems', 'wells-uncorrelated' ]
 
-    aquifersTooltip.remove()
+  wellsLayerIds.forEach((wellLayerId) => {
+    map.on('mousemove', wellLayerId, (e) => {
+      map.getCanvas().style.cursor = 'pointer'
 
-    if (map.popup.isOpen()) { return }
+      aquifersTooltip.remove()
 
-    const feature = e.features[0]
-    const contentDiv = createWellPopupElement($router, feature.properties, options)
-    wellsTooltip
-      .setLngLat(getLngLatOfPointFeature(feature))
-      .setDOMContent(contentDiv)
-      .addTo(map)
-  })
+      if (map.popup.isOpen()) { return }
 
-  map.on('mouseleave', 'wells', () => {
-    map.getCanvas().style.cursor = ''
-    wellsTooltip.remove()
-    if (overAquifer && !map.popup.isOpen()) {
-      aquifersTooltip.addTo(map)
-    }
+      const feature = e.features[0]
+      const contentDiv = createWellPopupElement($router, feature.properties, options)
+      wellsTooltip
+        .setLngLat(getLngLatOfPointFeature(feature))
+        .setDOMContent(contentDiv)
+        .addTo(map)
+    })
+
+    map.on('mouseleave', wellLayerId, () => {
+      map.getCanvas().style.cursor = ''
+      wellsTooltip.remove()
+      if (overAquifer && !map.popup.isOpen()) {
+        aquifersTooltip.addTo(map)
+      }
+    })
   })
 
   map.on('mouseenter', 'aquifer-fill', (e) => {


### PR DESCRIPTION
1. Uses [fork of mbgl-gesture-handling](https://github.com/geolonia/mbgl-gesture-handling/pull/7) to use ctrl key instead of alt.
2. Updates well popup to only surround WTN with a link.
3. EMS and Uncorrelated wells layers mouse over tooltips now work when Wells layer is not enabled

![image](https://user-images.githubusercontent.com/1957566/81206808-7b469d80-8f81-11ea-99f4-123d4ca6d986.png)

