### PR TITLE
OpenShift v4.12 upgrade

### DIFF
--- a/openshift/ocp4/jobs/export-databc/export.cj.json
+++ b/openshift/ocp4/jobs/export-databc/export.cj.json
@@ -31,7 +31,7 @@
     ],
     "objects": [
         {
-            "apiVersion": "batch/v1beta1",
+            "apiVersion": "batch/v1",
             "kind": "CronJob",
             "metadata": {
                 "name": "${NAME}"

--- a/openshift/ocp4/jobs/import-licences/import-licences.cj.json
+++ b/openshift/ocp4/jobs/import-licences/import-licences.cj.json
@@ -31,7 +31,7 @@
     ],
     "objects": [
         {
-            "apiVersion": "batch/v1beta1",
+            "apiVersion": "batch/v1",
             "kind": "CronJob",
             "metadata": {
                 "name": "${NAME}"

--- a/openshift/ocp4/jobs/minio-backup/minio-backup.cj.yaml
+++ b/openshift/ocp4/jobs/minio-backup/minio-backup.cj.yaml
@@ -37,7 +37,7 @@ objects:
         requests:
           storage: ${PVC_SIZE}
       storageClassName: netapp-file-backup
-  - apiVersion: batch/v1beta1
+  - apiVersion: batch/v1
     kind: CronJob
     metadata:
       name: gwells-documents-${NAME_SUFFIX}-backup

--- a/openshift/ocp4/jobs/postgres-backup-nfs/postgres-backup.cj.yaml
+++ b/openshift/ocp4/jobs/postgres-backup-nfs/postgres-backup.cj.yaml
@@ -126,7 +126,7 @@ objects:
         template: "${JOB_NAME}-config-template"
       name: ${TARGET}-backup
       namespace: ${NAMESPACE}
-  - apiVersion: batch/v1beta1
+  - apiVersion: batch/v1
     kind: CronJob
     metadata:
       name: ${TARGET}-nfs-backup

--- a/openshift/ocp4/jobs/update-aquifer/update-aquifer.cj.json
+++ b/openshift/ocp4/jobs/update-aquifer/update-aquifer.cj.json
@@ -31,7 +31,7 @@
     ],
     "objects": [
         {
-            "apiVersion": "batch/v1beta1",
+            "apiVersion": "batch/v1",
             "kind": "CronJob",
             "metadata": {
                 "name": "${NAME}"


### PR DESCRIPTION
**Background:**

Platform Services recently upgraded the OpenShift Silver cluster to v4.12, which breaks the GWELLS pipeline because it uses a deprecated API that was removed in this version.

Specifically, the `batch/v1beta` API version of Cronjob was deprecated in Kubernetes v1.21 and removed in v4.25 (which OpenShift 4.12 uses).

There are no major changes aside from the change in version name - it seems to mostly be just a promotion from beta to general availability.

**Changes made:**

Replaced `batch/v1beta` with `batch/v1` to reflect this deprecation/removal. That's pretty much it.

**More info:**

* https://docs.openshift.com/container-platform/4.12/release_notes/ocp-4-12-release-notes.html#ocp-4-12-removed-features
* https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25