### PR TITLE
Point GWELLS at Keycloak Gold

### DIFF
--- a/app/backend/.envrc
+++ b/app/backend/.envrc
@@ -47,7 +47,7 @@ export S3_REGISTRANT_BUCKET=gwells-registries
 export S3_PRIVATE_REGISTRANT_BUCKET=gwells-private-registries
 export S3_ROOT_BUCKET=gwells-docs
 export S3_USE_SECURE=1
-export SSO_IDP_HINT=idir
+export SSO_IDP_HINT=undefined
 export ENABLE_AQUIFERS_SEARCH=True
 export CUSTOM_GDAL_GEOS=False
 

--- a/app/backend/gwells/authentication.py
+++ b/app/backend/gwells/authentication.py
@@ -156,8 +156,8 @@ class JwtOidcAuthentication(JSONWebTokenAuthentication):
         preferred_username = payload.get('preferred_username')
 
         if payload.get('iss').endswith(KEYCLOAK_GOLD_REALM_URL):
-            identity_provider = payload.get('identity_provider')
-            return '@idir' in identity_provider or '@bceid' in identity_provider\
+            identity_provider = payload.get('identity_provider').lower()
+            return identity_provider == 'idir' or identity_provider == 'bceidboth' \
                 or preferred_username == 'testuser'
         else:
             return 'idir\\' in preferred_username or 'bceid\\' in preferred_username\

--- a/app/backend/gwells/authentication.py
+++ b/app/backend/gwells/authentication.py
@@ -35,8 +35,7 @@ class JwtOidcAuthentication(JSONWebTokenAuthentication):
             raise exceptions.AuthenticationFailed(
                 'JWT did not contain a "sub" attribute')
 
-        # Make sure the preferred username contains either idir\ or bceid\
-        # so we know that the user is coming from a known sso authority
+        # Make sure the user is coming from a known sso authority
         if not self.known_sso_authority(payload):
             raise exceptions.AuthenticationFailed(
                 'Preferred username is invalid.')
@@ -154,11 +153,14 @@ class JwtOidcAuthentication(JSONWebTokenAuthentication):
     @staticmethod
     def known_sso_authority(payload):
         preferred_username = payload.get('preferred_username')
-
+        
+        # Keycloak Gold has a dedicated IDP field that we can check...
         if payload.get('iss').endswith(KEYCLOAK_GOLD_REALM_URL):
             identity_provider = payload.get('identity_provider').lower()
             return identity_provider == 'idir' or identity_provider == 'bceidboth' \
                 or preferred_username == 'testuser'
+        # ...but Silver doesn't, so have to instead look at the preferred username, 
+        # which comes in the format "{idp}\{username}"
         else:
             return 'idir\\' in preferred_username or 'bceid\\' in preferred_username\
                 or preferred_username == 'testuser'

--- a/app/frontend/src/common/authenticate.js
+++ b/app/frontend/src/common/authenticate.js
@@ -122,6 +122,7 @@ export default {
             const refreshToken = localStorage.getItem('refreshToken')
             const idToken = localStorage.getItem('idToken')
             instance.init({
+              pkceMethod: 'S256',
               onLoad: 'check-sso',
               checkLoginIframe: true,
               timeSkew: 10, // Allow for some deviation

--- a/app/frontend/src/common/store/auth.js
+++ b/app/frontend/src/common/store/auth.js
@@ -20,33 +20,39 @@ const auth = {
         // e.g. We don't need to understand what a Statutory Authority is here, we should
         // only be concerned if the right to edit/approve is set. It's up to keycloak to associate some
         // group called Statutory Authority with the edit/approve roles.
-        return {
+
+        // NOTE: keycloak.js comes with hasResourceRole(role, resource) for checking if the user has a
+        // particular role, but it doesn't seem to look at the correct JWT so using it will return false
+        // even if the user does have that role.
+        // Instead, we have to look at the "raw" list of roles contained inside the keycloak instance.
+        const clientRoles = state.keycloak.idTokenParsed['client_roles']
+        return {          
           registry: {
-            view: state.keycloak.hasRealmRole('registries_viewer'),
-            edit: state.keycloak.hasRealmRole('registries_edit'),
-            approve: state.keycloak.hasRealmRole('registries_approve')
+            view: clientRoles.includes('registries_viewer'),
+            edit: clientRoles.includes('registries_edit'),
+            approve: clientRoles.includes('registries_approve')
           },
           wells: {
-            view: state.keycloak.hasRealmRole('wells_viewer'),
-            edit: state.keycloak.hasRealmRole('wells_edit'),
-            approve: state.keycloak.hasRealmRole('wells_approve')
+            view: clientRoles.includes('wells_viewer'),
+            edit: clientRoles.includes('wells_edit'),
+            approve: clientRoles.includes('wells_approve')
           },
           submissions: {
-            view: state.keycloak.hasRealmRole('wells_submission_viewer'),
-            edit: state.keycloak.hasRealmRole('wells_submission'),
-            approve: state.keycloak.hasRealmRole('wells_approve')
+            view: clientRoles.includes('wells_submission_viewer'),
+            edit: clientRoles.includes('wells_submission'),
+            approve: clientRoles.includes('wells_approve')
           },
           aquifers: {
-            edit: state.keycloak.hasRealmRole('aquifers_edit')
+            edit: clientRoles.includes('aquifers_edit')
           },
           surveys: {
-            edit: state.keycloak.hasRealmRole('surveys_edit')
+            edit: clientRoles.includes('surveys_edit')
           },
           bulk: {
-            wellAquiferCorrelation: state.keycloak.hasRealmRole('bulk_well_aquifer_correlation_upload'),
-            wellDocuments: state.keycloak.hasRealmRole('bulk_well_documents_upload'),
-            aquiferDocuments: state.keycloak.hasRealmRole('bulk_aquifer_documents_upload'),
-            verticalAquiferExtents: state.keycloak.hasRealmRole('bulk_vertical_aquifer_extents_upload')
+            wellAquiferCorrelation: clientRoles.includes('bulk_well_aquifer_correlation_upload'),
+            wellDocuments: clientRoles.includes('bulk_well_documents_upload'),
+            aquiferDocuments: clientRoles.includes('bulk_aquifer_documents_upload'),
+            verticalAquiferExtents: clientRoles.includes('bulk_vertical_aquifer_extents_upload')
           }
         }
       } else {

--- a/app/frontend/src/common/store/auth.js
+++ b/app/frontend/src/common/store/auth.js
@@ -16,7 +16,8 @@ const auth = {
     userRoles (state) {
       if (state.keycloak && state.keycloak.authenticated) {
         // map SSO roles to web app permissions
-        // IMPORTANT: One should be relying on SSO groups to assign the appropriate roles.
+        // IMPORTANT: One should be relying on SSO composite roles (which can be found alongside all of the 
+        // granular roles on Common Hosted SSO) to assign the appropriate roles.
         // e.g. We don't need to understand what a Statutory Authority is here, we should
         // only be concerned if the right to edit/approve is set. It's up to keycloak to associate some
         // group called Statutory Authority with the edit/approve roles.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,13 +123,13 @@ services:
       MINIO_SECRET_KEY: minio1234
       PYTHONUNBUFFERED: "1"
       SESSION_COOKIE_SECURE: "False"
-      SSO_AUDIENCE: gwells-test
-      SSO_CLIENT: gwells-test
-      SSO_AUTH_HOST: https://test.oidc.gov.bc.ca/auth
+      SSO_AUDIENCE: gwells-4121
+      SSO_CLIENT: gwells-4121
+      SSO_AUTH_HOST: https://test.loginproxy.gov.bc.ca/auth
       SSO_IDP_HINT: "undefined"
       SSO_PORT: 0
-      SSO_REALM: gwells
-      SSO_PUBKEY: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAh+5Hc4w/PKN04avW1LX/orSyXsJ7nJiEbErMyQqCvYAEKmQUeok7Yy+r6sVuJSyQQMCExk37NY3fUQOK92J83oC/9WGij7bvlWHew810edIisechoKpLuQbw63xlj/5ifQfJ977NM1n1RQgXF4hr4MDuhGbV+PAkQGdSPfufjEFleCwj8mvjUwTFnSwE9I+Rf78DVJzCHZbpFMq9skvrpCzeNsLNNoz+k1DENQ6MKnVnbUYskG+j5NZ3g+kxfkRf2G0tw2KisLYtxUSdfwutieT2Zxglk/kZeMWS7khXWzhwjvWf5a1qM5ebreVVYNhra7MjcrkXSh0v5IBcW+122wIDAQAB
+      SSO_REALM: standard
+      SSO_PUBKEY: MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiFdv9GA83uHuy8Eu9yiZHGGF9j6J8t7FkbcpaN81GDjwbjsIJ0OJO9dKRAx6BAtTC4ubJTBJMPvQER5ikOhIeBi4o25fg61jpgsU6oRZHkCXc9gX6mrjMjbsPaf3/bjjYxP5jicBDJQeD1oRa24+tiGggoQ7k6gDEN+cRYqqNpzC/GQbkUPk8YsgroncEgu8ChMh/3ERsLV2zorchMANUq76max16mHrhtWIQxrb/STpSt4JuSlUzzBV/dcXjJe5gywZHe0jAutFhNqjHzHdgyaC4RAd3eYQo+Kl/JOgy2AZrnx+CiPmvOJKe9tAW4k4H087ng8aVE40v4HW/FEbnwIDAQAB
       S3_HOST: minio-public:9000
       S3_PRIVATE_HOST: minio-private:9001
       S3_PRIVATE_BUCKET: gwells


### PR DESCRIPTION
This points the GWELLS application at the Keycloak Gold common realm. Environment variables have been updated to the appropriate values for Gold.

Several fixes have also been made to the Gold-specific code added in previous PRs:
* [Backend] Checking the SSO authority failed due to incorrect string comparison
* [Frontend] Added parameter for PKCE, as Gold requires it (Silver doesn't)
* [Frontend] Look for client roles instead of realm roles