### PR TITLE
[FEATURE][GWELLS-2094] Address autofill/autocomplete added to Well Owner and Well Location forms

### DIFF
--- a/app/backend/.envrc
+++ b/app/backend/.envrc
@@ -50,7 +50,6 @@ export S3_USE_SECURE=1
 export SSO_IDP_HINT=undefined
 export ENABLE_AQUIFERS_SEARCH=True
 export CUSTOM_GDAL_GEOS=False
-export GEOCODER_ADDRESS_API_BASE=https://geocoder.api.gov.bc.ca/addresses.json?q=
 
 dotenv .secret_env
 

--- a/app/backend/.envrc
+++ b/app/backend/.envrc
@@ -50,6 +50,7 @@ export S3_USE_SECURE=1
 export SSO_IDP_HINT=undefined
 export ENABLE_AQUIFERS_SEARCH=True
 export CUSTOM_GDAL_GEOS=False
+export GEOCODER_ADDRESS_API_BASE=https://geocoder.api.gov.bc.ca/addresses.json?q=
 
 dotenv .secret_env
 

--- a/app/backend/wells/views.py
+++ b/app/backend/wells/views.py
@@ -895,8 +895,7 @@ class WellLithology(ListAPIView):
         return qs
 class AddressGeocoder(APIView):
     def get(self, request,**kwargs):
-        GEOCODER_ADDRESS_API_BASE = 'https://geocoder.api.gov.bc.ca/addresses.json?q='
-        GEOCODER_ADDRESS_URL = GEOCODER_ADDRESS_API_BASE + self.request.query_params.get('searchTag')
+        GEOCODER_ADDRESS_URL = get_env_variable('GEOCODER_ADDRESS_API_BASE') + self.request.query_params.get('searchTag')
         response = requests.get(GEOCODER_ADDRESS_URL)
         # Check if the request was successful (status code 200)
         if response.status_code == 200:

--- a/app/frontend/src/common/constants.js
+++ b/app/frontend/src/common/constants.js
@@ -59,3 +59,5 @@ export const TOOLTIP_TEXT = {
     analysis_method: 'Mathematical solutions (Theis, Cooper-Jacob, Neuman, etc.) where response data (discharge, drawdown/time) from pumping tests are used to estimate the hydraulic properties of aquifers.',
   },
 }
+
+export const GEOCODER_ADDRESS_API = 'https://geocoder.api.gov.bc.ca/addresses.json?q='

--- a/app/frontend/src/common/constants.js
+++ b/app/frontend/src/common/constants.js
@@ -59,5 +59,3 @@ export const TOOLTIP_TEXT = {
     analysis_method: 'Mathematical solutions (Theis, Cooper-Jacob, Neuman, etc.) where response data (discharge, drawdown/time) from pumping tests are used to estimate the hydraulic properties of aquifers.',
   },
 }
-
-export const GEOCODER_ADDRESS_API = 'https://geocoder.api.gov.bc.ca/addresses.json?q='

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -220,6 +220,8 @@ import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 
 import BackToTopLink from '@/common/components/BackToTopLink.vue'
 
+import { GEOCODER_ADDRESS_API } from '@/common/constants';
+
 export default {
   name: 'Location',
   mixins: [inputBindingsMixin],
@@ -322,7 +324,7 @@ export default {
       const querystring = require('querystring');
       const searchParams = querystring.stringify(params);
       try {
-        const response = await fetch(`https://geocoder.api.gov.bc.ca/addresses.json?q=${searchParams}`);
+        const response = await fetch(`${GEOCODER_ADDRESS_API}${searchParams}`);
         const data = await response.json();
         if (data && data.features) {    
           this.addressSuggestions = data.features.map(item => item.properties.fullAddress);

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -47,9 +47,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
           ></form-input>
            <!-- Display the address suggestions -->
         <div v-if="addressSuggestions.length > 0" class="address-suggestions list-group list-group-flush border" id="address-suggestions-list">
-          <li v-for="(suggestion, index) in addressSuggestions" :key="index">
+          <div v-for="(suggestion, index) in addressSuggestions" :key="index">
             <button @mousedown="selectAddressSuggestion(suggestion)" class="list-group-item list-group-item-action border-0">{{ suggestion }}</button>
-          </li>
+          </div>
         </div>
         <!-- Display a loading indicator while fetching suggestions -->
         <div v-if="isLoadingSuggestions" class="loading-indicator">

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -312,7 +312,8 @@ export default {
      * Finally, sets the loading state to false.
      */
     async fetchAddressSuggestions() {
-      if (!this.streetAddressInput) {
+      const MIN_QUERY_LENGTH = 3;
+      if (!this.streetAddressInput || this.streetAddressInput.length < MIN_QUERY_LENGTH) {
         this.addressSuggestions = [];
         return;
       }

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -305,7 +305,7 @@ export default {
   },
   methods: {
       /**
-     * Asynchronously fetches address suggestions based on the owner's address input.
+     * @desc Asynchronously fetches address suggestions based on the owner's address input.
      * If no input is provided, it clears the current suggestions.
      * On success, it maps the received data to full addresses and updates the addressSuggestions state.
      * On failure, it logs the error and clears the current suggestions.
@@ -345,7 +345,7 @@ export default {
     },
 
     /**
-     * Processes the selected address suggestion.
+     * @desc Processes the selected address suggestion.
      * Splits the suggestion into components and updates the owner's province, city, and address inputs accordingly.
      * Clears the address suggestions afterward.
      * @param {string} suggestion - The selected address suggestion. ("1234 Street Rd, Name of City, BC")
@@ -370,14 +370,14 @@ export default {
     },
 
     /**
-     * Clears the current list of address suggestions.
+     * @desc Clears the current list of address suggestions.
      */
     clearAddressSuggestions () {
       this.addressSuggestions = [];
     },
     
     /**
-     * Shows the address suggestions list in the UI.
+     * @desc Shows the address suggestions list in the UI.
      */
     showList() {
       if(document.getElementById('address-suggestions-list')){
@@ -386,7 +386,7 @@ export default {
     },
     
     /**
-     * Hides the address suggestions list in the UI.
+     * @desc Hides the address suggestions list in the UI.
      */
     hideList() {
       if(document.getElementById('address-suggestions-list')){

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -401,4 +401,9 @@ export default {
 .dropdown-error-border {
   border-radius: 5px;
 }
+.address-suggestions {
+    list-style-type: none;
+    position: absolute;
+    z-index: 10;
+  }
 </style>

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -304,13 +304,18 @@ export default {
     }
   },
   methods: {
+      /**
+     * Asynchronously fetches address suggestions based on the owner's address input.
+     * If no input is provided, it clears the current suggestions.
+     * On success, it maps the received data to full addresses and updates the addressSuggestions state.
+     * On failure, it logs the error and clears the current suggestions.
+     * Finally, sets the loading state to false.
+     */
     async fetchAddressSuggestions() {
-
       if (!this.streetAddressInput) {
         this.addressSuggestions = [];
         return;
       }
-
       this.isLoadingSuggestions = true;
       const params = {
         minScore: 50,
@@ -338,6 +343,13 @@ export default {
         this.isLoadingSuggestions = false;
       }
     },
+
+    /**
+     * Processes the selected address suggestion.
+     * Splits the suggestion into components and updates the owner's province, city, and address inputs accordingly.
+     * Clears the address suggestions afterward.
+     * @param {string} suggestion - The selected address suggestion. ("1234 Street Rd, Name of City, BC")
+     */
     selectAddressSuggestion(suggestion) {
       const wellAddressArray = suggestion.split(',');
 
@@ -356,14 +368,26 @@ export default {
         }
       }
     },
+
+    /**
+     * Clears the current list of address suggestions.
+     */
     clearAddressSuggestions () {
       this.addressSuggestions = [];
     },
+    
+    /**
+     * Shows the address suggestions list in the UI.
+     */
     showList() {
       if(document.getElementById('address-suggestions-list')){
         document.getElementById('address-suggestions-list').style.display = 'block';
       }     
     },
+    
+    /**
+     * Hides the address suggestions list in the UI.
+     */
     hideList() {
       if(document.getElementById('address-suggestions-list')){
         document.getElementById('address-suggestions-list').style.display = 'none';

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -357,7 +357,7 @@ export default {
       switch (wellAddressArray.length) {
         case 3: {
           this.streetAddressInput = wellAddressArray[0];
-          this.cityInput = wellAddressArray[1];
+          this.cityInput = wellAddressArray[1].trim();
           break;
         }
         case 2: {

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -304,69 +304,69 @@ export default {
   methods: {
     async fetchAddressSuggestions() {
 
-if (!this.streetAddressInput) {
-  this.addressSuggestions = [];
-  return;
-}
+      if (!this.streetAddressInput) {
+        this.addressSuggestions = [];
+        return;
+      }
 
-this.isLoadingSuggestions = true;
-const params = {
-  minScore: 50,
-  maxResults: 5,
-  echo: 'false',
-  brief: true,
-  autoComplete: true,
-  addressString: this.streetAddressInput
-};
+      this.isLoadingSuggestions = true;
+      const params = {
+        minScore: 50,
+        maxResults: 5,
+        echo: 'false',
+        brief: true,
+        autoComplete: true,
+        addressString: this.streetAddressInput
+      };
 
-const querystring = require('querystring');
-const searchParams = querystring.stringify(params);
-try {
-  const response = await fetch(`https://geocoder.api.gov.bc.ca/addresses.json?q=${searchParams}`);
-  console.log(encodeURIComponent(params));
-  console.log(searchParams);
-  const data = await response.json();
-  console.log(data);
-  if (data && data.features) {
-    
-    this.addressSuggestions = data.features.map(item => item.properties.fullAddress);
-  } else {
-    this.addressSuggestions = [];
-  }
-} catch (error) {
-  console.error(error);
-  this.addressSuggestions = [];
-} finally {
-  this.isLoadingSuggestions = false;
-}
-},
-selectAddressSuggestion(suggestion) {
-const wellAddressArray = suggestion.split(',');
+      const querystring = require('querystring');
+      const searchParams = querystring.stringify(params);
+      try {
+        const response = await fetch(`https://geocoder.api.gov.bc.ca/addresses.json?q=${searchParams}`);
+        const data = await response.json();
+        if (data && data.features) {    
+          this.addressSuggestions = data.features.map(item => item.properties.fullAddress);
+        } else {
+          this.addressSuggestions = [];
+        }
+      } catch (error) {
+        console.error(error);
+        this.addressSuggestions = [];
+      } finally {
+        this.isLoadingSuggestions = false;
+      }
+    },
+    selectAddressSuggestion(suggestion) {
+      const wellAddressArray = suggestion.split(',');
 
-let province = '';
+      let province = '';
 
-switch (wellAddressArray.length) {
-  case 3: {
-    this.streetAddressInput = wellAddressArray[0];
-    this.cityInput = wellAddressArray[1];
-    break;
-  }
-  case 2: {
-    this.cityInput = wellAddressArray[0];
-    this.streetAddressInput = '';
-    break;
-  }
-}
-},
-clearAddressSuggestions () {
-this.addressSuggestions = [];
-},
-showList() {
-      document.getElementById('address-suggestions-list').style.display = 'block';
-},
-hideList() {
-document.getElementById('address-suggestions-list').style.display = 'none';
-}
+      switch (wellAddressArray.length) {
+        case 3: {
+          this.streetAddressInput = wellAddressArray[0];
+          this.cityInput = wellAddressArray[1];
+          break;
+        }
+        case 2: {
+          this.cityInput = wellAddressArray[0];
+          this.streetAddressInput = '';
+          break;
+        }
+      }
+    },
+    clearAddressSuggestions () {
+      this.addressSuggestions = [];
+    },
+    showList() {
+      if(document.getElementById('address-suggestions-list')){
+        document.getElementById('address-suggestions-list').style.display = 'block';
+      }     
+    },
+    hideList() {
+      if(document.getElementById('address-suggestions-list')){
+        document.getElementById('address-suggestions-list').style.display = 'none';
+      }
+    }     
   }
 }
 </script>

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -39,8 +39,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
             type="text"
             label="Street address"
             @input="fetchAddressSuggestions"
-            v-on:focus="showList"
-            v-on:blur="hideList"
+            v-on:focus="showList(true)"
+            v-on:blur="showList(false)"
             :errors="errors['street_address']"
             :loaded="fieldsLoaded['street_address']"
             :disabled="sameAsOwnerAddress"
@@ -378,22 +378,14 @@ export default {
     },
     
     /**
-     * @desc Shows the address suggestions list in the UI.
+     * @desc Shows or hides the address suggestions list in the UI.
+     * @param {boolean} show - a boolean which indicates whether to show or hide the element
      */
-    showList() {
+     showList(show) {
       if(document.getElementById('address-suggestions-list')){
-        document.getElementById('address-suggestions-list').style.display = 'block';
-      }     
-    },
-    
-    /**
-     * @desc Hides the address suggestions list in the UI.
-     */
-    hideList() {
-      if(document.getElementById('address-suggestions-list')){
-        document.getElementById('address-suggestions-list').style.display = 'none';
+        document.getElementById('address-suggestions-list').style.display =  show? 'block' : 'none';
       }
-    }     
+    }        
   }
 }
 </script>

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -32,11 +32,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <b-col cols="12" md="6">
         <form-input id="ownerMailingAddress" label="Owner Mailing Address" v-model="ownerAddressInput" @input="fetchAddressSuggestions" v-on:focus="showList" v-on:blur="hideList" :errors="errors['owner_mailing_address']" :loaded="fieldsLoaded['owner_mailing_address']"></form-input>
         <!-- Display the address suggestions -->
-        <ul v-if="addressSuggestions.length > 0" class="address-suggestions list-group" id="address-suggestions-list">
+        <div v-if="addressSuggestions.length > 0" class="address-suggestions list-group list-group-flush border" id="address-suggestions-list">
           <li v-for="(suggestion, index) in addressSuggestions" :key="index">
-            <button @mousedown="selectAddressSuggestion(suggestion)" class="list-group-item list-group-item-action">{{ suggestion }}</button>
+            <button @mousedown="selectAddressSuggestion(suggestion)" class="list-group-item list-group-item-action border-0">{{ suggestion }}</button>
           </li>
-        </ul>
+        </div>
         <!-- Display a loading indicator while fetching suggestions -->
         <div v-if="isLoadingSuggestions" class="loading-indicator">
           Loading...
@@ -216,5 +216,7 @@ export default {
 </script>
 
 <style>
-
+  .address-suggestions {
+    list-style-type: none;
+  }
 </style>

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -180,7 +180,7 @@ export default {
       if (!this.ownerAddressInput || this.ownerAddressInput.length < MIN_QUERY_LENGTH) {
         this.addressSuggestions = [];
         return;
-      } else {
+      } 
         this.isLoadingSuggestions = true;
         const params = {
           minScore: 50, //accuracy score of results compared to input
@@ -203,14 +203,14 @@ export default {
             this.addressSuggestions = [];
           }
         }
-      })
+      }
+      )
         } catch (error) {
           console.error(error);
           this.addressSuggestions = [];
         } finally {
           this.isLoadingSuggestions = false;
         }
-      }   
     },
 
     /**

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -30,11 +30,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <form-input id="ownerFullName" label="Well Owner Name" v-model="ownerFullNameInput" :errors="errors['owner_full_name']" :loaded="fieldsLoaded['owner_full_name']"></form-input>
       </b-col>
       <b-col cols="12" md="6">
-        <form-input id="ownerMailingAddress" label="Owner Mailing Address" v-model="ownerAddressInput" @input="fetchAddressSuggestions" v-on:blur="clearAddressSuggestions" :errors="errors['owner_mailing_address']" :loaded="fieldsLoaded['owner_mailing_address']"></form-input>
+        <form-input id="ownerMailingAddress" label="Owner Mailing Address" v-model="ownerAddressInput" @input="fetchAddressSuggestions" v-on:focus="showList" v-on:blur="hideList" :errors="errors['owner_mailing_address']" :loaded="fieldsLoaded['owner_mailing_address']"></form-input>
         <!-- Display the address suggestions -->
-        <ul v-if="addressSuggestions.length > 0" class="address-suggestions">
+        <ul v-if="addressSuggestions.length > 0" class="address-suggestions list-group" id="address-suggestions-list">
           <li v-for="(suggestion, index) in addressSuggestions" :key="index">
-            <button @mousedown="selectAddressSuggestion(suggestion)">{{ suggestion }}</button>
+            <button @mousedown="selectAddressSuggestion(suggestion)" class="list-group-item list-group-item-action">{{ suggestion }}</button>
           </li>
         </ul>
         <!-- Display a loading indicator while fetching suggestions -->
@@ -200,9 +200,16 @@ export default {
       this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;
       else
       this.ownerProvinceInput = "";
+      this.clearAddressSuggestions();
     },
     clearAddressSuggestions () {
       this.addressSuggestions = [];
+    },
+    showList() {
+            document.getElementById('address-suggestions-list').style.display = 'block';
+    },
+    hideList() {
+      document.getElementById('address-suggestions-list').style.display = 'none';
     }
   }
 }

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -236,7 +236,7 @@ export default {
       else {
         this.ownerProvinceInput = "";
       }
-      this.ownerCityInput = ownerAddressArray[CITY_ARRAY_INDEX];
+      this.ownerCityInput = ownerAddressArray[CITY_ARRAY_INDEX].trim();
       if(ownerAddressArray[STREET_ARRAY_INDEX]) this.ownerAddressInput = ownerAddressArray[STREET_ARRAY_INDEX];
       }
       this.clearAddressSuggestions();

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -154,16 +154,21 @@ export default {
     ...mapGetters(['codes'])
   },
   methods: {
+    /**
+     * Asynchronously fetches address suggestions based on the owner's address input.
+     * If no input is provided, it clears the current suggestions.
+     * On success, it maps the received data to full addresses and updates the addressSuggestions state.
+     * On failure, it logs the error and clears the current suggestions.
+     * Finally, sets the loading state to false.
+     */
     async fetchAddressSuggestions() {
-
       if (!this.ownerAddressInput) {
         this.addressSuggestions = [];
         return;
       }
-
       this.isLoadingSuggestions = true;
       const params = {
-        minScore: 50,
+        minScore: 50, //accuracy score of results compared to input
 		    maxResults: 5,
         echo: 'false',
         brief: true,
@@ -189,6 +194,13 @@ export default {
         this.isLoadingSuggestions = false;
       }
     },
+
+    /**
+     * Processes the selected address suggestion.
+     * Splits the suggestion into components and updates the owner's province, city, and address inputs accordingly.
+     * Clears the address suggestions afterward.
+     * @param {string} suggestion - The selected address suggestion. ("1234 Street Rd, Name of City, BC")
+     */
     selectAddressSuggestion(suggestion) {
       const ownerAddressArray = suggestion.split(',');
       if(ownerAddressArray){
@@ -204,14 +216,26 @@ export default {
       
       this.clearAddressSuggestions();
     },
+
+    /**
+     * Clears the current list of address suggestions.
+     */
     clearAddressSuggestions () {
       this.addressSuggestions = [];
     },
+
+    /**
+     * Shows the address suggestions list in the UI.
+     */
     showList() {
       if(document.getElementById('address-suggestions-list')){
         document.getElementById('address-suggestions-list').style.display = 'block';
       }     
     },
+
+    /**
+     * Hides the address suggestions list in the UI.
+     */
     hideList() {
       if(document.getElementById('address-suggestions-list')){
         document.getElementById('address-suggestions-list').style.display = 'none';

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -155,7 +155,7 @@ export default {
   },
   methods: {
     /**
-     * Asynchronously fetches address suggestions based on the owner's address input.
+     * @desc Asynchronously fetches address suggestions based on the owner's address input.
      * If no input is provided, it clears the current suggestions.
      * On success, it maps the received data to full addresses and updates the addressSuggestions state.
      * On failure, it logs the error and clears the current suggestions.
@@ -196,7 +196,7 @@ export default {
     },
 
     /**
-     * Processes the selected address suggestion.
+     * @desc Processes the selected address suggestion.
      * Splits the suggestion into components and updates the owner's province, city, and address inputs accordingly.
      * Clears the address suggestions afterward.
      * @param {string} suggestion - The selected address suggestion. ("1234 Street Rd, Name of City, BC")
@@ -218,14 +218,14 @@ export default {
     },
 
     /**
-     * Clears the current list of address suggestions.
+     * @desc Clears the current list of address suggestions.
      */
     clearAddressSuggestions () {
       this.addressSuggestions = [];
     },
 
     /**
-     * Shows the address suggestions list in the UI.
+     * @desc Shows the address suggestions list in the UI.
      */
     showList() {
       if(document.getElementById('address-suggestions-list')){
@@ -234,7 +234,7 @@ export default {
     },
 
     /**
-     * Hides the address suggestions list in the UI.
+     * @desc Hides the address suggestions list in the UI.
      */
     hideList() {
       if(document.getElementById('address-suggestions-list')){

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -193,9 +193,9 @@ export default {
       }
     },
     selectAddressSuggestion(suggestion) {
-      this.ownerAddressInput = suggestion;
-      this.addressSuggestions = [];
       const ownerAddressArray = suggestion.split(',');
+      this.ownerAddressInput = ownerAddressArray[0];
+      this.ownerCityInput = ownerAddressArray[1];
       if(ownerAddressArray[2].toUpperCase().trim() === 'BC' || ownerAddressArray[2].toUpperCase().trim() === 'BRITISH COLUMBIA')
       this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;
       else

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -219,16 +219,22 @@ export default {
      * @param {string} suggestion - The selected address suggestion. ("1234 Street Rd, Name of City, BC")
      */
     selectAddressSuggestion(suggestion) {
+      const PROV_ARRAY_INDEX = ownerAddressArray.length -1;
+      const CITY_ARRAY_INDEX = ownerAddressArray.length -2;
+      const STREET_ARRAY_INDEX = ownerAddressArray.length -3;
+
       const ownerAddressArray = suggestion.split(',');
       if(ownerAddressArray){
-        if(ownerAddressArray[ownerAddressArray.length -1].toUpperCase().trim() === 'BC' || ownerAddressArray[-1].toUpperCase().trim() === 'BRITISH COLUMBIA')
-        {
+        if(ownerAddressArray[PROV_ARRAY_INDEX].toUpperCase().trim() === 'BC' 
+          || ownerAddressArray[-1].toUpperCase().trim() === 'BRITISH COLUMBIA'){
           this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;
           this.ownerAddressInput = '';
         }
-      else this.ownerProvinceInput = "";
-      this.ownerCityInput = ownerAddressArray[ownerAddressArray.length -2];
-      if(ownerAddressArray[ownerAddressArray.length -3]) this.ownerAddressInput = ownerAddressArray[ownerAddressArray.length -3];
+      else {
+        this.ownerProvinceInput = "";
+      }
+      this.ownerCityInput = ownerAddressArray[CITY_ARRAY_INDEX];
+      if(ownerAddressArray[STREET_ARRAY_INDEX]) this.ownerAddressInput = ownerAddressArray[STREET_ARRAY_INDEX];
       }
       
       this.clearAddressSuggestions();

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -162,37 +162,39 @@ export default {
      * Finally, sets the loading state to false.
      */
     async fetchAddressSuggestions() {
-      if (!this.ownerAddressInput) {
+      console.log(this.ownerAddressInput.length);
+      if (!this.ownerAddressInput || this.ownerAddressInput.length < 3) {
         this.addressSuggestions = [];
         return;
-      }
-      this.isLoadingSuggestions = true;
-      const params = {
-        minScore: 50, //accuracy score of results compared to input
-		    maxResults: 5,
-        echo: 'false',
-        brief: true,
-        autoComplete: true,
-        addressString: this.ownerAddressInput
-      };
+      } else {
+        this.isLoadingSuggestions = true;
+        const params = {
+          minScore: 50, //accuracy score of results compared to input
+          maxResults: 5,
+          echo: 'false',
+          brief: true,
+          autoComplete: true,
+          addressString: this.ownerAddressInput
+        };
 
-      const querystring = require('querystring');
-      const searchParams = querystring.stringify(params);
-      try {
-        const response = await fetch(`${GEOCODER_ADDRESS_API}${searchParams}`);
-        const data = await response.json();
-        if (data && data.features) {
-          
-          this.addressSuggestions = data.features.map(item => item.properties.fullAddress);
-        } else {
+        const querystring = require('querystring');
+        const searchParams = querystring.stringify(params);
+        try {
+          const response = await fetch(`${GEOCODER_ADDRESS_API}${searchParams}`);
+          const data = await response.json();
+          if (data && data.features) {
+            
+            this.addressSuggestions = data.features.map(item => item.properties.fullAddress);
+          } else {
+            this.addressSuggestions = [];
+          }
+        } catch (error) {
+          console.error(error);
           this.addressSuggestions = [];
+        } finally {
+          this.isLoadingSuggestions = false;
         }
-      } catch (error) {
-        console.error(error);
-        this.addressSuggestions = [];
-      } finally {
-        this.isLoadingSuggestions = false;
-      }
+      }   
     },
 
     /**

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -100,7 +100,7 @@ import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import inputFormatMixin from '@/common/inputFormatMixin.js'
 
 import BackToTopLink from '@/common/components/BackToTopLink.vue'
-
+const GEOCODER_QUERY_URL = 'https://geocoder.api.gov.bc.ca/addresses.json?q='
 export default {
   mixins: [inputBindingsMixin, inputFormatMixin],
   components: {
@@ -174,11 +174,8 @@ export default {
       const querystring = require('querystring');
       const searchParams = querystring.stringify(params);
       try {
-        const response = await fetch(`https://geocoder.api.gov.bc.ca/addresses.json?q=${searchParams}`);
-        console.log(encodeURIComponent(params));
-        console.log(searchParams);
+        const response = await fetch(GEOCODER_QUERY_URL + searchParams);
         const data = await response.json();
-        console.log(data);
         if (data && data.features) {
           
           this.addressSuggestions = data.features.map(item => item.properties.fullAddress);
@@ -194,23 +191,29 @@ export default {
     },
     selectAddressSuggestion(suggestion) {
       const ownerAddressArray = suggestion.split(',');
-      this.ownerAddressInput = ownerAddressArray[0];
-      this.ownerCityInput = ownerAddressArray[1];
-      if(ownerAddressArray[2].toUpperCase().trim() === 'BC' || ownerAddressArray[2].toUpperCase().trim() === 'BRITISH COLUMBIA')
-      this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;
-      else
-      this.ownerProvinceInput = "";
+      if(ownerAddressArray){
+        if(ownerAddressArray[ownerAddressArray.length -1].toUpperCase().trim() === 'BC' || ownerAddressArray[-1].toUpperCase().trim() === 'BRITISH COLUMBIA')
+        this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;
+      else this.ownerProvinceInput = "";
+      this.ownerCityInput = ownerAddressArray[ownerAddressArray.length -2];
+      if(ownerAddressArray[ownerAddressArray.length -3]) this.ownerAddressInput = ownerAddressArray[ownerAddressArray.length -3];
+      }
+      
       this.clearAddressSuggestions();
     },
     clearAddressSuggestions () {
       this.addressSuggestions = [];
     },
     showList() {
-            document.getElementById('address-suggestions-list').style.display = 'block';
+      if(document.getElementById('address-suggestions-list')){
+        document.getElementById('address-suggestions-list').style.display = 'block';
+      }     
     },
     hideList() {
-      document.getElementById('address-suggestions-list').style.display = 'none';
-    }
+      if(document.getElementById('address-suggestions-list')){
+        document.getElementById('address-suggestions-list').style.display = 'none';
+      }
+    }     
   }
 }
 </script>

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -30,11 +30,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <form-input id="ownerFullName" label="Well Owner Name" v-model="ownerFullNameInput" :errors="errors['owner_full_name']" :loaded="fieldsLoaded['owner_full_name']"></form-input>
       </b-col>
       <b-col cols="12" md="6">
-        <form-input id="ownerMailingAddress" label="Owner Mailing Address" v-model="ownerAddressInput" :errors="errors['owner_mailing_address']" :loaded="fieldsLoaded['owner_mailing_address']"></form-input>
+        <form-input id="ownerMailingAddress" label="Owner Mailing Address" v-model="ownerAddressInput" @input="fetchAddressSuggestions" v-on:blur="clearAddressSuggestions" :errors="errors['owner_mailing_address']" :loaded="fieldsLoaded['owner_mailing_address']"></form-input>
         <!-- Display the address suggestions -->
         <ul v-if="addressSuggestions.length > 0" class="address-suggestions">
           <li v-for="(suggestion, index) in addressSuggestions" :key="index">
-            <button @click="selectAddressSuggestion(suggestion)">{{ suggestion }}</button>
+            <button @mousedown="selectAddressSuggestion(suggestion)">{{ suggestion }}</button>
           </li>
         </ul>
         <!-- Display a loading indicator while fetching suggestions -->
@@ -198,11 +198,11 @@ export default {
       const ownerAddressArray = suggestion.split(',');
       if(ownerAddressArray[2].toUpperCase().trim() === 'BC' || ownerAddressArray[2].toUpperCase().trim() === 'BRITISH COLUMBIA')
       this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;
-    }
-  },
-  watch: {
-    ownerAddressInput() {
-      this.fetchAddressSuggestions();
+      else
+      this.ownerProvinceInput = "";
+    },
+    clearAddressSuggestions () {
+      this.addressSuggestions = [];
     }
   }
 }

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -221,7 +221,7 @@ export default {
      */
     selectAddressSuggestion(suggestion) {
       const ownerAddressArray = suggestion.split(',');
-      if(ownerAddressArray){
+      if(ownerAddressArray.length > 1){
 
         const PROV_ARRAY_INDEX = ownerAddressArray.length -1;
         const CITY_ARRAY_INDEX = ownerAddressArray.length -2;

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -100,7 +100,7 @@ import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import inputFormatMixin from '@/common/inputFormatMixin.js'
 
 import BackToTopLink from '@/common/components/BackToTopLink.vue'
-const GEOCODER_QUERY_URL = 'https://geocoder.api.gov.bc.ca/addresses.json?q='
+import { GEOCODER_ADDRESS_API } from '@/common/constants'
 export default {
   mixins: [inputBindingsMixin, inputFormatMixin],
   components: {
@@ -174,7 +174,7 @@ export default {
       const querystring = require('querystring');
       const searchParams = querystring.stringify(params);
       try {
-        const response = await fetch(GEOCODER_QUERY_URL + searchParams);
+        const response = await fetch(`${GEOCODER_ADDRESS_API}${searchParams}`);
         const data = await response.json();
         if (data && data.features) {
           
@@ -193,7 +193,10 @@ export default {
       const ownerAddressArray = suggestion.split(',');
       if(ownerAddressArray){
         if(ownerAddressArray[ownerAddressArray.length -1].toUpperCase().trim() === 'BC' || ownerAddressArray[-1].toUpperCase().trim() === 'BRITISH COLUMBIA')
-        this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;
+        {
+          this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;
+          this.ownerAddressInput = '';
+        }
       else this.ownerProvinceInput = "";
       this.ownerCityInput = ownerAddressArray[ownerAddressArray.length -2];
       if(ownerAddressArray[ownerAddressArray.length -3]) this.ownerAddressInput = ownerAddressArray[ownerAddressArray.length -3];

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -248,5 +248,7 @@ export default {
 <style>
   .address-suggestions {
     list-style-type: none;
+    position: absolute;
+    z-index: 10;
   }
 </style>

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -195,6 +195,9 @@ export default {
     selectAddressSuggestion(suggestion) {
       this.ownerAddressInput = suggestion;
       this.addressSuggestions = [];
+      const ownerAddressArray = suggestion.split(',');
+      if(ownerAddressArray[2].toUpperCase().trim() === 'BC' || ownerAddressArray[2].toUpperCase().trim() === 'BRITISH COLUMBIA')
+      this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;
     }
   },
   watch: {

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -222,7 +222,6 @@ export default {
     selectAddressSuggestion(suggestion) {
       const ownerAddressArray = suggestion.split(',');
       if(ownerAddressArray.length > 1){
-
         const PROV_ARRAY_INDEX = ownerAddressArray.length -1;
         const CITY_ARRAY_INDEX = ownerAddressArray.length -2;
         const STREET_ARRAY_INDEX = ownerAddressArray.length -3;
@@ -231,11 +230,11 @@ export default {
           this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;
           this.ownerAddressInput = '';
         }
-      else {
+        else {
         this.ownerProvinceInput = "";
-      }
-      this.ownerCityInput = ownerAddressArray[CITY_ARRAY_INDEX].trim();
-      if(ownerAddressArray[STREET_ARRAY_INDEX]) this.ownerAddressInput = ownerAddressArray[STREET_ARRAY_INDEX];
+        }
+        this.ownerCityInput = ownerAddressArray[CITY_ARRAY_INDEX].trim();
+        if(ownerAddressArray[STREET_ARRAY_INDEX]) this.ownerAddressInput = ownerAddressArray[STREET_ARRAY_INDEX];
       }
       this.clearAddressSuggestions();
     },

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -48,9 +48,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </form-input>
         <!-- Display the address suggestions -->
         <div v-if="addressSuggestions.length > 0" class="address-suggestions list-group list-group-flush border" id="address-suggestions-list">
-          <li v-for="(suggestion, index) in addressSuggestions" :key="index">
+          <div v-for="(suggestion, index) in addressSuggestions" :key="index">
             <button @mousedown="selectAddressSuggestion(suggestion)" class="list-group-item list-group-item-action border-0">{{ suggestion }}</button>
-          </li>
+          </div>
         </div>
         <!-- Display a loading indicator while fetching suggestions -->
         <div v-if="isLoadingSuggestions" class="loading-indicator">

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -27,10 +27,25 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
     <b-row>
       <b-col cols="12" md="6">
-        <form-input id="ownerFullName" label="Well Owner Name" v-model="ownerFullNameInput" :errors="errors['owner_full_name']" :loaded="fieldsLoaded['owner_full_name']"></form-input>
+        <form-input 
+          id="ownerFullName" 
+          label="Well Owner Name" 
+          v-model="ownerFullNameInput" 
+          :errors="errors['owner_full_name']" 
+          :loaded="fieldsLoaded['owner_full_name']"
+        ></form-input>       
       </b-col>
       <b-col cols="12" md="6">
-        <form-input id="ownerMailingAddress" label="Owner Mailing Address" v-model="ownerAddressInput" @input="fetchAddressSuggestions" v-on:focus="showList" v-on:blur="hideList" :errors="errors['owner_mailing_address']" :loaded="fieldsLoaded['owner_mailing_address']"></form-input>
+        <form-input 
+          id="ownerMailingAddress" 
+          label="Owner Mailing Address" 
+          v-model="ownerAddressInput" 
+          @input="fetchAddressSuggestions" 
+          v-on:focus="showList(true)" 
+          v-on:blur="showList(false)" 
+          :errors="errors['owner_mailing_address']" 
+          :loaded="fieldsLoaded['owner_mailing_address']">
+        </form-input>
         <!-- Display the address suggestions -->
         <div v-if="addressSuggestions.length > 0" class="address-suggestions list-group list-group-flush border" id="address-suggestions-list">
           <li v-for="(suggestion, index) in addressSuggestions" :key="index">
@@ -162,8 +177,8 @@ export default {
      * Finally, sets the loading state to false.
      */
     async fetchAddressSuggestions() {
-      console.log(this.ownerAddressInput.length);
-      if (!this.ownerAddressInput || this.ownerAddressInput.length < 3) {
+      const MIN_QUERY_LENGTH = 3;
+      if (!this.ownerAddressInput || this.ownerAddressInput.length < MIN_QUERY_LENGTH) {
         this.addressSuggestions = [];
         return;
       } else {
@@ -227,22 +242,14 @@ export default {
     },
 
     /**
-     * @desc Shows the address suggestions list in the UI.
+     * @desc Shows or hides the address suggestions list in the UI.
+     * @param {boolean} show - a boolean which indicates whether to show or hide the element
      */
-    showList() {
+     showList(show) {
       if(document.getElementById('address-suggestions-list')){
-        document.getElementById('address-suggestions-list').style.display = 'block';
-      }     
-    },
-
-    /**
-     * @desc Hides the address suggestions list in the UI.
-     */
-    hideList() {
-      if(document.getElementById('address-suggestions-list')){
-        document.getElementById('address-suggestions-list').style.display = 'none';
+        document.getElementById('address-suggestions-list').style.display =  show? 'block' : 'none';
       }
-    }     
+    }        
   }
 }
 </script>

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -239,7 +239,6 @@ export default {
       this.ownerCityInput = ownerAddressArray[CITY_ARRAY_INDEX];
       if(ownerAddressArray[STREET_ARRAY_INDEX]) this.ownerAddressInput = ownerAddressArray[STREET_ARRAY_INDEX];
       }
-      
       this.clearAddressSuggestions();
     },
 

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -220,8 +220,6 @@ export default {
      * @param {string} suggestion - The selected address suggestion. ("1234 Street Rd, Name of City, BC")
      */
     selectAddressSuggestion(suggestion) {
-      console.log(suggestion);
-
       const ownerAddressArray = suggestion.split(',');
       if(ownerAddressArray){
 

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -48,9 +48,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </form-input>
         <!-- Display the address suggestions -->
         <div v-if="addressSuggestions.length > 0" class="address-suggestions list-group list-group-flush border" id="address-suggestions-list">
-          <div v-for="(suggestion, index) in addressSuggestions" :key="index">
+          <li v-for="(suggestion, index) in addressSuggestions" :key="index">
             <button @mousedown="selectAddressSuggestion(suggestion)" class="list-group-item list-group-item-action border-0">{{ suggestion }}</button>
-          </div>
+          </li>
         </div>
         <!-- Display a loading indicator while fetching suggestions -->
         <div v-if="isLoadingSuggestions" class="loading-indicator">
@@ -219,12 +219,15 @@ export default {
      * @param {string} suggestion - The selected address suggestion. ("1234 Street Rd, Name of City, BC")
      */
     selectAddressSuggestion(suggestion) {
-      const PROV_ARRAY_INDEX = ownerAddressArray.length -1;
-      const CITY_ARRAY_INDEX = ownerAddressArray.length -2;
-      const STREET_ARRAY_INDEX = ownerAddressArray.length -3;
+      console.log(suggestion);
 
       const ownerAddressArray = suggestion.split(',');
       if(ownerAddressArray){
+
+        const PROV_ARRAY_INDEX = ownerAddressArray.length -1;
+        const CITY_ARRAY_INDEX = ownerAddressArray.length -2;
+        const STREET_ARRAY_INDEX = ownerAddressArray.length -3;
+
         if(ownerAddressArray[PROV_ARRAY_INDEX].toUpperCase().trim() === 'BC' 
           || ownerAddressArray[-1].toUpperCase().trim() === 'BRITISH COLUMBIA'){
           this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,7 @@ services:
       S3_WELL_EXPORT_BUCKET: gwells
       S3_USE_SECURE: 0
       EMAIL_NOTIFICATION_RECIPIENT: sustainment.team@gov.bc.ca
+      GEOCODER_ADDRESS_API_BASE: https://geocoder.api.gov.bc.ca/addresses.json?q=
     command: /bin/bash -c "
       sleep 3 &&
       set -x &&

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,7 +188,7 @@ services:
       S3_WELL_EXPORT_BUCKET: gwells
       S3_USE_SECURE: 0
       EMAIL_NOTIFICATION_RECIPIENT: sustainment.team@gov.bc.ca
-      GEOCODER_ADDRESS_API_BASE: https://geocoder.api.gov.bc.ca/addresses.json?q=
+      GEOCODER_ADDRESS_API_BASE: https://geocoder.api.gov.bc.ca/addresses.json?
     command: /bin/bash -c "
       sleep 3 &&
       set -x &&

--- a/openshift/backend.dc.json
+++ b/openshift/backend.dc.json
@@ -733,6 +733,15 @@
                                     {
                                         "name": "ENFORCE_ENV_VARIABLES",
                                         "value": "False"
+                                    },
+                                    {
+                                        "name": "GEOCODER_ADDRESS_API_BASE",
+                                        "valueFrom": {
+                                            "configMapKeyRef": {
+                                                "key": "GEOCODER_ADDRESS_API_BASE",
+                                                "name": "gwells-global-config${NAME_SUFFIX}"
+                                            }
+                                        }
                                     }
                                 ],
                                 "resources": {

--- a/openshift/ocp4/backend.dc.json
+++ b/openshift/ocp4/backend.dc.json
@@ -742,6 +742,15 @@
                                                 "name": "gwells-global-config${NAME_SUFFIX}"
                                             }
                                         }
+                                    },
+                                    {
+                                        "name": "GEOCODER_ADDRESS_API_BASE",
+                                        "valueFrom": {
+                                            "configMapKeyRef": {
+                                                "key": "GEOCODER_ADDRESS_API_BASE",
+                                                "name": "gwells-global-config${NAME_SUFFIX}"
+                                            }
+                                        }
                                     }
                                 ],
                                 "resources": {


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Added address auto-complete + auto-fill to the Well Owner Information form for well submissions and well editing
- Added address auto-complete + auto-fill to the Well Location form for well submissions and well editing

Utilized the BC Gov Geocoder API to get addresses. This API allows 1000 requests/min so no throttling should occur. BUT, it does not have Postal Code information, so Postal Code is not auto-filled.
 
![image](https://github.com/bcgov/gwells/assets/113044739/98b8ac49-8a10-4b01-85e8-2da932b2c4fa)
