### PR TITLE
[CHANGE][GWELLS-2087] audit well data search field sortable keys

### DIFF
--- a/app/frontend/src/wells/components/SearchResults.vue
+++ b/app/frontend/src/wells/components/SearchResults.vue
@@ -31,7 +31,7 @@
             <th
               v-for="column in columns"
               :key="column.id"
-              class="text-nowrap"
+              class="text-nowrap vertical-align-middle"
               scope="col">
               {{ column.resultLabel ? column.resultLabel : column.label }}
               <b-button v-if="column.sortable"
@@ -356,6 +356,10 @@ export default {
 
   .sort-button.active {
     opacity: 1;
+  }
+
+  .vertical-align-middle {
+    vertical-align: middle;
   }
 }
 

--- a/app/frontend/src/wells/components/mixins/filters.js
+++ b/app/frontend/src/wells/components/mixins/filters.js
@@ -95,7 +95,7 @@ const SEARCH_FIELDS = {
     type: 'select',
     textField: 'description',
     valueField: 'licenced_status_code',
-    sortable: true,
+    sortable: false,
   },
   personResponsible: {
     param: 'person_responsible_name',
@@ -137,7 +137,7 @@ const SEARCH_FIELDS = {
     param: 'well_depth',
     label: 'Well depth',
     type: 'range',
-    sortable: true,
+    sortable: false,
   },
   aquiferNr: {
     param: 'aquifer',
@@ -209,13 +209,13 @@ const SEARCH_FIELDS = {
     param: 'consultant_name',
     label: 'Consultant name',
     type: 'text',
-    sortable: true,
+    sortable: false,
   },
   consultantCompany: {
     param: 'consultant_company',
     label: 'Consultant company',
     type: 'text',
-    sortable: true,
+    sortable: false,
   },
   ownerMailingAddress: {
     authenticated: true,
@@ -327,7 +327,7 @@ const SEARCH_FIELDS = {
     param: 'backfill_above_surface_seal',
     label: 'Backfill material above surface seal',
     type: 'text',
-    sortable: true,
+    sortable: false,
   },
   backfillDepth: {
     param: 'backfill_depth',
@@ -660,7 +660,7 @@ const SEARCH_FIELDS = {
     param: 'comments',
     label: 'Comments',
     type: 'text',
-    sortable: true,
+    sortable: false,
   },
   alternativeSpecsSubmitted: {
     param: 'alternative_specs_submitted',
@@ -743,7 +743,7 @@ const SEARCH_FIELDS = {
     param: 'specific_capacity',
     label: 'Specific Capacity',
     type: 'range',
-    sortable: true,
+    sortable: false,
   },
   pumpingTestDescription: {
     param: 'pumping_test_description',
@@ -751,7 +751,7 @@ const SEARCH_FIELDS = {
     type: 'select',
     textField: 'description',
     valueField: 'pumping_test_description_code',
-    sortable: true,
+    sortable: false,
   },
   createUser: {
     authenticated: true,
@@ -823,7 +823,7 @@ const SEARCH_FIELDS = {
     param: 'legal_pid',
     label: 'PID',
     type: 'text',
-    sortable: true,
+    sortable: false,
   },
   diameter: {
     param: 'diameter',
@@ -859,13 +859,13 @@ const SEARCH_FIELDS = {
     param: 'decomission_start_date',
     label: 'Decomission start date',
     type: 'dateRange',
-    sortable: true,
+    sortable: false,
   },
   decomissionEndDate: {
     param: 'decomission_end_date',
     label: 'Decomission end date',
     type: 'dateRange',
-    sortable: true,
+    sortable: false,
   },
   wellDisinfectedStatus: {
     param: 'well_disinfected_status',


### PR DESCRIPTION
…tly not sortable.

## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Updated sortable keys for the Well data search fields on the front end to reflect whether they are currently sortable.
![Screen Shot 2024-01-04 at 8 45 35 AM](https://github.com/bcgov/gwells/assets/20193291/6f69283a-4d54-4592-a566-ee84c4fdfe31)

- Adjusted vertical alignment to account for sortable fields without the sort icons. See screenshots below.
![Screen Shot 2024-01-04 at 8 35 15 AM](https://github.com/bcgov/gwells/assets/20193291/cd1d4091-7226-4a95-8cb3-4e770f944444)
![Screen Shot 2024-01-04 at 8 34 13 AM](https://github.com/bcgov/gwells/assets/20193291/b47584ec-ac6e-42a8-8bdb-6757edc53e88)


