### PR TITLE
[GWELLS-2048] BUG FIX** Display Licences in Well Summary

### DIFF
--- a/app/backend/wells/admin.py
+++ b/app/backend/wells/admin.py
@@ -20,7 +20,8 @@ from wells.models import (
     FilterPackMaterialSizeCode,
     FilterPackMaterialCode,
     Well,
-    WellAttachment
+    WellAttachment,
+    WellLicence
 )
 from gwells.models.lithology import (
     LithologyColourCode, LithologyHardnessCode,
@@ -41,3 +42,4 @@ admin.site.register(FilterPackMaterialSizeCode)
 admin.site.register(FilterPackMaterialCode)
 admin.site.register(Well)
 admin.site.register(WellAttachment)
+admin.site.register(WellLicence)

--- a/app/backend/wells/models.py
+++ b/app/backend/wells/models.py
@@ -2640,3 +2640,13 @@ class WellAttachment(models.Model):
         return_string += "{} File count: {}".format('Consultants Report',self.consultants_report)
         
         return return_string
+
+class WellLicence(models.Model):
+    id = models.IntegerField(primary_key=True)
+    well_id = models.IntegerField()
+    waterrightslicence_id = models.IntegerField()
+    class Meta:
+        db_table = "well_licences"
+        managed = False
+    def __str__(self):
+        return "Well Number: " + str(self.well_id) + ", License #: " + str(self.waterrightslicence_id)

--- a/app/backend/wells/views.py
+++ b/app/backend/wells/views.py
@@ -805,7 +805,7 @@ def well_licensing(request, **kwargs):
                     'date': ''
                 }
             return JsonResponse(data)
-    except Exception as e:
+    except Exception:
         return HttpResponse(status=500)
     return HttpResponse(status=400)
 

--- a/app/frontend/src/wells/views/WellDetail.vue
+++ b/app/frontend/src/wells/views/WellDetail.vue
@@ -135,9 +135,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
           <legend>Licensing Information</legend>
           <b-row>
             <b-col cols="12" md="4"><span class="font-weight-bold">Licensed Status:</span> {{ wellLicence.status }}</b-col>
-            <b-col cols="12" md="4"><span class="font-weight-bold">Licence Number:</span>&nbsp;
-              <a :href="`https://j200.gov.bc.ca/pub/ams/Default.aspx?PossePresentation=AMSPublic&amp;PosseObjectDef=o_ATIS_DocumentSearch&amp;PosseMenuName=WS_Main&Criteria_LicenceNumber=${wellLicence.number}`" target="_blank">
-                {{ wellLicence.number }}
+            <b-col cols="12" md="4"><span class="font-weight-bold">Licence Number{{ wellLicence.number.length > 1 ? "s" : "" }}:</span>&nbsp;
+              <a v-for="(licence, index) in wellLicence.number" :href="`https://j200.gov.bc.ca/pub/ams/Default.aspx?PossePresentation=AMSPublic&amp;PosseObjectDef=o_ATIS_DocumentSearch&amp;PosseMenuName=WS_Main&Criteria_LicenceNumber=${licence}`" target="_blank">
+                {{ licence}}{{ index + 1 < wellLicence.number.length ? ", " : ""}}
               </a>
             </b-col>
             <b-col cols="12" md="4"></b-col>

--- a/app/frontend/tests/unit/specs/wells/__snapshots__/WellDetail.spec.js.snap
+++ b/app/frontend/tests/unit/specs/wells/__snapshots__/WellDetail.spec.js.snap
@@ -505,14 +505,6 @@ exports[`WellDetail.vue should match snapshot 1`] = `
             </span>
              
             
-            <a
-              href="https://j200.gov.bc.ca/pub/ams/Default.aspx?PossePresentation=AMSPublic&PosseObjectDef=o_ATIS_DocumentSearch&PosseMenuName=WS_Main&Criteria_LicenceNumber="
-              target="_blank"
-            >
-              
-              
-            
-            </a>
           </b-col-stub>
            
           <b-col-stub


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change

# Description

This PR includes the following proposed change(s):

- refactored code to get licence numbers for a given well. Old code was externally sourced and no longer working
- created WellLicence model since none existed to link to table.
- made well summary licence numbers scalable to multiple licences (from singular)
