### PR TITLE
Fixes CSS bug with aquifer search checkboxes

### DIFF
--- a/app/frontend/src/aquifers/components/Search.vue
+++ b/app/frontend/src/aquifers/components/Search.vue
@@ -514,9 +514,15 @@ export default {
     margin: 0;
   }
 
-  .aquifer-checkbox-group .custom-control-label:before {
-    background-color: white;
-    border: 1px solid #CED4DA;
+  .aquifer-checkbox-group {
+    .custom-control-label:before {
+      background-color: white;
+      border: 1px solid #CED4DA;
+    }
+
+    .custom-control-input:checked~.custom-control-label:before {
+      background-color: #007bff;
+    }
   }
 
   #aquifers-search-button {


### PR DESCRIPTION
https://apps.nrs.gov.bc.ca/int/jira/browse/WATER-1103

With a refactor of the Aquifer Search CSS the "Advanced Search" checkboxes were no longer styled properly.

Before:
![image](https://user-images.githubusercontent.com/1957566/81620809-98280a00-93a1-11ea-924f-685e2071cae5.png)

After:
![image](https://user-images.githubusercontent.com/1957566/81620793-8b0b1b00-93a1-11ea-9521-0e4a1a125026.png)
