### PR TITLE
[FEATURE][GWELLS-2049] Added a hyperlink to the tool tip description of Aquifer notations on Aquifer Summary page

### DIFF
--- a/app/frontend/src/aquifers/components/View.vue
+++ b/app/frontend/src/aquifers/components/View.vue
@@ -505,8 +505,9 @@
                         <i id="aquiferNotations" tabindex="0" class="fa fa-question-circle color-info fa-xs pt-0 mt-0 d-print-none"></i>
                         <b-popover
                           target="aquiferNotations"
-                          triggers="hover focus"
-                          content="Water allocation notations are a water management tool that indicates a potential lack of water availability/quality in a source."/>
+                          triggers="hover focus">
+                          <p>Water allocation notations are a water management tool that indicates a potential lack of water availability/quality in a source. For details click <a href="https://www2.gov.bc.ca/gov/content/environment/air-land-water/water/water-licensing-rights/water-allocation-notations">here</a>.</p>
+                        </b-popover>
                       </dt>
                       <dd class="m-0">{{ aquiferNotations || 'No notation currently assigned.' }}</dd>
                     </dl>

--- a/app/frontend/tests/unit/specs/aquifers/components/__snapshots__/View.spec.js.snap
+++ b/app/frontend/tests/unit/specs/aquifers/components/__snapshots__/View.spec.js.snap
@@ -1249,10 +1249,19 @@ exports[`View Component View mode matches the snapshot 1`] = `
                         />
                          
                         <b-popover-stub
-                          content="Water allocation notations are a water management tool that indicates a potential lack of water availability/quality in a source."
                           target="aquiferNotations"
                           triggers="hover focus"
-                        />
+                        >
+                          <p>
+                            Water allocation notations are a water management tool that indicates a potential lack of water availability/quality in a source. For details click 
+                            <a
+                              href="https://www2.gov.bc.ca/gov/content/environment/air-land-water/water/water-licensing-rights/water-allocation-notations"
+                            >
+                              here
+                            </a>
+                            .
+                          </p>
+                        </b-popover-stub>
                       </dt>
                        
                       <dd


### PR DESCRIPTION
changed the popup tooltip for aquifer notations on the aquifer summar…y page to include a link to an info page

## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Added some text and a link to the popover tooltip for aquifer notations on the aquifer summary page
![image](https://github.com/bcgov/gwells/assets/113044739/88474153-cb22-4992-b5dc-4276e5ae70d6)
