### PR TITLE
Upgrade gdal to 3.1.0 for SNYK-PYTHON-GDAL-571002 vulnerability

### DIFF
--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -21,7 +21,7 @@ cryptography==2.3.1
 django-reversion==2.0.13
 openpyxl==2.5.11
 lxml==4.2.5
-GDAL>=2.4,<3.0
+GDAL==3.1.0
 deepdiff>=4
 urllib3>=1.24,<1.25
 djangorestframework-csv==2.1.0


### PR DESCRIPTION
Created this PR since the Snyk PR #1661 didn't change the requirements.txt file.