### PR TITLE
[FEATURE][GWELLS-2053] Increased map well halo width to be more visible

### DIFF
--- a/app/frontend/src/common/mapbox/layers.js
+++ b/app/frontend/src/common/mapbox/layers.js
@@ -287,7 +287,7 @@ export function wellsBaseAndArtesianLayer (options = {}) {
       ['to-boolean', ['get', 'artesian']], '#EE14CA',
       'transparent'
     ],
-    'circle-stroke-width': 1
+    'circle-stroke-width': 2.5
   })
 
   const filter = options.filter || wellLayerFilter(false)
@@ -313,7 +313,7 @@ export function searchedWellsLayer (options = {}) {
       ['to-boolean', ['get', 'artesian_conditions']], '#EE14CA',
       'black'
     ],
-    'circle-stroke-width': 2
+    'circle-stroke-width': 2.5
   })
 
   return layerConfig(layerId, options.source || SEARCHED_WELLS_SOURCE_ID, options.layerType || 'circle', styles, options.layout)


### PR DESCRIPTION
increased circle-stroke-width to make the halo indicating 'aquifer parameters' more noticeable

## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

In app\frontend\src\common\mapbox\layers.js, changed wellsBaseAndArtesianLayer and searchedWellsLayer to set circle-stroke-width to 2.5 (from 1).

This change makes the map halo around wells that are marked "aquifer parameters" (and "artesian") thicker so that they are more visible.

