### PR TITLE
[GWELLS-2024] FEATURE** Change regional area keys in API response

### DIFF
--- a/app/backend/registries/views.py
+++ b/app/backend/registries/views.py
@@ -205,7 +205,11 @@ class PersonOptionsView(APIView):
         result['regional_areas'] = \
             list(map(lambda item: RegionalAreaSerializer(item).data,
                      RegionalArea.objects.all().order_by('name')))
-
+        substring = "Regional District of"
+        for item in result['regional_areas']:
+            if substring in item['name']:
+                item['name'] = item['name'].replace(substring + " ", "") + ", " + substring
+        result['regional_areas'].sort(key=lambda item: item['name'])
         return Response(result)
 
 


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Updated API to move "Regional District of" to the end of a substring in the `/gwells/registries` page
- Response uses uuids for search, so no further changes needed

## Additional details

- [Dev realm](https://gwells-dev-pr-2157.apps.silver.devops.gov.bc.ca/gwells/registries)
- The `Dev` realm test data is inconsistent to `staging`, using the regions filter won't properly display data because of it
  - This is consistent across `dev` realms, and it not a result of these changes
  - The behaviour functions as expected when using in Staging
- You can browse the network in dev tools to witness its using a uuid for search, and not the `name` string

API Object
![image](https://github.com/bcgov/gwells/assets/62873746/a202c8aa-7243-4e77-9a09-dc95394a2842)

Request Headers
![image](https://github.com/bcgov/gwells/assets/62873746/9137a989-d1a2-429c-b4f8-a6f3addc10f4)

Before Change
![image](https://github.com/bcgov/gwells/assets/62873746/20c90fab-05b9-4cdb-85cf-418bea7baea3)

After Change
![image](https://github.com/bcgov/gwells/assets/62873746/8e4f0417-a29f-47c5-b017-ebd6032fb836)
