### PR TITLE
[HOTFIX][GWELLS-#2132] - Check if the $ref exists for activitySubmission, bug fix on Submit

### DIFF
--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -587,20 +587,21 @@ export default {
         validateWellClassAndIntendedWaterUse = false
       }
 
-      const wellCoordsNotWithinBC = !this.$refs.activitySubmissionForm.$refs.wellCoords.validCoordinate
-      const wellCoordsMissing = !this.form.latitude || !this.form.longitude;
-      //
-      if (wellCoordsMissing) {
-        if (!this.form.latitude){
-          errors.latitude = ['Valid Latitude Required'];
+      if (this.$refs.activitySubmissionForm) {
+        const wellCoordsNotWithinBC = !this.$refs.activitySubmissionForm.$refs.wellCoords.validCoordinate
+        const wellCoordsMissing = !this.form.latitude || !this.form.longitude;
+        //
+        if (wellCoordsMissing) {
+          if (!this.form.latitude){
+            errors.latitude = ['Valid Latitude Required'];
+          }
+          if (!this.form.longitude) { 
+            errors.longitude = ['Valid Longitude Required']
+          }
+        } else if (wellCoordsNotWithinBC) {
+          errors.position = ['Coordinates not within BC']
         }
-        if (!this.form.longitude) { 
-          errors.longitude = ['Valid Longitude Required']
-        }
-      } else if (wellCoordsNotWithinBC) {
-        errors.position = ['Coordinates not within BC']
       }
-      
       
       // Always validate well_class and intended_water_use except for ALT or DEC submissions with a
       // well_tag_number specified


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Check if the `$ref.ActivitySubmission` exists for form validation
- Fix the error where isFormValid() is called on the final Submit where the component isn't rendered on the page (but the coordinates are valid and were submitted in the previous step). 
