### PR TITLE
[BUG][GWELLS-2173] temporary fix for aquifer reversion from bulk updates

### DIFF
--- a/app/backend/gwells/views/bulk.py
+++ b/app/backend/gwells/views/bulk.py
@@ -97,29 +97,51 @@ class BulkWellAquiferCorrelation(APIView):
                     # If the correlation is changing — check if the well is inside the aquifer
                     self.check_well_in_aquifer(well, aquifer)
 
-                if existing_aquifer_id == aquifer_id: # this well correlation is unchanged
+                #NOTE: This represents the intended behavior but it is temporarilly blocking a fix
+                # if existing_aquifer_id == aquifer_id: # this well correlation is unchanged
+                #     change = {
+                #         'action': 'same'
+                #     }
+                # else:
+                #     if existing_aquifer_id is None:
+                #         # No existing aquifer for this well? Must be a new correlation
+                #         self.append_to_change_log(well_tag_number, aquifer_id, None)
+                #         change = {
+                #             'action': 'new',
+                #             'aquiferId': aquifer_id
+                #         }
+                #         wells_to_update.append(well)
+                #         self.append_to_change_log_activity_submission(well_tag_number, aquifer_id)
+                #     elif existing_aquifer_id != aquifer_id: # existing ids don't match - must be a change
+                #         self.append_to_change_log(well_tag_number, aquifer_id, existing_aquifer_id)
+                #         change = {
+                #             'action': 'update',
+                #             'existingAquiferId': existing_aquifer_id,
+                #             'newAquiferId': aquifer_id
+                #         }
+                #         self.append_to_change_log_activity_submission(well_tag_number, aquifer_id)
+                #         wells_to_update.append(well)
+
+                #START: Temporary fix for aquifer reversion from bulk updates
+                if existing_aquifer_id is None:
+                    # No existing aquifer for this well? Must be a new correlation
+                    self.append_to_change_log(well_tag_number, aquifer_id, None)
                     change = {
-                        'action': 'same'
+                        'action': 'new',
+                        'aquiferId': aquifer_id
                     }
-                else:
-                    if existing_aquifer_id is None:
-                        # No existing aquifer for this well? Must be a new correlation
-                        self.append_to_change_log(well_tag_number, aquifer_id, None)
-                        change = {
-                            'action': 'new',
-                            'aquiferId': aquifer_id
-                        }
-                        wells_to_update.append(well)
-                        self.append_to_change_log_activity_submission(well_tag_number, aquifer_id)
-                    elif existing_aquifer_id != aquifer_id: # existing ids don't match - must be a change
-                        self.append_to_change_log(well_tag_number, aquifer_id, existing_aquifer_id)
-                        change = {
-                            'action': 'update',
-                            'existingAquiferId': existing_aquifer_id,
-                            'newAquiferId': aquifer_id
-                        }
-                        self.append_to_change_log_activity_submission(well_tag_number, aquifer_id)
-                        wells_to_update.append(well)
+                    wells_to_update.append(well)
+                    self.append_to_change_log_activity_submission(well_tag_number, aquifer_id)
+                else: 
+                    self.append_to_change_log(well_tag_number, aquifer_id, existing_aquifer_id)
+                    change = {
+                        'action': 'update',
+                        'existingAquiferId': existing_aquifer_id,
+                        'newAquiferId': aquifer_id
+                    }
+                    self.append_to_change_log_activity_submission(well_tag_number, aquifer_id)
+                    wells_to_update.append(well)
+                #END: Temporary fix
 
                 if change:
                     changes[well_tag_number] = change


### PR DESCRIPTION
To address ticket #2108 , we recommended that all bulk updates be rerun, in order for the fix to take place (adding entries in activity_submissions and fields_provided). However, we did not account for the fact that redoing bulk updates would skip updating wells where the reversion had NOT YET occurred.

## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

changed views/bulk.py to NOT ignore wells where the aquifer is NOT changing. This will make it so redoing bulk updates will fix the reversion.

This change should only be temporary and should be reverted once all historical bulk updates have been redone.
