### PR TITLE
[FEATURE][GWELLS-2094] Address autofill/autocomplete added to Well Owner and Well Location forms

### DIFF
--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -269,8 +269,7 @@ export default {
       wellAddressHints: [],
       sameAsOwnerAddress: false,
       addressSuggestions: [],
-      isLoadingSuggestions: false,
-      streetAddressInput: ''
+      isLoadingSuggestions: false
     }
   },
   computed: {

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -321,6 +321,7 @@ export default {
         echo: 'false',
         brief: true,
         autoComplete: true,
+        matchPrecision: 'CIVIC_NUMBER', //forced minimum level of specificity for return values. will only return addresses that contain at least contain a street number
         addressString: this.streetAddressInput
       };
 
@@ -352,19 +353,11 @@ export default {
      * @param {string} suggestion - The selected address suggestion. ("1234 Street Rd, Name of City, BC")
      */
     selectAddressSuggestion(suggestion) {
+      const CITY_ARRAY_INDEX = 1;
+      const STREET_ARRAY_INDEX = 0;
       const wellAddressArray = suggestion.split(',');
-      switch (wellAddressArray.length) {
-        case 3: {
-          this.streetAddressInput = wellAddressArray[0];
-          this.cityInput = wellAddressArray[1].trim();
-          break;
-        }
-        case 2: {
-          this.cityInput = wellAddressArray[0];
-          this.streetAddressInput = '';
-          break;
-        }
-      }
+      this.streetAddressInput = wellAddressArray[STREET_ARRAY_INDEX];
+      this.cityInput = wellAddressArray[CITY_ARRAY_INDEX].trim();
     },
 
     /**

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -151,6 +151,7 @@ export default {
   },
   fields: {
     ownerFullNameInput: 'ownerFullName',
+    ownerAddressInput: 'ownerMailingAddress',
     ownerCityInput: 'ownerCity',
     ownerProvinceInput: 'ownerProvinceState',
     ownerPostalCodeInput: 'ownerPostalCode',
@@ -160,8 +161,7 @@ export default {
   data () {
     return {
       addressSuggestions: [],
-      isLoadingSuggestions: false,
-      ownerAddressInput: ''
+      isLoadingSuggestions: false
     }
   },
   computed: {

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -188,6 +188,7 @@ export default {
           echo: 'false',
           brief: true,
           autoComplete: true,
+          matchPrecision: 'CIVIC_NUMBER', //forced minimum level of specificity for return values. will only return addresses that contain at least contain a street number
           addressString: this.ownerAddressInput
         };
 
@@ -221,22 +222,20 @@ export default {
      */
     selectAddressSuggestion(suggestion) {
       const ownerAddressArray = suggestion.split(',');
-      if(ownerAddressArray.length > 1){
-        const PROV_ARRAY_INDEX = ownerAddressArray.length -1;
-        const CITY_ARRAY_INDEX = ownerAddressArray.length -2;
-        const STREET_ARRAY_INDEX = ownerAddressArray.length -3;
-        let province = ownerAddressArray[PROV_ARRAY_INDEX].toUpperCase().trim();
-        if(province === 'BC' || province === 'BRITISH COLUMBIA'){
-          this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;
-          this.ownerAddressInput = '';
-        }
-        else {
-        this.ownerProvinceInput = "";
-        }
-        this.ownerCityInput = ownerAddressArray[CITY_ARRAY_INDEX].trim();
-        if(ownerAddressArray[STREET_ARRAY_INDEX]) this.ownerAddressInput = ownerAddressArray[STREET_ARRAY_INDEX];
+      const PROV_ARRAY_INDEX = 2;
+      const CITY_ARRAY_INDEX = 1;
+      const STREET_ARRAY_INDEX = 0;
+      let province = ownerAddressArray[PROV_ARRAY_INDEX].toUpperCase().trim();
+      if(province === 'BC' || province === 'BRITISH COLUMBIA'){
+        this.ownerProvinceInput = this.codes.province_codes[0].province_state_code;
       }
-      this.clearAddressSuggestions();
+      else {
+      this.ownerProvinceInput = "";
+      }
+      this.ownerCityInput = ownerAddressArray[CITY_ARRAY_INDEX].trim();
+      this.ownerAddressInput = ownerAddressArray[STREET_ARRAY_INDEX];
+    
+    this.clearAddressSuggestions();
     },
 
     /**


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

Added address auto-complete + auto-fill to the Well Owner Information form for well submissions and well editing
Added address auto-complete + auto-fill to the Well Location form for well submissions and well editing
Utilized the BC Gov Geocoder API to get addresses. This API allows 1000 requests/min so no throttling should occur. BUT, it does not have Postal Code information, so Postal Code is not auto-filled.