### PR TITLE
[CHANGE][GWELLS-2090] created a command to update/create the description of drilling_method_codes

### DIFF
--- a/app/backend/gwells/fixtures/wellsearch-codetables.json
+++ b/app/backend/gwells/fixtures/wellsearch-codetables.json
@@ -1225,7 +1225,7 @@
             "create_date": "2017-07-01T08:00:00Z",
             "update_user": "ETL_USER",
             "update_date": "2017-07-01T08:00:00Z",
-            "description": "Dugout",
+            "description": "Dug",
             "display_order": 50,
             "effective_date": "2018-05-25T07:00:00Z",
             "expiry_date": "9999-12-31T23:59:59Z"

--- a/app/backend/wells/management/commands/update_drilling_method_codes.py
+++ b/app/backend/wells/management/commands/update_drilling_method_codes.py
@@ -1,0 +1,18 @@
+from django.core.management.base import BaseCommand
+from wells.models import DrillingMethodCode
+from collections import defaultdict
+import json
+
+class Command(BaseCommand):
+  help = "Update a value in the drilling_methods_code table"
+  def update_drilling_method_codes(self):
+    drilling_method_codes = open("gwells/fixtures/wellsearch-codetables.json")
+    drilling_method_codes = json.load(drilling_method_codes)
+
+    for item in drilling_method_codes:
+        if item["model"] == "wells.drillingmethodcode":          
+            DrillingMethodCode.objects.update_or_create(pk=item["pk"], defaults=item["fields"])
+            
+  def handle(self, *args, **options):
+    self.update_drilling_method_codes()
+    print("update_drilling_method_codes.py completed successfully")


### PR DESCRIPTION
As 'Dugout' was reported to be inaccurate, changed the description of that drilling method to 'Dug'.

## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Created a command **wells\management\commands\update_drilling_method_codes.py** that updates/creates drilling_method_codes that are read from **\gwells\fixtures\wellsearch-codetables.json**. 

- Manually updated the 'description' field in wellsearch-codetables.json (fixed seed data) from 'Dugout' to 'Dug' and ran the command to update the models.

- As all UI elements that display drilling methods use the description for the displayed value, no further changes should be necessary. 

![image](https://github.com/bcgov/gwells/assets/113044739/bca5e0b3-e6af-42d2-a978-640cfa8fd399)


