### PR TITLE
[GWELLS-2011/2013] HOTFIX** correct date_of_action to date_of_uploads

### DIFF
--- a/app/backend/gwells/documents.py
+++ b/app/backend/gwells/documents.py
@@ -125,7 +125,7 @@ class MinioClient():
                     # split on last occurrence of '/' and return last item (supports any or no prefixes)
                     'name': unquote_plus(document.object_name).rsplit('/', 1)[-1],
                     "well_number": self.extract_well_number(document.object_name),
-                    "date_of_upload": self.extract_date_of_action(document.object_name),
+                    "date_of_upload": self.extract_date_of_upload(document.object_name),
                     "document_type": self.extract_well_label(document.object_name),
                     "document_status": private
                 }, objects)
@@ -138,7 +138,7 @@ class MinioClient():
         except IndexError:
             return "Unknown"
 
-    def extract_date_of_action(self, object_name):
+    def extract_date_of_upload(self, object_name):
         try:
             return int(unquote_plus(object_name).rsplit('/', 1)[-1].split("_")[2].split(".")[0].strip())
         except IndexError:

--- a/app/frontend/src/wells/components/Documents.vue
+++ b/app/frontend/src/wells/components/Documents.vue
@@ -35,7 +35,7 @@
               {{ callLongFormLabel(data.item.document_type) }}
             </template>
             <template v-slot:cell(date_of_upload)="data">
-              {{ data.item.date_of_action !== -1 ? new Date(data.item.date_of_upload).toLocaleDateString() : "Date Unknown" }}
+              {{ data.item.date_of_upload !== -1 ? new Date(data.item.date_of_upload).toLocaleDateString() : "Date Unknown" }}
             </template>
             <template v-slot:cell(uploaded_document)="data">
               <a :href="data.item.url" :download="data.item.name" target="_blank" @click="handleDownloadEvent(data.item.name)">{{ data.item.name }}</a>


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- one date_of_action was leftover causing 1969 date to display in place of "Date Unknown"
- renamed function to reflect being about date of uploads and not date of action
