### PR TITLE
[GWELLS-2093] FEATURE** Gwells 2093 lat long validation checks + point n click map

### DIFF
--- a/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
@@ -204,6 +204,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <coords class="my-5"
         v-if="showSection('wellCoords')"
         id="wellCoords"
+        ref="wellCoords"
         :latitude.sync="form.latitude"
         :longitude.sync="form.longitude"
         :drinking_water="form.drinking_water_protection_area_ind"

--- a/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
@@ -26,7 +26,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </b-col>
       </b-row>
       <p>To determine coordinates using a Global Positioning System (GPS), set the datum to North America Datum of 1983 (NAD 83), the current ministry standard for mapping.</p>
-      <p class="bg-warning p-2">The map pin can be placed manually, by clicking, or dragging on the map. The GPS coordinates will be updated automatically.</p>
+      <p class="bg-warning p-2">The map pin can be placed manually, by clicking, or by dragging on the map. The GPS coordinates will be updated automatically.</p>
       <b-row>
         <b-col sm="12" md="6">
           <b-card no-body class="p-3 m-1 m-md-1">

--- a/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
@@ -196,7 +196,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </b-card>
           <b-row>
             <b-col class="mt-3">
-              <div v-if="!validCoordinate">
+              <div v-if="validCoordinate === false">
                 <div class="alert alert-danger" role="alert">You have entered an invalid coordinate</div>
               </div>
             </b-col>

--- a/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
@@ -26,7 +26,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </b-col>
       </b-row>
       <p>To determine coordinates using a Global Positioning System (GPS), set the datum to North America Datum of 1983 (NAD 83), the current ministry standard for mapping.</p>
-      <p class="bg-warning p-2">After the GPS coordinates are entered, the map pin can be moved by clicking and dragging it on the map. The GPS coordinates will be updated automatically.</p>
+      <p class="bg-warning p-2">The map pin can be placed manually, by clicking, or dragging on the map. The GPS coordinates will be updated automatically.</p>
       <b-row>
         <b-col sm="12" md="6">
           <b-card no-body class="p-3 m-1 m-md-1">
@@ -196,7 +196,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </b-card>
           <b-row>
             <b-col class="mt-3">
-              <div v-if="validCoordinate === false">
+              <div v-if="!validCoordinate">
                 <div class="alert alert-danger" role="alert">You have entered an invalid coordinate</div>
               </div>
             </b-col>

--- a/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
@@ -26,7 +26,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </b-col>
       </b-row>
       <p>To determine coordinates using a Global Positioning System (GPS), set the datum to North America Datum of 1983 (NAD 83), the current ministry standard for mapping.</p>
-      <p>After the GPS coordinates are entered, the map pin can be moved by clicking and dragging it on the map. The GPS coordinates will be updated automatically.</p>
+      <p class="bg-warning p-2">After the GPS coordinates are entered, the map pin can be moved by clicking and dragging it on the map. The GPS coordinates will be updated automatically.</p>
       <b-row>
         <b-col sm="12" md="6">
           <b-card no-body class="p-3 m-1 m-md-1">

--- a/app/frontend/src/submissions/components/SubmissionForm/CoordsMap.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/CoordsMap.vue
@@ -132,6 +132,13 @@ export default {
           })
         }
 
+        // Allow users to place a marker if one is not already present
+        this.map.on('click', (ev) => {
+          if(!this.latitude || !this.longitude){
+            this.handleMapClick(ev);
+          }
+        });
+        
         if (this.longitude && this.latitude) {
           this.coordsChanged(this.longitude, this.latitude)
 
@@ -190,6 +197,20 @@ export default {
       } else {
         this.resetMap()
       }
+    },
+    /**
+     * @desc Updates the Longitude / Latitude of the map marker when user clicks, if click is within BC
+     * @summary Updates map marker to click location
+     * @param {Object} event Mapbox event
+     */
+    handleMapClick(event) {
+      const { lat, lng } = event.lngLat
+      this.performCheck(lng, lat).then((isInsideBC) => {
+        if (isInsideBC) {
+          const longLat = { lng: Math.abs(lng), lat }
+          this.$emit('coordinate', longLat);
+        }
+      });
     },
     handleDrag () {
       const markerLngLat = this.marker.getLngLat()

--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -61,6 +61,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </div>
               <activity-submission-form
                 v-else
+                ref="activitySubmissionForm"
                 :form="form"
                 :events="events"
                 :submissionsHistory="submissionsHistory"
@@ -586,6 +587,14 @@ export default {
         validateWellClassAndIntendedWaterUse = false
       }
 
+      const wellCoordsWithinBC = this.$refs.activitySubmissionForm.$refs.wellCoords.validCoordinate
+      if (!this.form.latitude || !this.form.longitude) {
+        errors.position = ['Latitude + Longitude required']
+      } else if (!wellCoordsWithinBC) {
+        errors.position = ['Coordinates not within BC']
+      }
+      
+      
       // Always validate well_class and intended_water_use except for ALT or DEC submissions with a
       // well_tag_number specified
       if (validateWellClassAndIntendedWaterUse) {

--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -587,10 +587,17 @@ export default {
         validateWellClassAndIntendedWaterUse = false
       }
 
-      const wellCoordsWithinBC = this.$refs.activitySubmissionForm.$refs.wellCoords.validCoordinate
-      if (!this.form.latitude || !this.form.longitude) {
-        errors.position = ['Latitude + Longitude required']
-      } else if (!wellCoordsWithinBC) {
+      const wellCoordsNotWithinBC = !this.$refs.activitySubmissionForm.$refs.wellCoords.validCoordinate
+      const wellCoordsMissing = !this.form.latitude || !this.form.longitude;
+      //
+      if (wellCoordsMissing) {
+        if (!this.form.latitude){
+          errors.latitude = ['Valid Latitude Required'];
+        }
+        if (!this.form.longitude) { 
+          errors.longitude = ['Valid Longitude Required']
+        }
+      } else if (wellCoordsNotWithinBC) {
         errors.position = ['Coordinates not within BC']
       }
       


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Allow user creating new well to place initial map marker with `click` action
    - Can only click initial action to reduce maps coordinates being accidentally overwritten in edit
- In new well submission, check Lat Long exist and are within British Columbia
- Highlight message about map placements

![image](https://github.com/bcgov/gwells/assets/62873746/c2f3cdcd-22c9-4eb2-b8dc-45cab46f7c19)

