### PR TITLE
[BUG FIX][GWELLS-2104] Refactor get licence number method

### DIFF
--- a/app/backend/wells/serializers_v2.py
+++ b/app/backend/wells/serializers_v2.py
@@ -19,7 +19,7 @@ from django.contrib.gis.geos import Point
 
 from gwells.utils import isPointInsideBC
 from wells.models import Well, DevelopmentMethodCode
-from aquifers.models import VerticalAquiferExtent, Aquifer, WaterRightsLicence
+from aquifers.models import VerticalAquiferExtent, Aquifer
 
 from aquifers.serializers_v2 import AquiferDetailSerializerV2
 from wells.serializers import (


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- I currently cannot reproduce the issue [locally](http://localhost:8080/gwells/?match_any=true&licenced_status=LICENSED&result_columns=wellTagNumber,identificationPlateNumber,ownerName,streetAddress,legalLot,legalPlan,legalDistrictLot,landDistrict,legalPid,diameter,finishedWellDepth,licenceNumber&limit=10&offset=0&ordering=-well_tag_number#advanced):
- I refactored the get licence number method to use the model layer rather than using raw SQL
![Screen Shot 2024-01-10 at 4 09 24 PM](https://github.com/bcgov/gwells/assets/20193291/98563b46-060b-4a90-81e3-315dd1206870)

