### PR TITLE
Mapbox aquifer map fixes

### DIFF
--- a/app/frontend/src/aquifers/components/AquiferMap.vue
+++ b/app/frontend/src/aquifers/components/AquiferMap.vue
@@ -185,7 +185,7 @@ export default {
 
       this.addTopCentreControlConainer()
 
-      new GestureHandling().addTo(this.map)
+      new GestureHandling({ modifierKey: 'ctrl' }).addTo(this.map)
 
       /* Add controls */
 

--- a/app/frontend/src/aquifers/popup.js
+++ b/app/frontend/src/aquifers/popup.js
@@ -179,7 +179,7 @@ export function setupMapTooltips (map, $router, options = {}) {
 
 // Adds mouse event listeners to the map which will show the popup for the clicked well or aquifer
 export function setupMapPopups (map, $router, options = {}) {
-  const wellsLayerId = options.wellsLayerId || WELLS_BASE_AND_ARTESIAN_LAYER_ID
+  const wellsLayerIds = options.wellsLayerIds || DEFAULT_WELL_LAYER_IDS
   const aquiferFillLayerId = options.aquiferFillLayerId || AQUIFERS_FILL_LAYER_ID
 
   let clickedOnWell = false
@@ -189,14 +189,16 @@ export function setupMapPopups (map, $router, options = {}) {
   })
   map.popup = popup
 
-  map.on('click', wellsLayerId, (e) => {
-    clickedOnWell = true
-    const feature = e.features[0]
-    const contentDiv = createWellPopupElement($router, feature.properties, options)
-    popup
-      .setLngLat(getLngLatOfPointFeature(feature))
-      .setDOMContent(contentDiv)
-      .addTo(map)
+  wellsLayerIds.forEach((wellLayerId) => {
+    map.on('click', wellLayerId, (e) => {
+      clickedOnWell = true
+      const feature = e.features[0]
+      const contentDiv = createWellPopupElement($router, feature.properties, options)
+      popup
+        .setLngLat(getLngLatOfPointFeature(feature))
+        .setDOMContent(contentDiv)
+        .addTo(map)
+    })
   })
 
   map.on('click', aquiferFillLayerId, (e) => {


### PR DESCRIPTION
Fixes bug where clicking on a EMS or uncorrelated well would not make a popup. Aquifer map uses the ctrl modifier key for mouse wheel zooming.