### PR TITLE
[BUG][GWELLS-2104] Return unique licence numbers

### DIFF
--- a/app/backend/aquifers/fixtures/aquifers.json
+++ b/app/backend/aquifers/fixtures/aquifers.json
@@ -871,6 +871,21 @@
     }
   },
   {
+    "model": "aquifers.waterrightslicence",
+    "pk": 8,
+    "fields": {
+      "create_user": "",
+      "create_date": "2019-11-04T19:40:43.379Z",
+      "update_user": "",
+      "update_date": "2019-11-04T19:47:48.075Z",
+      "purpose": "03A",
+      "licence_number": 501528,
+      "quantity_flag": "T",
+      "quantity": "100000.000",
+      "effective_date": "2019-11-04T19:40:43.379Z"
+    }
+  },
+  {
     "model": "wells.well",
     "pk": 100123,
     "fields": {
@@ -1263,7 +1278,7 @@
       "well_subclass": "ce97445a-664e-44f1-a096-95c97ffd084e",
       "intended_water_use": "DWS",
       "well_status": "NEW",
-      "licences": [4, 5, 6, 7],
+      "licences": [4, 5, 6, 7, 8],
       "street_address": "6647 CHRISTENSEN ROAD",
       "city": "ANAHIM LAKE",
       "legal_lot": "A",

--- a/app/backend/wells/serializers_v2.py
+++ b/app/backend/wells/serializers_v2.py
@@ -160,7 +160,8 @@ class WellListSerializerV2(serializers.ModelSerializer):
         return "{0:0>9}".format(instance.legal_pid)
     
     def get_licence_number(self, instance):
-        return list(instance.licences.values_list('licence_number', flat=True))
+        licence_numbers = instance.licences.values_list('licence_number', flat=True).distinct()
+        return list(licence_numbers)
 
     class Meta:
         model = Well


### PR DESCRIPTION
…eturned unique.

## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- To replicate the issue seen in staging and production I have updated the aquifers fixture JSON to include a water rights licence with multiple purposes. Specifically another water rights licence with the same licence number but a different purpose.
- Updated the well list serializer to return only unique licence numbers.

After replicating but before fix:
![Screenshot 2024-01-31 at 4 21 47 PM](https://github.com/bcgov/gwells/assets/20193291/d1963f21-4dfc-420f-aa40-fd9c3ad334ff)

After bug fix:
![Screenshot 2024-02-01 at 1 07 59 PM](https://github.com/bcgov/gwells/assets/20193291/2858a7a4-39b1-42ea-9b89-35ce99eeb0e1)
