### PR TITLE
clean up API docs and reduce to a simplified set of endpoints

### DIFF
--- a/app/backend/aquifers/views.py
+++ b/app/backend/aquifers/views.py
@@ -343,7 +343,7 @@ class AquiferNameList(ListAPIView):
     serializer_class = serializers.AquiferSerializerBasic
     model = Aquifer
     pagination_class = None
-
+    swagger_schema = None
     filter_backends = (filters.SearchFilter,)
     ordering = ('aquifer_id',)
     search_fields = (
@@ -513,16 +513,9 @@ AQUIFER_PROPERTIES = openapi.Schema(
 
 
 @swagger_auto_schema(
-    operation_description=(
-        'Get GeoJSON (see https://tools.ietf.org/html/rfc7946) dump of aquifers.'),
-    method='get',
-    manual_parameters=GEO_JSON_PARAMS,
-    responses={
-        302: openapi.Response(GEO_JSON_302_MESSAGE),
-        200: openapi.Response(
-            'GeoJSON data for aquifers.',
-            get_geojson_schema(AQUIFER_PROPERTIES, 'Polygon'))
-    })
+    method="GET",
+    auto_schema=None
+)
 @api_view(['GET'])
 def aquifer_geojson_v1(request, **kwargs):
     realtime = request.GET.get('realtime') in ('True', 'true')
@@ -557,7 +550,7 @@ def aquifer_geojson_v1(request, **kwargs):
             'api/v1/gis/aquifers.json')
         return HttpResponseRedirect(url)
 
-
+@swagger_auto_schema(method='GET', auto_schema=None)
 @api_view(['GET'])
 @cache_page(60*15)
 def aquifer_geojson_simplified_v1(request, **kwargs):

--- a/app/backend/gwells/views/api.py
+++ b/app/backend/gwells/views/api.py
@@ -1,7 +1,7 @@
 import requests
 import geojson
 from geojson import Feature, FeatureCollection, Point
-
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from django.http import JsonResponse, HttpResponse
@@ -44,6 +44,8 @@ class GeneralConfig(APIView):
 class AnalyticsConfig(APIView):
     """ serves analytics config """
 
+    swagger_schema = None
+    
     def get(self, request, **kwargs):
         config = {
             "enable_google_analytics": get_env_variable("ENABLE_GOOGLE_ANALYTICS") == "True"
@@ -53,7 +55,9 @@ class AnalyticsConfig(APIView):
 
 class InsideBC(APIView):
     """ Check if a given point is inside BC """
-
+    
+    swagger_schema = None
+    
     def get(self, request, **kwargs):
         latitude = request.query_params.get('latitude')
         longitude = request.query_params.get('longitude')
@@ -65,7 +69,8 @@ class InsideBC(APIView):
 
 class DataBCGeocoder(APIView):
     """ Looks up address using DataBC's geocoder """
-
+    swagger_schema = None
+    
     def get(self, request, **kwargs):
         query = kwargs['query']
 

--- a/app/backend/registries/urls.py
+++ b/app/backend/registries/urls.py
@@ -36,6 +36,7 @@ schema_view = get_schema_view(
         license=openapi.License(name="Open Government License - British Columbia",
                                 url="https://www2.gov.bc.ca/gov/content?id=A519A56BC2BF44E4A008B33FCF527F61"),
     ),
+    url='https://apps.nrs.gov.bc.ca/gwells/',
     public=False,
     permission_classes=(permissions.RegistriesEditOrReadOnly,)
 )
@@ -128,6 +129,6 @@ urlpatterns = [
         name='city-list-installers'),
 
     # Swagger documentation endpoint
-    url(r'^api/$', schema_view.with_ui('redoc', cache_timeout=None), name='api-docs'),
+    url(r'^api/$', schema_view.with_ui('swagger', cache_timeout=None), name='api-docs'),
 
 ]

--- a/app/backend/registries/views.py
+++ b/app/backend/registries/views.py
@@ -324,7 +324,6 @@ class PersonListView(RevisionMixin, AuditCreateMixin, ListCreateAPIView):
     permission_classes = (RegistriesEditOrReadOnly,)
     serializer_class = PersonAdminSerializer
     pagination_class = APILimitOffsetPagination
-
     # Allow searching on name fields, names of related companies, etc.
     filter_backends = (restfilters.DjangoFilterBackend,
                        filters.SearchFilter, filters.OrderingFilter)
@@ -577,6 +576,7 @@ class OrganizationNameListView(ListAPIView):
         .select_related('province_state')
     pagination_class = None
     lookup_field = 'organization_guid'
+    swagger_schema = None
 
     def get_queryset(self):
         return self.queryset.filter(expiry_date__gt=timezone.now())
@@ -769,6 +769,7 @@ class PersonNameSearch(ListAPIView):
     serializer_class = PersonNameSerializer
     pagination_class = None
     lookup_field = 'person_guid'
+    swagger_schema = None
 
     ordering = ('surname',)
 
@@ -780,29 +781,13 @@ class PersonNameSearch(ListAPIView):
 
 class ListFiles(APIView):
     """
-    List documents associated with an aquifer
+    List documents associated with a person in the Registry
 
-    get: list files found for the aquifer identified in the uri
+    get: list files found for the person identified in the uri
     """
 
-    @swagger_auto_schema(responses={200: openapi.Response('OK',
-        openapi.Schema(type=openapi.TYPE_OBJECT, properties={
-            'public': openapi.Schema(type=openapi.TYPE_ARRAY, items=openapi.Schema(
-                type=openapi.TYPE_OBJECT,
-                properties={
-                    'url': openapi.Schema(type=openapi.TYPE_STRING),
-                    'name': openapi.Schema(type=openapi.TYPE_STRING)
-                }
-            )),
-            'private': openapi.Schema(type=openapi.TYPE_ARRAY, items=openapi.Schema(
-                type=openapi.TYPE_OBJECT,
-                properties={
-                    'url': openapi.Schema(type=openapi.TYPE_STRING),
-                    'name': openapi.Schema(type=openapi.TYPE_STRING)
-                }
-            ))
-        })
-    )})
+    swagger_schema = None
+
     def get(self, request, person_guid, **kwargs):
         user_is_staff = self.request.user.groups.filter(
             Q(name=REGISTRIES_EDIT_ROLE) | Q(name=REGISTRIES_VIEWER_ROLE)).exists()
@@ -825,8 +810,8 @@ class PreSignedDocumentKey(APIView):
 
     queryset = Person.objects.all()
     permission_classes = (RegistriesEditPermissions,)
+    swagger_schema = None
 
-    @swagger_auto_schema(auto_schema=None)
     def get(self, request, person_guid, **kwargs):
         person = get_object_or_404(self.queryset, pk=person_guid)
         client = MinioClient(
@@ -852,8 +837,8 @@ class DeleteDrillerDocument(APIView):
 
     queryset = Person.objects.all()
     permission_classes = (RegistriesEditPermissions,)
+    swagger_schema = None
 
-    @swagger_auto_schema(auto_schema=None)
     def delete(self, request, person_guid, **kwargs):
         person = get_object_or_404(self.queryset, pk=person_guid)
         client = MinioClient(

--- a/app/backend/wells/views.py
+++ b/app/backend/wells/views.py
@@ -269,6 +269,7 @@ class WellTagSearchAPIView(ListAPIView):
     pagination_class = None
     serializer_class = WellTagSearchSerializer
     lookup_field = 'well_tag_number'
+    swagger_schema = None
 
     filter_backends = (filters.SearchFilter, filters.OrderingFilter)
     ordering_fields = ('well_tag_number',)
@@ -318,6 +319,7 @@ class WellLocationListAPIViewV1(ListAPIView):
     permission_classes = (WellsEditOrReadOnly,)
     model = Well
     serializer_class = WellLocationSerializerV1
+    swagger_schema = None
 
     # Allow searching on name fields, names of related companies, etc.
     filter_backends = (WellListFilterBackend, BoundingBoxFilterBackend,
@@ -631,15 +633,8 @@ WELL_PROPERTIES = openapi.Schema(
 
 
 @swagger_auto_schema(
-    operation_description=('Get GeoJSON (see https://tools.ietf.org/html/rfc7946) dump of wells.'),
-    method='get',
-    manual_parameters=GEO_JSON_PARAMS,
-    responses={
-        302: openapi.Response(GEO_JSON_302_MESSAGE),
-        200: openapi.Response(
-            'GeoJSON data for well.',
-            get_geojson_schema(WELL_PROPERTIES, 'Point'))
-    }
+    method="GET",
+    auto_schema=None
 )
 @api_view(['GET'])
 def well_geojson(request, **kwargs):
@@ -710,16 +705,8 @@ LITHOLOGY_PROPERTIES = openapi.Schema(
 
 
 @swagger_auto_schema(
-    operation_description=('Get GeoJSON (see https://tools.ietf.org/html/rfc7946) dump of well '
-                           'lithology.'),
-    method='get',
-    manual_parameters=GEO_JSON_PARAMS,
-    responses={
-        302: openapi.Response(GEO_JSON_302_MESSAGE),
-        200: openapi.Response(
-            'GeoJSON data for well lithology.',
-            get_geojson_schema(LITHOLOGY_PROPERTIES, 'Point'))
-    }
+    method="GET",
+    auto_schema=None
 )
 @api_view(['GET'])
 def lithology_geojson(request, **kwargs):
@@ -751,7 +738,7 @@ def lithology_geojson(request, **kwargs):
             'api/v1/gis/lithology.json')
         return HttpResponseRedirect(url)
 
-
+@swagger_auto_schema(method='GET', auto_schema=None)
 @api_view(['GET'])
 def well_licensing(request, **kwargs):
     tag = request.GET.get('well_tag_number')


### PR DESCRIPTION
Simplified documentation to include the following "core" endpoints and get it ready for publishing on DataBC:

* wells list and well details, and public files for wells
* aquifers list and aquifer details, and aquifer documentation
* registries list

New documention:  https://gwells-dev-pr-1799.apps.silver.devops.gov.bc.ca/gwells/api/

the current documentation can be compared here https://apps.nrs.gov.bc.ca/gwells/api/ , feedback welcome on endpoints that should be kept.