### PR TITLE
[GWELLS-2162] DEV** Get hotloading running in the frontend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,6 @@ services:
       VUE_APP_AXIOS_BASE_URL: /api/
       VUE_APP_VECTOR_TILE_BASE_URL: "/tiles/"
       VECTOR_TILE_SERVER: "http://tileserv:7800/"
-      CHOKIDAR_USEPOLLING: "True"
       API_TARGET: "${API_TARGET}"
     command: /bin/bash -c "
         set -x &&
@@ -128,7 +127,6 @@ services:
       - type: bind
         source: ./app/frontend
         target: /app/frontend
-        consistency: cached
       - /app/frontend/node_modules/
     depends_on:
       - backend


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):
- removed `consistency: cached` which was added in [PR #1487](https://github.com/bcgov/gwells/pull/1487) & [PR #1476](https://github.com/bcgov/gwells/pull/1476). These PRs are over 4 years old. (Times have changed)
  - Removing this allowed hotloading to continue, but with the previously forewarned high CPU rates (sometimes > 90%) 
- removed `CHOKIDAR_USEPOLLING` added in [PR #923](https://github.com/bcgov/gwells/pull/923). 5+ year old PR at this time
  -  It seems this is a method of checking for file changes, When I removed it the containers still hot reloaded appropriately, but even with mass editing and saving I cannot get my CPU >41%. Idle time has typically been hanging <2%.
