### PR TITLE
[FEATURE][GWELLS-#2053] changed hex colour values for hydraulic wells to be more visible

### DIFF
--- a/app/frontend/src/common/assets/images/wells-hydraulic.svg
+++ b/app/frontend/src/common/assets/images/wells-hydraulic.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-  <circle cx="10" cy="10" r="3" fill="#006FFF" stroke="#e29200" stroke-width="1.6" />
+  <circle cx="10" cy="10" r="3" fill="#006FFF" stroke="#5dfa57" stroke-width="1.6" />
 </svg>

--- a/app/frontend/src/common/mapbox/layers.js
+++ b/app/frontend/src/common/mapbox/layers.js
@@ -283,7 +283,7 @@ export function wellsBaseAndArtesianLayer (options = {}) {
     'circle-radius': 3,
     'circle-stroke-color': [
       'case',
-      ['boolean', ['get', 'has_hydraulic_info']], '#e29200',
+      ['boolean', ['get', 'has_hydraulic_info']], '#5dfa57',
       ['to-boolean', ['get', 'artesian']], '#EE14CA',
       'transparent'
     ],
@@ -307,9 +307,9 @@ export function searchedWellsLayer (options = {}) {
     'circle-radius': 5,
     'circle-stroke-color': [
       'case',
-      ['to-boolean', ['get', 'storativity']], '#e29200',
-      ['to-boolean', ['get', 'transmissivity']], '#e29200',
-      ['to-boolean', ['get', 'hydraulic_conductivity']], '#e29200',
+      ['to-boolean', ['get', 'storativity']], '#5dfa57',
+      ['to-boolean', ['get', 'transmissivity']], '#5dfa57',
+      ['to-boolean', ['get', 'hydraulic_conductivity']], '#5dfa57',
       ['to-boolean', ['get', 'artesian_conditions']], '#EE14CA',
       'black'
     ],


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- changed the hex value for the halo (stroke) of wells with hydraulic properties from #e29200 to #5dfa57. Values changed in:
 app\frontend\src\common\assets\images\wells-hydraulic.svg  
 app\frontend\src\common\mapbox\layers.js
