### PR TITLE
Feat: Removed pumping stress index

### DIFF
--- a/app/frontend/src/aquifers/components/Search.vue
+++ b/app/frontend/src/aquifers/components/Search.vue
@@ -364,6 +364,12 @@ export default {
           name: 'Hydraulically connected',
           code: HYDRAULICALLY_CONNECTED_CODE
         })
+        // remove pumping stress index option
+        const idx = sections.findIndex(s => s.code === 'P')
+        if(idx > -1) {
+          sections.splice(idx, 1);
+        }
+        // add sections to aquifers store
         this.addSections(sections)
       })
     },

--- a/app/frontend/src/aquifers/components/View.vue
+++ b/app/frontend/src/aquifers/components/View.vue
@@ -433,7 +433,6 @@ export default {
         { code: 'A', name: 'Artesian advisory' },
         { key: 'obs-wells', name: 'Oberservation Wells' },
         { code: 'N', name: 'Numerical model' },
-        { code: 'P', name: 'Pumping stress index' },
         { code: 'W', name: 'Water budget' },
         { key: 'water-quality', name: 'Water quality information' },
         { key: 'aquifer-connected', name: 'Hydraulically connected (screening level)' },

--- a/app/frontend/tests/unit/specs/aquifers/components/__snapshots__/View.spec.js.snap
+++ b/app/frontend/tests/unit/specs/aquifers/components/__snapshots__/View.spec.js.snap
@@ -1073,26 +1073,6 @@ exports[`View Component View mode matches the snapshot 1`] = `
                     <dt
                       class="text-right"
                     >
-                      Pumping stress index
-                    </dt>
-                     
-                    <dd
-                      class="m-0"
-                    >
-                       
-                      <p
-                        class="m-0"
-                      >
-                        No information available.
-                      </p>
-                    </dd>
-                  </div>
-                </li>
-                <li>
-                  <div>
-                    <dt
-                      class="text-right"
-                    >
                       Water budget
                     </dt>
                      


### PR DESCRIPTION
Phase 2 - Task 1
Removed 'Pumping Stress Index' as an option from aquifer search and aquifer summary. I did not remove the aquifer_resource_section_code with matching ‘P’ code because there are aquifer resource reports that use this code as a reference value. Instead we simply remove the option from the frontend options array.