### PR TITLE
unquote object names to remove plus signs

### DIFF
--- a/app/backend/gwells/documents.py
+++ b/app/backend/gwells/documents.py
@@ -16,7 +16,7 @@ import os
 import logging
 from datetime import timedelta
 from django.urls import reverse
-from urllib.parse import quote
+from urllib.parse import quote, unquote_plus
 from minio import Minio
 from gwells.settings.base import get_env_variable
 
@@ -111,7 +111,7 @@ class MinioClient():
         return 'https://{}/{}/{}'.format(
             host,
             quote(obj.bucket_name),
-            quote(obj.object_name)
+            quote(unquote_plus(obj.object_name))
         )
 
     def create_url_list(self, objects, host, bucket_name, private=False):
@@ -122,7 +122,7 @@ class MinioClient():
                     'url': self.create_url(document, host, bucket_name, private),
 
                     # split on last occurrence of '/' and return last item (supports any or no prefixes)
-                    'name': document.object_name.rsplit('/', 1)[-1]
+                    'name': unquote_plus(document.object_name).rsplit('/', 1)[-1]
                 }, objects)
         )
         return urls


### PR DESCRIPTION
We are suddenly seeing that spaces in S3 object keys are encoded as plus signs when we list files, but requesting them with the exact same object key as returned by the list operation fails because the plus signs aren't converted back.  So far this is only the case with S3, not Minio.