### PR TITLE
Removed duplicate output for alternative specs

### DIFF
--- a/app/frontend/src/wells/views/WellDetail.vue
+++ b/app/frontend/src/wells/views/WellDetail.vue
@@ -470,9 +470,6 @@ Licensed under the Apache License, Version 2.0 (the "License");
           <p>
             {{ well.comments ? well.comments : 'No comments submitted' }}
           </p>
-          <p>
-            <span class="font-weight-bold">Alternative Specs Submitted:</span> {{ well.alternative_specs_submitted | nullBooleanToYesNo }}
-          </p>
         </fieldset>
 
         <fieldset id="documents_fieldset" class="detail-section my-3">


### PR DESCRIPTION
Removed duplicate output from the WellDetail view file.

Contradicting data was an issue caused from data expecting a boolean value where a string stored. (function nullBooleanToYesNo)