### PR TITLE
[FEATURE[GWELLS-2054] Dynamically Adjust Legend for Aquifer summary map based on elements rendered in view

### DIFF
--- a/app/frontend/src/aquifers/components/SingleAquiferMap.vue
+++ b/app/frontend/src/aquifers/components/SingleAquiferMap.vue
@@ -408,6 +408,10 @@ if (layer) {
 
   console.log("visibility>>>>>>>" + visibility);
 
+//   this.map.on('data', () => {
+// console.log(data + 'A data event occurred.');
+// });
+
   //console.log(layerId + " visible");
   if (visibility === 'visible')
   {
@@ -423,13 +427,25 @@ if (layer) {
 }
     },
     listenForMapMovement () {
+//       this.map.on('data', () => {
+// console.log(data + 'A data event occurred.');
+// });
       //console.log("movement-----called>>>>>");
       const startEvents = ['zoomstart', 'movestart']
       startEvents.forEach(eventName => {
         this.map.on(eventName, (e) => {
-          console.log("movezoom start-----called>>>>>");
-          this.isLayerVisible(DATABC_CADASTREL_LAYER_ID);
+          // console.log("movezoom start-----called>>>>>");
+         // this.isLayerVisible(DATABC_CADASTREL_LAYER_ID);
           //this.isLayerVisible(DATABC_ECOCAT_LAYER_ID);
+          const visibleFeatures = this.map.queryRenderedFeatures({ layers: [ DATABC_GROUND_WATER_LICENCES_LAYER_ID ] });
+          if (visibleFeatures.length != 0) {
+           // console.log("features visible>>>>>>" + JSON.stringify(visibleFeatures));
+            console.log("features visible>>>>>>");
+          }else{
+            console.log("features invisible>>>>>>");
+            //console.log("features invisible>>>>>>"  + JSON.stringify(visibleFeatures));
+          }
+          
           // if (this.searchMapButtonEnabled) {
           //   this.showMapSearchButton()
           // }
@@ -438,7 +454,16 @@ if (layer) {
       const endEvents = ['zoomend', 'moveend']
       endEvents.forEach(eventName => {
         this.map.on(eventName, (e) => {
-          console.log("movezoomend-----called>>>>>");
+          const visibleFeatures = this.map.queryRenderedFeatures({ layers: [ DATABC_GROUND_WATER_LICENCES_LAYER_ID ] });
+          if (visibleFeatures.length != 0) {
+           // console.log("features visible>>>>>>" + JSON.stringify(visibleFeatures));
+            console.log("features visible>>>>>>");
+          }else{
+            console.log("features invisible>>>>>>");
+            //console.log("features invisible>>>>>>"  + JSON.stringify(visibleFeatures));
+          }
+          
+          // console.log("movezoomend-----called>>>>>");
           // const visibleFeatures = this.map.queryRenderedFeatures({ layers: [ AQUIFERS_FILL_LAYER_ID ] })
           // const bounds = this.map.getBounds()
           // const aquiferIds = visibleFeatures.map((l) => l.properties.aquifer_id)

--- a/app/frontend/src/aquifers/components/SingleAquiferMap.vue
+++ b/app/frontend/src/aquifers/components/SingleAquiferMap.vue
@@ -338,10 +338,10 @@ export default {
     },
 
     async layersChanged(layerId, show) {
-      try {
-        // Turn the layer's visibility on / off
-        this.map.setLayoutProperty(layerId, 'visibility', show ? 'visible' : 'none');
 
+      // Turn the layer's visibility on / off
+      this.map.setLayoutProperty(layerId, 'visibility', show ? 'visible' : 'none');
+      try {
         // Wait for the layer change to be rendered
         await this.waitForLayerChangeRender(layerId, show);
 
@@ -354,7 +354,7 @@ export default {
       }
     },
 
-    async waitForLayerChangeRender(layerId, show) {
+    async waitForLayerChangeRender(layerId, show) {//waits for layer with layerId to appear or be removed based on value of show
       const maxAttempts = 10; // Adjust the number of attempts as needed
       let attempts = 0;
       let hasChangeBeenRendered = false;
@@ -369,15 +369,10 @@ export default {
         }
 
         if (!hasChangeBeenRendered) {
-          // Add a delay before checking again (e.g., 100ms)
+          // Add a delay before checking again
           await new Promise(resolve => setTimeout(resolve, 100));
           attempts++;
         }
-      }
-
-      if (!hasChangeBeenRendered) {
-        console.warn('Timeout waiting for layer change to be rendered.');
-        // Handle the timeout scenario (e.g., log, throw, etc.)
       }
     },
 
@@ -459,7 +454,7 @@ export default {
       }
       this.legendControl.update();
     },
-    getRenderedLayerIds(){
+    getRenderedLayerIds(){ //returns a set of all layer ids which are currently being rendered
       const visibleFeatures = (this.map.queryRenderedFeatures());
       const uniqueRenderedLayerIds = new Set();
       visibleFeatures.forEach(item => {

--- a/app/frontend/src/aquifers/components/SingleAquiferMap.vue
+++ b/app/frontend/src/aquifers/components/SingleAquiferMap.vue
@@ -336,14 +336,39 @@ export default {
       filter.splice(1, 0, ['==', ['get', 'aquifer_id'], this.aquiferId], false)
       return filter
     },
+    updateMapLegendBasedOnVisibleElements() {
+      //gets a list of rendered objects and then updates the legend to only display entries for items that are currently rendered
+      const visibleFeatures = this.map.queryRenderedFeatures();
+      const uniqueRenderedLayerIds = new Set();
+      visibleFeatures.forEach(item => {
+        if (item.layer.id){
+          uniqueRenderedLayerIds.add(item.layer.id);
+        }
+      });
+
+      //cadastrals are a raster layer rather than a vector layer like the others, so seperate logic is required.         
+      this.mapLayers.forEach(layerObj =>{
+        if(uniqueRenderedLayerIds.has(layerObj.id) && layerObj.id != DATABC_CADASTREL_LAYER_ID){
+          this.mapLayers.find((layer) => layer.id === layerObj.id).show = true;
+        } else if(!uniqueRenderedLayerIds.has(layerObj.id) && layerObj.id != DATABC_CADASTREL_LAYER_ID){
+          this.mapLayers.find((layer) => layer.id === layerObj.id).show = false;
+        }
+      });
+
+      //For simplicity, the cadastral check is only based on the maps zoom level and not on any cadastrals being rendered.
+      //Check if cadastral checkbox is checked
+      if(this.map.getZoom() > CADASTRAL_LAYER_MIN_ZOOM && this.map.getLayoutProperty(DATABC_CADASTREL_LAYER_ID, 'visibility') != "none"){
+        this.mapLayers.find((layer) => layer.id === DATABC_CADASTREL_LAYER_ID).show = true;
+      } else {
+        this.mapLayers.find((layer) => layer.id === DATABC_CADASTREL_LAYER_ID).show = false;
+      }
+      this.legendControl.update();//finally, update the legend
+    },
     layersChanged (layerId, show) {
-      // Find the layer and mark it as shown so the legend can be updated properly
-      this.mapLayers.find((layer) => layer.id === layerId).show = show
-
-      this.legendControl.update()
-
       // Turn the layer's visibility on / off
       this.map.setLayoutProperty(layerId, 'visibility', show ? 'visible' : 'none')
+      //find visible elements and update the legend
+      this.updateMapLegendBasedOnVisibleElements();
     },
     zoomToAquifer (fitBoundsOptions) {
       if (!this.geom) { return }
@@ -400,34 +425,6 @@ export default {
         canInteract,
         ecocatLayerIds: [ DATABC_ECOCAT_LAYER_ID ]
       })
-    },
-    updateMapLegendBasedOnVisibleElements() {
-      //gets a list of rendered objects and then updates the legend to only display entries for items that are currently rendered
-      const visibleFeatures = this.map.queryRenderedFeatures();
-      const uniqueRenderedLayerIds = new Set();
-      visibleFeatures.forEach(item => {
-        if (item.layer.id){
-          uniqueRenderedLayerIds.add(item.layer.id);
-        }
-      });
-
-      //as cadastrals are a raster layer rather than a vector layer like the others, so seperate logic is required.         
-      this.mapLayers.forEach(layerObj =>{
-        if(uniqueRenderedLayerIds.has(layerObj.id) && layerObj.id != DATABC_CADASTREL_LAYER_ID){
-          this.mapLayers.find((layer) => layer.id === layerObj.id).show = true;
-        } else if(!uniqueRenderedLayerIds.has(layerObj.id) && layerObj.id != DATABC_CADASTREL_LAYER_ID){
-          this.mapLayers.find((layer) => layer.id === layerObj.id).show = false;
-        }
-      });
-
-      //For simplicity, the cadastral check is only based on the maps zoom level and not on any cadastrals being rendered.
-      //Check if cadastral checkbox is checked
-      if(this.map.getZoom() > CADASTRAL_LAYER_MIN_ZOOM && this.map.getLayoutProperty(DATABC_CADASTREL_LAYER_ID, 'visibility') != "none"){
-        this.mapLayers.find((layer) => layer.id === DATABC_CADASTREL_LAYER_ID).show = true;
-      } else {
-        this.mapLayers.find((layer) => layer.id === DATABC_CADASTREL_LAYER_ID).show = false;
-      }
-      this.legendControl.update();
     },
     listenForMapMovement () {
       const startEvents = ['zoomstart', 'movestart']

--- a/app/frontend/src/aquifers/components/SingleAquiferMap.vue
+++ b/app/frontend/src/aquifers/components/SingleAquiferMap.vue
@@ -421,7 +421,8 @@ export default {
       });
 
       //For simplicity, the cadastral check is only based on the maps zoom level and not on any cadastrals being rendered.
-      if(this.map.getZoom() > CADASTRAL_LAYER_MIN_ZOOM){
+      //Check if cadastral checkbox is checked
+      if(this.map.getZoom() > CADASTRAL_LAYER_MIN_ZOOM && this.map.getLayoutProperty(DATABC_CADASTREL_LAYER_ID, 'visibility') != "none"){
         this.mapLayers.find((layer) => layer.id === DATABC_CADASTREL_LAYER_ID).show = true;
       } else {
         this.mapLayers.find((layer) => layer.id === DATABC_CADASTREL_LAYER_ID).show = false;

--- a/app/frontend/src/aquifers/components/SingleAquiferMap.vue
+++ b/app/frontend/src/aquifers/components/SingleAquiferMap.vue
@@ -292,6 +292,7 @@ export default {
 
         this.$emit('mapLoaded')
       })
+      this.listenForMapMovement();
     },
     buildMapStyle () {
       return {
@@ -398,8 +399,55 @@ export default {
         canInteract,
         ecocatLayerIds: [ DATABC_ECOCAT_LAYER_ID ]
       })
+    //}
+    },
+    isLayerVisible(layerId) {
+    const layer = this.map.getLayer(layerId);
+if (layer) {
+  const visibility = this.map.getLayoutProperty(layerId, 'visibility');
+
+  console.log("visibility>>>>>>>" + visibility);
+
+  //console.log(layerId + " visible");
+  if (visibility === 'visible')
+  {
+    console.log(layerId + " visible");
+  }
+  else
+  {
+    console.log(layerId + " invisible");
+  }
+} else {
+  console.log(layerId + " invisible");
+  return false;
+}
+    },
+    listenForMapMovement () {
+      //console.log("movement-----called>>>>>");
+      const startEvents = ['zoomstart', 'movestart']
+      startEvents.forEach(eventName => {
+        this.map.on(eventName, (e) => {
+          console.log("movezoom start-----called>>>>>");
+          this.isLayerVisible(DATABC_CADASTREL_LAYER_ID);
+          //this.isLayerVisible(DATABC_ECOCAT_LAYER_ID);
+          // if (this.searchMapButtonEnabled) {
+          //   this.showMapSearchButton()
+          // }
+        })
+      })
+      const endEvents = ['zoomend', 'moveend']
+      endEvents.forEach(eventName => {
+        this.map.on(eventName, (e) => {
+          console.log("movezoomend-----called>>>>>");
+          // const visibleFeatures = this.map.queryRenderedFeatures({ layers: [ AQUIFERS_FILL_LAYER_ID ] })
+          // const bounds = this.map.getBounds()
+          // const aquiferIds = visibleFeatures.map((l) => l.properties.aquifer_id)
+          // this.$emit('moved', bounds, uniq(aquiferIds))
+        })
+      })
     }
   },
+  
   watch: {
     aquiferId (newAquiferId, oldAquiferId) {
       this.setSelectedAquifer(oldAquiferId, false)


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description
For the map legend on the Aquifer Summary page, made it so legend items appear only if a corresponding element is being rendered in the map view. If an element is not being rendered in the view, whether because the zoom level is too low or there are simply no entries present in the search area, the legend will not show an entry for that element.

This PR includes the following proposed change(s):

Updated SingleAquiferMap.vue to do the following:

  On the Aquifer Summary page:
- when a map element filter is checked, only update the legend if any of that element is currently being rendered in the map view.
- when the map is moved or zoomed, update the legend to only show elements that are currently being rendered in the map view.

This change affects ***all*** toggle-able map elements, including elements that are viewable at any zoom level.

** **Note** ** - because the cadastral layer is different then the others (raster vs vector), a different method was required to deal with it. Due to the fact that nearly all map areas contain cadastral data, it was decided that simply checking for the zoom level that cadastrals are rendered at would be sufficient.
