### PR TITLE
[GWELLS-2142] TESTS** Update API-Testing Files, bash scripts, MAKE command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,6 @@ backend:
 
 psql:
 	docker-compose exec db /bin/bash -c "psql -U gwells -d gwells"
+
+api-tests-local:
+	newman run tests/api-tests/*.json --global-var base_url="localhost:8000/gwells"

--- a/Makefile
+++ b/Makefile
@@ -53,5 +53,8 @@ backend:
 psql:
 	docker-compose exec db /bin/bash -c "psql -U gwells -d gwells"
 
+DEFAULT_API_TEST := 'local_run_all.sh'
+TEST_FILE?="$(DEFAULT_API_TEST)"
+
 api-tests-local:
-	newman run tests/api-tests/*.json --global-var base_url="localhost:8000/gwells"
+	cd tests/api-tests && "./$(TEST_FILE)"

--- a/tests/api-tests/.envrc
+++ b/tests/api-tests/.envrc
@@ -1,10 +1,21 @@
 
 # Set variables required for newman api tests
-#export GWELLS_API_BASE_URL=https://gwells-dev-pr-862-moe-gwells-dev.pathfinder.gov.bc.ca/gwells
-#export GWELLS_API_BASE_URL=https://gwells-dev-pr-860-moe-gwells-dev.pathfinder.gov.bc.ca/gwells
 export GWELLS_API_BASE_URL=http://127.0.0.1:8000/gwells
-export GWELLS_API_TEST_USER=testuser
+GWELLS_API_TEST_USER=""
+GWELLS_API_TEST_PASSWORD=""
+export GWELLS_API_TEST_CLIENT_SECRET=""
 export GWELLS_API_TEST_AUTH_SERVER=https://test.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/token
 export GWELLS_API_TEST_CLIENT_ID=gwells-api-tests-4820
 
-dotenv .secret_env
+
+if [ -z "$GWELLS_API_TEST_USER" ]; then
+  echo "Enter IDIR Login: "
+  read GWELLS_API_TEST_USER
+fi
+if [ -z "$GWELLS_API_TEST_PASSWORD"]; then
+  echo "Enter IDIR Password: "
+  read -s GWELLS_API_TEST_PASSWORD
+fi
+
+export GWELLS_API_TEST_USER
+export GWELLS_API_TEST_PASSWORD

--- a/tests/api-tests/README.md
+++ b/tests/api-tests/README.md
@@ -2,15 +2,58 @@
 
 The API tests use [Newman](https://www.npmjs.com/package/newman) to run the tests that are created in [Postman](https://www.getpostman.com).
 
+You can install Newman as a global dependency with `npm i -g newman@4.6.1` (This is the version currently used by Jenkins.)
+
+## Running your tests locally
+Running the tests through the following methods will load all the necessary environment variables locally into your terminal shell. These values don't persist outside of your shell. These commands will run **all** tests.
+
+1. Have your Docker images running.
+2. In your .envrc file, you need to populate the `GWELLS_API_TEST_CLIENT_SECRET` secret. This is obtainable from OpenShift under `[-tools]` -> `Secrets` -> `apitest-secrets`.
+    - Optionally you can populate the `GWELLS_API_TEST_USER` and `GWELLS_API_TEST_PASSWORD` keys using OpenShift secrets or your own IDIR.
+        - If these two fields are not populated, the terminal will prompt for input.
+3. Run one of the following commands to run all the test suites:
+    - From **api-tests**: `./run_local_all.sh`
+    - From **root**: `make api-tests-local`
+        - add the argument `TEST_FILE="your filename"` to run only one test suite
+
+> <span style="color: red"> Do not commit these secrets (even accidentally!).</span> 
+
+## Creating New Tests
+
+### Developing Tests
+
 * Develop your API Tests in Postman
 * Export the collection (this results in a json file)
-* Update the runnewman.sh to point to your json file
+* Create an accompanying Bash script
 * The pipeline will run your tests and report back in Jenkins
 
-Please note that the API tests use 2 environment variables for user and password:
-* GWELLS_API_TEST_USER
-* GWELLS_API_TEST_PASSWORD
+### Bash Scripts
 
-They are both populated from the apitest-secrets secret.
-This user/pw has been created in our dev database.
+When you're developing new Postman collections, please create an accompanying bash script to run them easily! This will help with loading in env variables, running all test suites at once, and reducing errors.
 
+> When creating your bash script, use the file structure `local_*.sh` This will ensure your tests are picked up by the `local_run_all.sh` script
+
+Add this section of script to the top of your new bash script. It will check if the `GWELLS_API_TEST_USER` Environment variable is present, if it is not it will load in all the environment variables to your terminal from the `.envrc` file. This helps to make all tests run standalone while reducing the setup.
+
+```bash
+# Load ENVs to environment if not already present
+if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./envrc"]; then
+  ./envrc
+fi
+```
+
+You can also ensure that all necessary environment variables are loaded before running the test suites by adding: 
+
+```bash
+ENV_VARS=(
+    # ...All Envs needed for your tests
+)
+
+for env_var in ${ENV_VARS[@]}
+do
+    if [ -z ${!env_var+x} ]; then 
+        echo "$env_var is unset"
+        exit
+    fi
+done
+```

--- a/tests/api-tests/README.md
+++ b/tests/api-tests/README.md
@@ -37,8 +37,9 @@ Add this section of script to the top of your new bash script. It will check if 
 
 ```bash
 # Load ENVs to environment if not already present
-if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./envrc"]; then
-  ./envrc
+if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./.envrc" ]; then
+  source ./.envrc
+  set -e
 fi
 ```
 

--- a/tests/api-tests/local_aquifers.sh
+++ b/tests/api-tests/local_aquifers.sh
@@ -13,6 +13,10 @@
 # - Run script:
 #     ./local_newman.sh
 
+# Load ENVs to environment if not already present
+if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./envrc"]; then
+  ./envrc
+fi
 
 ENV_VARS=(
     "GWELLS_API_TEST_USER"

--- a/tests/api-tests/local_aquifers.sh
+++ b/tests/api-tests/local_aquifers.sh
@@ -14,8 +14,9 @@
 #     ./local_newman.sh
 
 # Load ENVs to environment if not already present
-if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./envrc"]; then
-  ./envrc
+if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./.envrc" ]; then
+  source ./.envrc
+  set -e
 fi
 
 ENV_VARS=(

--- a/tests/api-tests/local_registries.sh
+++ b/tests/api-tests/local_registries.sh
@@ -13,7 +13,10 @@
 # - Run script:
 #     ./local_newman.sh
 
-
+# Load ENVs to environment if not already present
+if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./envrc"]; then
+  ./envrc
+fi
 
 ENV_VARS=(
     "GWELLS_API_TEST_USER"

--- a/tests/api-tests/local_registries.sh
+++ b/tests/api-tests/local_registries.sh
@@ -14,8 +14,9 @@
 #     ./local_newman.sh
 
 # Load ENVs to environment if not already present
-if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./envrc"]; then
-  ./envrc
+if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./.envrc" ]; then
+  source ./.envrc
+  set -e
 fi
 
 ENV_VARS=(

--- a/tests/api-tests/local_run_all.sh
+++ b/tests/api-tests/local_run_all.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # Run all api (newman/postman) tests locally.
-
+source ./.envrc
 set -e
 
 ./local_aquifers.sh
@@ -9,3 +9,5 @@ set -e
 ./local_submissions.sh
 ./local_wells_search.sh
 ./local_wells.sh
+
+echo "Environment variables (including your password) will not persist after this terminal is closed"

--- a/tests/api-tests/local_run_all.sh
+++ b/tests/api-tests/local_run_all.sh
@@ -1,13 +1,23 @@
 #!/bin/sh
 #
-# Run all api (newman/postman) tests locally.
-source ./.envrc
 set -e
 
-./local_aquifers.sh
-./local_registries.sh
-./local_submissions.sh
-./local_wells_search.sh
-./local_wells.sh
+currentFile=$(basename "$0")
+
+if [ -f "./.envrc" ]; then
+  source ./.envrc
+fi
+
+for file in local_*.sh; do
+  if [ "$file" == "$currentFile" ]; then
+    continue
+  elif [ -x "$file" ]; then
+    "./$file"
+  else
+    echo "$file can't be executed, check your file permissions 'ls -al'"
+    echo "Abandoning Tests"
+    exit
+  fi
+done
 
 echo "Environment variables (including your password) will not persist after this terminal is closed"

--- a/tests/api-tests/local_submissions.sh
+++ b/tests/api-tests/local_submissions.sh
@@ -15,8 +15,9 @@
 
 
 # Load ENVs to environment if not already present
-if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./envrc"]; then
-  ./envrc
+if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./.envrc" ]; then
+  source ./.envrc
+  set -e
 fi
 
 ENV_VARS=(

--- a/tests/api-tests/local_submissions.sh
+++ b/tests/api-tests/local_submissions.sh
@@ -14,6 +14,11 @@
 #     ./local_newman.sh
 
 
+# Load ENVs to environment if not already present
+if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./envrc"]; then
+  ./envrc
+fi
+
 ENV_VARS=(
     "GWELLS_API_TEST_USER"
     "GWELLS_API_TEST_PASSWORD"

--- a/tests/api-tests/local_wells.sh
+++ b/tests/api-tests/local_wells.sh
@@ -13,7 +13,10 @@
 # - Run script:
 #     ./local_newman.sh
 
-
+# Load ENVs to environment if not already present
+if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./envrc"]; then
+  ./envrc
+fi
 
 ENV_VARS=(
     "GWELLS_API_TEST_USER"
@@ -23,6 +26,8 @@ ENV_VARS=(
     "GWELLS_API_TEST_CLIENT_ID"
     "GWELLS_API_TEST_CLIENT_SECRET"
 )
+
+echo "Running local_wells.sh"
 
 for env_var in ${ENV_VARS[@]}
 do

--- a/tests/api-tests/local_wells.sh
+++ b/tests/api-tests/local_wells.sh
@@ -14,8 +14,9 @@
 #     ./local_newman.sh
 
 # Load ENVs to environment if not already present
-if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./envrc"]; then
-  ./envrc
+if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./.envrc" ]; then
+  source ./.envrc
+  set -e
 fi
 
 ENV_VARS=(

--- a/tests/api-tests/local_wells_search.sh
+++ b/tests/api-tests/local_wells_search.sh
@@ -9,8 +9,9 @@
 #     ./local_wells_search.sh
 
 # Load ENVs to environment if not already present
-if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./envrc"]; then
-  ./envrc
+if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./.envrc" ]; then
+  source ./.envrc
+  set -e
 fi
 
 ENV_VARS=(

--- a/tests/api-tests/local_wells_search.sh
+++ b/tests/api-tests/local_wells_search.sh
@@ -8,10 +8,24 @@
 # - Run script:
 #     ./local_wells_search.sh
 
-if [ -z $GWELLS_API_BASE_URL ]; then
-    echo "GWELLS_API_BASE_URL is unset"
-    exit
+# Load ENVs to environment if not already present
+if [ -z "$GWELLS_API_TEST_USER" ] && [ -f "./envrc"]; then
+  ./envrc
 fi
+
+ENV_VARS=(
+    "GWELLS_API_BASE_URL"
+)
+
+echo "Running local_wells.sh"
+
+for env_var in ${ENV_VARS[@]}
+do
+    if [ -z ${!env_var+x} ]; then
+        echo "$env_var is unset"
+        exit
+    fi
+done
 
 echo "Remember to install newman (npm install -g newman) and set GWELLS_API_BASE_URL."
 newman run ./wells_search_api_tests.json --global-var base_url=$GWELLS_API_BASE_URL

--- a/tests/api-tests/runnewman.sh
+++ b/tests/api-tests/runnewman.sh
@@ -1,3 +1,0 @@
-export GWELLS_API_BASE_URL="https://gwells-dev.pathfinder.gov.bc.ca/gwells/registries"
-export GWELLS_API_TEST_USER="<secret>"
-export GWELLS_API_TEST_PASSWORD="<secret>"

--- a/tests/api-tests/wells_search_api_tests.json
+++ b/tests/api-tests/wells_search_api_tests.json
@@ -2245,7 +2245,7 @@
 										"exec": [
 											"pm.test(\"Street address matches filter\", function () {",
 											"  const streetAddress = pm.request.url.query.get(\"street_address\").toLowerCase();",
-											"const decodedStreetAddress = decodeURIComponent(streetAddress",
+											"const decodedStreetAddress = decodeURIComponent(streetAddress)",
 											"  pm.response.json().results.forEach(function(result) {",
 											"    pm.expect(result.street_address.toLowerCase()).to.include(decodedStreetAddress);",
 											"  });",

--- a/tests/api-tests/wells_search_api_tests.json
+++ b/tests/api-tests/wells_search_api_tests.json
@@ -2245,9 +2245,9 @@
 										"exec": [
 											"pm.test(\"Street address matches filter\", function () {",
 											"  const streetAddress = pm.request.url.query.get(\"street_address\").toLowerCase();",
-											"",
+											"const decodedStreetAddress = decodeURIComponent(streetAddress",
 											"  pm.response.json().results.forEach(function(result) {",
-											"    pm.expect(result.street_address.toLowerCase()).to.include(streetAddress);",
+											"    pm.expect(result.street_address.toLowerCase()).to.include(decodedStreetAddress);",
 											"  });",
 											"});"
 										],

--- a/tests/api-tests/wells_search_v2_api_tests.json
+++ b/tests/api-tests/wells_search_v2_api_tests.json
@@ -143,8 +143,9 @@
 								"exec": [
 									"pm.test(\"Street address matches filter\", function () {",
 									"  const streetAddress = pm.request.url.query.get(\"search\").toLowerCase();",
+									" const decodedAddress = decodeURIComponent(streetAddress);",
 									"  pm.response.json().results.forEach(function(result) {",
-									"    pm.expect(result.street_address.toLowerCase()).to.include(streetAddress);",
+									"    pm.expect(result.street_address.toLowerCase()).to.include(decodedAddress);",
 									"  });",
 									"});"
 								],
@@ -185,8 +186,9 @@
 								"exec": [
 									"pm.test(\"City matches filter\", function () {",
 									"  const city = pm.request.url.query.get(\"search\").toLowerCase();",
+									"  const decodedCity = decodeURIComponent(city);",
 									"  pm.response.json().results.forEach(function(result) {",
-									"    pm.expect(result.city.toLowerCase()).to.include(city);",
+									"    pm.expect(result.city.toLowerCase()).to.include(decodedCity);",
 									"  });",
 									"});"
 								],
@@ -227,8 +229,9 @@
 								"exec": [
 									"pm.test(\"Owner matches filter\", function () {",
 									"  const ownerFullName = pm.request.url.query.get(\"search\").toLowerCase();",
+									"  const decodedOwnerName = decodeURIComponent(ownerFullName);",
 									"  pm.response.json().results.forEach(function(result) {",
-									"    pm.expect(result.owner_full_name.toLowerCase()).to.include(ownerFullName);",
+									"    pm.expect(result.owner_full_name.toLowerCase()).to.include(decodedOwnerName);",
 									"  });",
 									"});"
 								],
@@ -389,8 +392,9 @@
 										"exec": [
 											"pm.test(\"Street address matches filter\", function () {",
 											"  const streetAddress = pm.request.url.query.get(\"street_address_or_city\").toLowerCase();",
+											"  const decodedStreetAddress = decodeURIComponent(streetAddress)",
 											"  pm.response.json().results.forEach(function(result) {",
-											"    pm.expect(result.street_address.toLowerCase()).to.include(streetAddress);",
+											"    pm.expect(result.street_address.toLowerCase()).to.include(decodedStreetAddress);",
 											"  });",
 											"});"
 										],
@@ -431,8 +435,9 @@
 										"exec": [
 											"pm.test(\"City matches filter\", function () {",
 											"  const city = pm.request.url.query.get(\"street_address_or_city\").toLowerCase();",
+											"  const decodedCity = decodeURIComponent(city)",
 											"  pm.response.json().results.forEach(function(result) {",
-											"    pm.expect(result.city.toLowerCase()).to.include(city);",
+											"    pm.expect(result.city.toLowerCase()).to.include(decodedCity);",
 											"  });",
 											"});"
 										],
@@ -2287,9 +2292,10 @@
 										"exec": [
 											"pm.test(\"Street address matches filter\", function () {",
 											"  const streetAddress = pm.request.url.query.get(\"street_address\").toLowerCase();",
+											"  const decodedStreetAddress = decodeURIComponent(streetAddress)",
 											"",
 											"  pm.response.json().results.forEach(function(result) {",
-											"    pm.expect(result.street_address.toLowerCase()).to.include(streetAddress);",
+											"    pm.expect(result.street_address.toLowerCase()).to.include(decodedStreetAddress);",
 											"  });",
 											"});"
 										],
@@ -2330,8 +2336,9 @@
 										"exec": [
 											"pm.test(\"Owner matches filter\", function () {",
 											"  const ownerFullName = pm.request.url.query.get(\"owner_full_name\").toLowerCase();",
+											"  const decodedOwnerName = decodeURIComponent(ownerFullName)",
 											"  pm.response.json().results.forEach(function(result) {",
-											"    pm.expect(result.owner_full_name.toLowerCase()).to.include(ownerFullName);",
+											"    pm.expect(result.owner_full_name.toLowerCase()).to.include(decodedOwnerName);",
 											"  });",
 											"});"
 										],
@@ -2372,8 +2379,9 @@
 										"exec": [
 											"pm.test(\"Company name matches filter\", function () {",
 											"  const companyNameQuery = pm.request.url.query.get(\"company_of_person_responsible_name\").toLowerCase();",
+											"  const decodedCompanyNameQuery = decodeURIComponent(companyNameQuery)",
 											"  pm.response.json().results.forEach(function(result) {",
-											"    pm.expect(result.company_of_person_responsible_name.toLowerCase()).to.include(companyNameQuery);",
+											"    pm.expect(result.company_of_person_responsible_name.toLowerCase()).to.include(decodedCompanyNameQuery);",
 											"  });",
 											"});"
 										],
@@ -2414,8 +2422,9 @@
 										"exec": [
 											"pm.test(\"Company name matches filter\", function () {",
 											"  const personNameQuery = pm.request.url.query.get(\"person_responsible_name\").toLowerCase();",
+											"  const decodedPersonNameQuery = decodeURIComponent(personNameQuery);",
 											"  pm.response.json().results.forEach(function(result) {",
-											"    pm.expect(result.person_responsible_name.toLowerCase()).to.include(personNameQuery);",
+											"    pm.expect(result.person_responsible_name.toLowerCase()).to.include(decodedPersonNameQuery);",
 											"  });",
 											"});"
 										],
@@ -2456,8 +2465,9 @@
 										"exec": [
 											"pm.test(\"Well location description matches filter\", function () {",
 											"  const wellLocationDesc = pm.request.url.query.get(\"well_location_description\");",
+											"  const decodedWellLocationDesc = decodeURIComponent(wellLocationDesc)",
 											"  pm.response.json().results.forEach(function(result) {",
-											"    pm.expect(result.well_location_description.toLowerCase()).to.include(wellLocationDesc);",
+											"    pm.expect(result.well_location_description.toLowerCase()).to.include(decodedWellLocationDesc);",
 											"  });",
 											"});"
 										],
@@ -2710,9 +2720,10 @@
 										"exec": [
 											"pm.test(\"Drilling method matches filter\", function () {",
 											"  const drillingMethod = pm.request.url.query.get(\"drilling_methods\");",
+											"  const decodedDrillingMethod = decodeURIComponent(drillingMethod)",
 											"",
 											"  pm.response.json().results.forEach(function(result) {",
-											"    pm.expect(result.drilling_methods).to.include(drillingMethod);",
+											"    pm.expect(result.drilling_methods).to.include(decodedDrillingMethod);",
 											"  });",
 											"});"
 										],
@@ -3160,7 +3171,7 @@
 					"response": []
 				},
 				{
-					"name": "ordering param (on consturction start date ascending)",
+					"name": "ordering param (on construction start date ascending)",
 					"event": [
 						{
 							"listen": "test",


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Updated Makefile to run API tests locally with "make api-tests-local"
    - Command can run individual tests suites with additional arg `TEST_FILE=<testfile.sh>`
- Updated `local_run_all.sh` to do the following
    - Run all tests wild carded with `local_*.sh`.
    - Load in environment variables from `.envrc`
    - Stop if permissions fail on a file
- Update all test suites to run standalone (load env's if not already present)
- Update Wiki section on Testing
- Update README in api-tests.
- Modified the test suites to use `decodeURIComponent()` on values. This was causing tests to fail locally that would pass in Jenkins (%20 taking the place if whitespace in comparisons).

**All tests now pass locally AND in Jenkins** *(previously only Jenkins)*

![image](https://github.com/bcgov/gwells/assets/62873746/c6e1d7f1-bc26-49fe-a3ae-a607d5fe141f)

