### PR TITLE
[GWELLS-2176] FEATURE** Get Swagger Documentation running

### DIFF
--- a/app/backend/aquifers/change_history.py
+++ b/app/backend/aquifers/change_history.py
@@ -136,7 +136,7 @@ def get_aquifer_reversion_history(aquifer):
 
 def get_vertical_aquifer_extents_history(aquifer):
     """
-    Returns a list of this aquifer's vertical extent history changes
+    Returns a list of this aquifer's vertical extent history changes.
 
     returns a list:
         [{

--- a/app/backend/aquifers/views.py
+++ b/app/backend/aquifers/views.py
@@ -76,10 +76,11 @@ logger = logging.getLogger(__name__)
 
 class AquiferEditDetailsAPIViewV1(RetrieveAPIView):
     """List aquifers
-    get: return details of aquifers
+    get:
+    Returns details of an Aquifer matching aquifer_id after update.
     """
     permission_classes = (HasAquiferEditRole,)
-    swagger_schema = None
+    
     lookup_field = 'aquifer_id'
     serializer_class = serializers.AquiferEditDetailSerializerV1
 
@@ -94,8 +95,14 @@ class AquiferEditDetailsAPIViewV1(RetrieveAPIView):
 
 class AquiferRetrieveUpdateAPIView(RevisionMixin, AuditUpdateMixin, RetrieveUpdateAPIView):
     """List aquifers
-    get: return details of aquifers
-    patch: update aquifer
+    get:
+    Returns full set of details about an aquifer matching the provided aquifer_id.
+
+    patch:
+    Updates an Aquifer.
+    
+    put:
+    Updates an Aquifer.
     """
     permission_classes = (HasAquiferEditRoleOrReadOnly,)
     queryset = Aquifer.objects.all()
@@ -202,8 +209,11 @@ class LargeResultsSetPagination(PageNumberPagination):
 
 class AquiferListCreateAPIView(RevisionMixin, AuditCreateMixin, ListCreateAPIView):
     """List aquifers
-    get: return a list of aquifers
-    post: create an aquifer
+    get:
+    Returns a list of aquifers.
+
+    post:
+    Create a new aquifer.
     """
     pagination_class = LargeResultsSetPagination
     permission_classes = (HasAquiferEditRoleOrReadOnly,)
@@ -237,80 +247,73 @@ class AquiferListCreateAPIView(RevisionMixin, AuditCreateMixin, ListCreateAPIVie
 
 
 class AquiferResourceSectionListAPIView(ListAPIView):
-    """List aquifer materials codes
-    get: return a list of aquifer material codes
+    """List aquifer materials codes.
+    get:
+    Returns a list of aquifer section codes.
     """
-
-    swagger_schema = None
     queryset = AquiferResourceSection.objects.all()
     serializer_class = serializers.AquiferResourceSectionSerializer
 
 
 class AquiferMaterialListAPIView(ListAPIView):
-    """List aquifer materials codes
-    get: return a list of aquifer material codes
+    """List aquifer materials codes.
+    get:
+    Returns a list of aquifer material codes.
     """
-    swagger_schema = None
     queryset = AquiferMaterial.objects.all()
     serializer_class = serializers.AquiferMaterialSerializer
 
 
 class QualityConcernListAPIView(ListAPIView):
-    """List aquifer materials codes
-    get: return a list of quality concern codes
+    """List aquifer materials codes.
+    get:
+    Returns a list of quality concern codes.
     """
-
-    swagger_schema = None
     queryset = models.QualityConcern.objects.all()
     serializer_class = serializers.QualityConcernSerializer
 
 
 class AquiferVulnerabilityListAPIView(ListAPIView):
-    """List aquifer vulnerability codes
-    get: return a list of aquifer vulnerability codes
+    """List aquifer vulnerability codes.
+    get:
+    Returns a list of aquifer vulnerability codes.
     """
-
-    swagger_schema = None
     queryset = AquiferVulnerabilityCode.objects.all()
     serializer_class = serializers.AquiferVulnerabilitySerializer
 
 
 class AquiferSubtypeListAPIView(ListAPIView):
-    """List aquifer subtypes codes
-    get: return a list of aquifer subtype codes
+    """List aquifer subtypes codes.
+    get:
+    Returns a list of aquifer subtype codes.
     """
-
-    swagger_schema = None
     queryset = AquiferSubtype.objects.all()
     serializer_class = serializers.AquiferSubtypeSerializer
 
 
 class AquiferProductivityListAPIView(ListAPIView):
-    """List aquifer productivity codes
-    get: return a list of aquifer productivity codes
+    """Returns a list of aquifer productivity codes.
+    get:
+    Returns a list of aquifer productivity codes.
     """
-
-    swagger_schema = None
     queryset = AquiferProductivity.objects.all()
     serializer_class = serializers.AquiferProductivitySerializer
 
 
 class AquiferDemandListAPIView(ListAPIView):
-    """List aquifer demand codes
-    get: return a list of aquifer demand codes
+    """List aquifer demand codes.
+    get:
+    Returns a list of aquifer demand codes.
     """
-
-    swagger_schema = None
     queryset = AquiferDemand.objects.all()
     serializer_class = serializers.AquiferDemandSerializer
 
 
 class WaterUseListAPIView(ListAPIView):
     """List Water Use Codes
-    get: return a list of water use codes
+    get:
+    Returns a list of water use codes.
     """
-
-    swagger_schema = None
     queryset = models.WaterUse.objects.all()
     serializer_class = serializers.WaterUseSerializer
 
@@ -319,7 +322,8 @@ class ListFiles(APIView):
     """
     List documents associated with an aquifer
 
-    get: list files found for the aquifer identified in the uri
+    get:
+    List files found for the aquifer identified in the URI.
     """
 
     @swagger_auto_schema(responses={200: openapi.Response(
@@ -355,12 +359,12 @@ class ListFiles(APIView):
 
 
 class AquiferNameList(ListAPIView):
-    """ List all aquifers in a simplified format """
+    """ List all aquifers in a simplified format. """
 
     serializer_class = serializers.AquiferSerializerBasic
     model = Aquifer
     pagination_class = None
-    swagger_schema = None
+    
     filter_backends = (filters.SearchFilter,)
     ordering = ('aquifer_id',)
     search_fields = (
@@ -388,16 +392,17 @@ class AquiferNameList(ListAPIView):
 
 class AquiferHistory(APIView):
     """
-    get: returns a history of changes to a Aquifer model record
+    get:
+    returns a history of changes to a Aquifer model record
     """
     permission_classes = (HasAquiferEditRole,)
     queryset = Aquifer.objects.all()
-    swagger_schema = None
+    
 
     def get(self, request, aquifer_id, **kwargs):
         """
-        Retrieves version history for the specified Aquifer record and creates a list of diffs
-        for each revision.
+        get:
+        Retrieves version history for the specified Aquifer record and creates a list of diffs for each revision.
         """
 
         try:
@@ -414,7 +419,8 @@ class PreSignedDocumentKey(APIView):
     """
     Get a pre-signed document key to upload into an S3 compatible document store
 
-    post: obtain a URL that is pre-signed to allow client-side uploads
+    post:
+    Obtain a URL that is pre-signed to allow client-side uploads.
     """
 
     permission_classes = (HasAquiferEditRole,)
@@ -442,9 +448,10 @@ class PreSignedDocumentKey(APIView):
 
 class DeleteAquiferDocument(APIView):
     """
-    Delete a document from a S3 compatible store
+    Delete a document from a S3 compatible store.
 
-    delete: remove the specified object from the S3 store
+    delete:
+    Remove the specified object from the S3 store.
     """
 
     permission_classes = (HasAquiferEditRole,)

--- a/app/backend/aquifers/views_v2.py
+++ b/app/backend/aquifers/views_v2.py
@@ -49,13 +49,12 @@ from aquifers.permissions import HasAquiferEditRole, HasAquiferEditRoleOrReadOnl
 
 logger = logging.getLogger(__name__)
 
-
 class AquiferEditDetailsAPIViewV2(RetrieveAPIView):
     """Get aquifer
-    get: return details of aquifers
+    get:
+    Return details of aquifers
     """
     permission_classes = (HasAquiferEditRole,)
-    swagger_schema = None
     lookup_field = 'aquifer_id'
     serializer_class = serializers_v2.AquiferEditDetailSerializerV2
 
@@ -70,10 +69,12 @@ class AquiferEditDetailsAPIViewV2(RetrieveAPIView):
 
 class AquiferRetrieveUpdateAPIViewV2(RevisionMixin, AuditUpdateMixin, RetrieveUpdateAPIView):
     """Get aquifer
-    get: return details of aquifers
-    patch: update aquifer
+    get:
+    Return details of aquifers.
+    
+    patch:
+    Update aquifer fields with new information.
     """
-    swagger_schema = None
     permission_classes = (HasAquiferEditRoleOrReadOnly,)
     lookup_field = 'aquifer_id'
 
@@ -205,10 +206,12 @@ class LargeResultsSetPagination(PageNumberPagination):
 
 class AquiferListCreateAPIViewV2(RevisionMixin, AuditCreateMixin, ListCreateAPIView):
     """List aquifers
-    get: return a list of aquifers
-    post: create an aquifer
+    get:
+    Returns a list of aquifers.
+    
+    post:
+    Creates a new aquifer.
     """
-    swagger_schema = None
     pagination_class = LargeResultsSetPagination
     permission_classes = (HasAquiferEditRoleOrReadOnly,)
     filter_backends = (djfilters.DjangoFilterBackend,
@@ -247,9 +250,10 @@ class AquiferListCreateAPIViewV2(RevisionMixin, AuditCreateMixin, ListCreateAPIV
 
 
 class AquiferNameListV2(ListAPIView):
-    """ List all aquifers in a simplified format """
-
-    swagger_schema = None
+    """
+    post:
+    List all aquifers in a simplified format.
+    """
     serializer_class = serializers.AquiferSerializerBasic
     model = Aquifer
     queryset = Aquifer.objects.all()

--- a/app/backend/gwells/views/__init__.py
+++ b/app/backend/gwells/views/__init__.py
@@ -68,10 +68,10 @@ class HealthView(TemplateView):
 
 class SurveyListCreateView(ListCreateAPIView):
     """
-    get: returns a list of active surveys
+    get:
+    Returns a list of active surveys.
     """
 
-    swagger_schema = None
     serializer_class = SurveySerializer
     queryset = Survey.objects.all()
     pagination_class = None
@@ -87,8 +87,7 @@ class SurveyListCreateView(ListCreateAPIView):
 
 
 class SurveyUpdateDeleteView(RetrieveUpdateDestroyAPIView):
-    """ handles updating and deleting of surveys """
-    swagger_schema = None
+    """ Handler for updating and deleting surveys. """
     serializer_class = SurveySerializer
     queryset = Survey.objects.all()
     pagination_class = None

--- a/app/backend/gwells/views/api.py
+++ b/app/backend/gwells/views/api.py
@@ -2,6 +2,7 @@ import requests
 import geojson
 from geojson import Feature, FeatureCollection, Point
 from drf_yasg.utils import swagger_auto_schema
+from drf_yasg import openapi
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from django.http import JsonResponse, HttpResponse
@@ -11,9 +12,7 @@ from gwells.settings.base import get_env_variable
 from gwells.utils import isPointInsideBC
 
 class KeycloakConfig(APIView):
-    """ serves keycloak config """
-
-    swagger_schema = None
+    """ Serves configuration object for Keycloak. """
 
     def get(self, request, **kwargs):
         config = {
@@ -29,9 +28,7 @@ class KeycloakConfig(APIView):
 
 
 class GeneralConfig(APIView):
-    """ serves general configuration """
-
-    swagger_schema = None
+    """ Serves general configuration object. """
 
     def get(self, request, **kwargs):
         config = {
@@ -42,9 +39,7 @@ class GeneralConfig(APIView):
 
 
 class AnalyticsConfig(APIView):
-    """ serves analytics config """
-
-    swagger_schema = None
+    """ Serves configuration object for Google analytics. """  
     
     def get(self, request, **kwargs):
         config = {
@@ -54,10 +49,23 @@ class AnalyticsConfig(APIView):
 
 
 class InsideBC(APIView):
-    """ Check if a given point is inside BC """
-    
-    swagger_schema = None
-    
+    """ Check if a given Latitude/Longitude are inside BC """
+    @swagger_auto_schema(
+        manual_parameters =[
+            openapi.Parameter(
+                name='longitude',
+                in_=openapi.IN_QUERY,
+                type=openapi.TYPE_NUMBER,
+                description="Longitude Coordinate"
+            ),
+            openapi.Parameter(
+                name='latitude',
+                in_=openapi.IN_QUERY,
+                type=openapi.TYPE_NUMBER,
+                description="Latitude Coordinate"
+            )
+        ]
+    )
     def get(self, request, **kwargs):
         latitude = request.query_params.get('latitude')
         longitude = request.query_params.get('longitude')

--- a/app/backend/registries/urls.py
+++ b/app/backend/registries/urls.py
@@ -17,12 +17,13 @@ from rest_framework.documentation import include_docs_urls
 from drf_yasg.views import get_schema_view
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
-
+import os
 from registries import permissions
 from . import views
 from . import views_v2
 from gwells.urls import api_path_prefix
-
+LOCAL = os.environ.get('LOCAL', False)
+API_URL = 'http://localhost:8000/gwells/' if LOCAL else 'https://apps.nrs.gov.bc.ca/gwells/'
 schema_view = get_schema_view(
     openapi.Info(
         title="Groundwater Wells, Aquifers and Registry API",
@@ -35,8 +36,8 @@ schema_view = get_schema_view(
         license=openapi.License(name="Open Government License - British Columbia",
                                 url="https://www2.gov.bc.ca/gov/content?id=A519A56BC2BF44E4A008B33FCF527F61"),
     ),
-    url='https://apps.nrs.gov.bc.ca/gwells/',
-    public=False,
+    url=API_URL,
+    public=LOCAL,
     permission_classes=(permissions.RegistriesEditOrReadOnly,)
 )
 

--- a/app/backend/registries/views.py
+++ b/app/backend/registries/views.py
@@ -82,10 +82,10 @@ from gwells.views import AuditCreateMixin, AuditUpdateMixin
 class OrganizationListView(RevisionMixin, AuditCreateMixin, ListCreateAPIView):
     """
     get:
-    Returns a list of all registered drilling organizations
+    Returns a list of all registered drilling organizations.
 
     post:
-    Creates a new drilling organization record
+    Creates a new drilling organization record.
     """
 
     permission_classes = (RegistriesEditPermissions,)
@@ -116,16 +116,16 @@ class OrganizationListView(RevisionMixin, AuditCreateMixin, ListCreateAPIView):
 class OrganizationDetailView(RevisionMixin, AuditUpdateMixin, RetrieveUpdateDestroyAPIView):
     """
     get:
-    Returns the specified drilling organization
+    Returns the specified drilling organization.
 
     put:
-    Replaces the specified record with a new one
+    Replaces the specified record with a new one.
 
     patch:
-    Updates a drilling organization with the fields/values provided in the request body
+    Updates a drilling organization with the fields/values provided in the request body.
 
     delete:
-    Removes the specified drilling organization record
+    Removes the specified drilling organization record.
     """
 
     permission_classes = (RegistriesEditPermissions,)
@@ -452,10 +452,10 @@ def exclude_persons_without_registrations(request, filtered_queryset, statuses_t
 class PersonListView(RevisionMixin, AuditCreateMixin, ListCreateAPIView):
     """
     get:
-    Returns a list of all person records
+    Returns a list of all person records.
 
     post:
-    Creates a new person record
+    Creates a new person record.
     """
 
     permission_classes = (RegistriesEditOrReadOnly,)
@@ -509,16 +509,16 @@ class PersonListView(RevisionMixin, AuditCreateMixin, ListCreateAPIView):
 class PersonDetailView(RevisionMixin, AuditUpdateMixin, RetrieveUpdateDestroyAPIView):
     """
     get:
-    Returns the specified person
+    Returns the specified person.
 
     put:
-    Replaces the specified person record with a new one
+    Replaces the specified person record with a new one.
 
     patch:
-    Updates a person with the fields/values provided in the request body
+    Updates a person with the fields/values provided in the request body.
 
     delete:
-    Removes the specified person record
+    Removes the specified person record.
     """
 
     permission_classes = (RegistriesEditPermissions,)
@@ -568,14 +568,14 @@ class PersonDetailView(RevisionMixin, AuditUpdateMixin, RetrieveUpdateDestroyAPI
 
 class CitiesListView(ListAPIView):
     """
-    List of cities with a qualified, registered operator (driller or installer)
+    List of cities with a qualified, registered operator (driller or installer).
 
-    get: returns a list of cities with a qualified, registered operator (driller or installer)
+    get:
+    Returns a list of cities with a qualified, registered operator (driller or installer).
     """
     serializer_class = CityListSerializer
     lookup_field = 'register_guid'
     pagination_class = None
-    swagger_schema = None
     permission_classes = (RegistriesEditOrReadOnly,)
     queryset = Register.objects \
         .exclude(organization__city__isnull=True) \
@@ -607,10 +607,10 @@ class CitiesListView(ListAPIView):
 class RegistrationListView(RevisionMixin, AuditCreateMixin, ListCreateAPIView):
     """
     get:
-    List all registration records
+    List all registration records.
 
     post:
-    Create a new well driller or well pump installer registration record for a person
+    Create a new well driller or well pump installer registration record for a person.
     """
 
     permission_classes = (RegistriesEditPermissions,)
@@ -634,16 +634,16 @@ class RegistrationListView(RevisionMixin, AuditCreateMixin, ListCreateAPIView):
 class RegistrationDetailView(RevisionMixin, AuditUpdateMixin, RetrieveUpdateDestroyAPIView):
     """
     get:
-    Returns a well driller or well pump installer registration record
+    Returns a well driller or well pump installer registration record.
 
     put:
-    Replaces a well driller or well pump installer registration record with a new one
+    Replaces a well driller or well pump installer registration record with a new one.
 
     patch:
-    Updates a registration record with new values
+    Updates a registration record with new values.
 
     delete:
-    Removes the specified registration record from the database
+    Removes the specified registration record from the database.
     """
 
     permission_classes = (RegistriesEditPermissions,)
@@ -668,10 +668,10 @@ class RegistrationDetailView(RevisionMixin, AuditUpdateMixin, RetrieveUpdateDest
 class ApplicationListView(RevisionMixin, AuditCreateMixin, ListCreateAPIView):
     """
     get:
-    Returns a list of all registration applications
+    Returns a list of all registration applications.
 
     post:
-    Creates a new registries application
+    Creates a new registries application.
     """
 
     permission_classes = (RegistriesEditPermissions,)
@@ -686,16 +686,16 @@ class ApplicationListView(RevisionMixin, AuditCreateMixin, ListCreateAPIView):
 class ApplicationDetailView(RevisionMixin, AuditUpdateMixin, RetrieveUpdateDestroyAPIView):
     """
     get:
-    Returns the specified drilling application
+    Returns the specified drilling application.
 
     put:
-    Replaces the specified record with a new one
+    Replaces the specified record with a new one.
 
     patch:
-    Updates a drilling application with the set of values provided in the request body
+    Updates a drilling application with the set of values provided in the request body.
 
     delete:
-    Removes the specified drilling application record
+    Removes the specified drilling application record.
     """
 
     permission_classes = (RegistriesEditPermissions,)
@@ -710,7 +710,7 @@ class ApplicationDetailView(RevisionMixin, AuditUpdateMixin, RetrieveUpdateDestr
 
 class OrganizationNameListView(ListAPIView):
     """
-    A list of organizations with only organization names
+    A list of organizations with only organization names.
     """
     permission_classes = (RegistriesEditOrReadOnly,)
     serializer_class = OrganizationNameListSerializer
@@ -718,7 +718,6 @@ class OrganizationNameListView(ListAPIView):
         .select_related('province_state')
     pagination_class = None
     lookup_field = 'organization_guid'
-    swagger_schema = None
 
     def get_queryset(self):
         return self.queryset.filter(expiry_date__gt=timezone.now())
@@ -727,15 +726,14 @@ class OrganizationNameListView(ListAPIView):
 class PersonNoteListView(AuditCreateMixin, ListCreateAPIView):
     """
     get:
-    Returns notes associated with a Person record
+    Returns notes associated with a Person record.
 
     post:
-    Adds a note record to the specified Person record
+    Adds a note record to the specified Person record.
     """
 
     permission_classes = (RegistriesEditPermissions,)
     serializer_class = PersonNoteSerializer
-    swagger_schema = None
 
     def get_queryset(self):
         person = self.kwargs['person_guid']
@@ -753,21 +751,20 @@ class PersonNoteListView(AuditCreateMixin, ListCreateAPIView):
 class PersonNoteDetailView(AuditUpdateMixin, RetrieveUpdateDestroyAPIView):
     """
     get:
-    Returns a PersonNote record
+    Returns a PersonNote record.
 
     put:
-    Replaces a PersonNote record with a new one
+    Replaces a PersonNote record with a new one.
 
     patch:
-    Updates a PersonNote record with the set of fields provided in the request body
+    Updates a PersonNote record with the set of fields provided in the request body.
 
     delete:
-    Removes a PersonNote record
+    Removes a PersonNote record.
     """
 
     permission_classes = (RegistriesEditPermissions,)
     serializer_class = PersonNoteSerializer
-    swagger_schema = None
 
     def get_queryset(self):
         person = self.kwargs['person']
@@ -777,15 +774,14 @@ class PersonNoteDetailView(AuditUpdateMixin, RetrieveUpdateDestroyAPIView):
 class OrganizationNoteListView(AuditCreateMixin, ListCreateAPIView):
     """
     get:
-    Returns notes associated with a Organization record
+    Returns notes associated with a Organization record.
 
     post:
-    Adds a note record to the specified Organization record
+    Adds a note record to the specified Organization record.
     """
 
     permission_classes = (RegistriesEditPermissions,)
     serializer_class = OrganizationNoteSerializer
-    swagger_schema = None
 
     def get_queryset(self):
         org = self.kwargs['org_guid']
@@ -803,21 +799,20 @@ class OrganizationNoteListView(AuditCreateMixin, ListCreateAPIView):
 class OrganizationNoteDetailView(AuditUpdateMixin, RetrieveUpdateDestroyAPIView):
     """
     get:
-    Returns a OrganizationNote record
+    Returns a OrganizationNote record.
 
     put:
-    Replaces a OrganizationNote record with a new one
+    Replaces a OrganizationNote record with a new one.
 
     patch:
-    Updates a OrganizationNote record with the set of fields provided in the request body
+    Updates a OrganizationNote record with the set of fields provided in the request body.
 
     delete:
-    Removes a OrganizationNote record
+    Removes a OrganizationNote record.
     """
 
     permission_classes = (RegistriesEditPermissions,)
     serializer_class = OrganizationNoteSerializer
-    swagger_schema = None
 
     def get_queryset(self):
         org = self.kwargs['org_guid']
@@ -826,12 +821,12 @@ class OrganizationNoteDetailView(AuditUpdateMixin, RetrieveUpdateDestroyAPIView)
 
 class OrganizationHistory(APIView):
     """
-    get: returns a history of changes to an Organization model record
+    get:
+    Returns a history of changes to an Organization model record.
     """
 
     permission_classes = (RegistriesEditPermissions,)
     queryset = Organization.objects.all()
-    swagger_schema = None
 
     def get(self, request, org_guid, **kwargs):
         try:
@@ -850,17 +845,17 @@ class OrganizationHistory(APIView):
 
 class PersonHistory(APIView):
     """
-    get: returns a history of changes to a Person model record
+    get:
+    Returns a history of changes to a Person model record.
     """
 
     permission_classes = (RegistriesEditPermissions,)
     queryset = Person.objects.all()
-    swagger_schema = None
 
     def get(self, request, person_guid, **kwargs):
         """
-        Retrieves version history for the specified Person record and creates a list of diffs
-        for each revision.
+        get:
+        Retrieves version history for the specified Person record and creates a list of diffs for each revision.
         """
 
         try:
@@ -905,13 +900,12 @@ class PersonHistory(APIView):
 
 
 class PersonNameSearch(ListAPIView):
-    """Search for a person in the Register"""
+    """Search for a person in the Register."""
 
     permission_classes = (RegistriesEditOrReadOnly,)
     serializer_class = PersonNameSerializer
     pagination_class = None
     lookup_field = 'person_guid'
-    swagger_schema = None
 
     ordering = ('surname',)
 
@@ -923,12 +917,12 @@ class PersonNameSearch(ListAPIView):
 
 class ListFiles(APIView):
     """
-    List documents associated with a person in the Registry
+    List documents associated with a person in the Registry.
 
-    get: list files found for the person identified in the uri
+    get:
+    Returns list of files found for the person identified in the URI.
     """
 
-    swagger_schema = None
 
     def get(self, request, person_guid, **kwargs):
         user_is_staff = self.request.user.groups.filter(
@@ -947,12 +941,12 @@ class PreSignedDocumentKey(APIView):
     """
     Get a pre-signed document key to upload into an S3 compatible document store
 
-    post: obtain a URL that is pre-signed to allow client-side uploads
+    post:
+    Obtain a URL that is pre-signed to allow client-side uploads.
     """
 
     queryset = Person.objects.all()
     permission_classes = (RegistriesEditPermissions,)
-    swagger_schema = None
 
     def get(self, request, person_guid, **kwargs):
         person = get_object_or_404(self.queryset, pk=person_guid)
@@ -972,14 +966,14 @@ class PreSignedDocumentKey(APIView):
 
 class DeleteDrillerDocument(APIView):
     """
-    Delete a document from a S3 compatible store
+    Delete a document from a S3 compatible store.
 
-    delete: remove the specified object from the S3 store
+    delete:
+    Remove the specified object from the S3 store.
     """
 
     queryset = Person.objects.all()
     permission_classes = (RegistriesEditPermissions,)
-    swagger_schema = None
 
     def delete(self, request, person_guid, **kwargs):
         person = get_object_or_404(self.queryset, pk=person_guid)

--- a/app/backend/registries/views_v2.py
+++ b/app/backend/registries/views_v2.py
@@ -97,7 +97,6 @@ class CSVExportV2(ListAPIView):
     of DRF, because DRF doesn't have native CSV support.
     """
 
-    swagger_schema = None
     permission_classes = (RegistriesEditPermissions,)
 
     # Allow searching on name fields, names of related companies, etc.
@@ -146,7 +145,6 @@ class XLSXExportV2(ListAPIView):
     """
     Export the registry as XLSX.
     """
-    swagger_schema = None
     permission_classes = (RegistriesEditPermissions,)
 
     # Allow searching on name fields, names of related companies, etc.

--- a/app/backend/submissions/views.py
+++ b/app/backend/submissions/views.py
@@ -221,7 +221,7 @@ def propagate_submission_comments(request, separator="."):
 
 
 class SubmissionGetAPIView(RetrieveAPIView):
-    """Get a submission"""
+    """Get a submission."""
 
     permission_classes = (WellsSubmissionViewerPermissions,)
     queryset = ActivitySubmission.objects.all()
@@ -256,7 +256,8 @@ class SubmissionGetAPIView(RetrieveAPIView):
 class SubmissionListAPIView(ListAPIView):
     """List submissions
 
-    get: returns a list of well activity submissions
+    get:
+    Returns a list of well activity submissions.
     """
 
     permission_classes = (WellsSubmissionViewerPermissions,)
@@ -318,7 +319,7 @@ class SubmissionBase(AuditCreateMixin, ListCreateAPIView):
 
 
 class SubmissionConstructionAPIView(SubmissionBase):
-    """Create a construction submission"""
+    """Create a construction submission."""
 
     model = ActivitySubmission
     serializer_class = WellConstructionSubmissionSerializer
@@ -351,7 +352,7 @@ class SubmissionAlterationAPIView(SubmissionBase):
 
 
 class SubmissionDecommissionAPIView(SubmissionBase):
-    """Create a decommission submission"""
+    """Create a decommission submission."""
 
     model = ActivitySubmission
     serializer_class = WellDecommissionSubmissionSerializer
@@ -371,7 +372,7 @@ class SubmissionDecommissionAPIView(SubmissionBase):
 
 
 class SubmissionStaffEditAPIView(SubmissionBase):
-    """ Create a staff edit submission"""
+    """ Create a staff edit submission."""
     model = ActivitySubmission
     serializer_class = WellStaffEditSubmissionSerializer
     permission_classes = (WellsEditPermissions,)
@@ -390,9 +391,7 @@ class SubmissionStaffEditAPIView(SubmissionBase):
 
 
 class SubmissionsOptions(APIView):
-    """Options required for submitting activity report forms"""
-
-    swagger_schema = None
+    """Options required for submitting activity report forms."""
 
     def get(self, request, **kwargs):
         options = {}
@@ -544,7 +543,8 @@ class PreSignedDocumentKey(RetrieveAPIView):
     """
     Get a pre-signed document key to upload into an S3 compatible document store
 
-    post: obtain a URL that is pre-signed to allow client-side uploads
+    post:
+    Obtain a URL that is pre-signed to allow client-side uploads.
     """
 
     queryset = ActivitySubmission.objects.all()
@@ -576,7 +576,6 @@ class EmailNotification(APIView):
     """
     Send GWELLS team notification of anyone changing the GPS COORDS of a well flagged for drinking water.
     """
-    swagger_schema = None
     permission_classes = (WellsSubmissionPermissions,)
 
     def post(self, request, *args, **kwargs):

--- a/app/backend/wells/views.py
+++ b/app/backend/wells/views.py
@@ -100,14 +100,14 @@ from wells.serializers import (
 from wells.permissions import WellsEditPermissions, WellsEditOrReadOnly
 from wells.constants import MAX_EXPORT_COUNT, MAX_LOCATION_COUNT, WELL_TAGS
 
-
 logger = logging.getLogger(__name__)
 
 
 class WellDetail(RetrieveAPIView):
     """
     Return well detail.
-    This view is open to all, and has no permissions.
+    get:
+    Returns information about a well given the well_tag_number. Unpublished wells are filtered if user is not authenticated.
     """
     serializer_class = WellDetailSerializer
 
@@ -137,7 +137,8 @@ class ListExtracts(APIView):
     """
     List well extracts
 
-    get: list well extracts
+    get:
+    list well extracts
     """
     @swagger_auto_schema(auto_schema=None)
     def get(self, request, **kwargs):
@@ -200,7 +201,8 @@ class ListFiles(APIView):
     """
     List documents associated with a well (e.g. well construction report)
 
-    get: list files found for the well identified in the uri
+    get:
+    List uploaded files the well identified in the URI.
     """
 
     @swagger_auto_schema(responses={200: openapi.Response('OK', LIST_FILES_OK)})
@@ -224,6 +226,14 @@ class ListFiles(APIView):
         return Response(documents)
 
 class FileSumView(APIView):
+    """
+    Handler for Updating File counts for a well. Bridge method to keep database records for files stored in S3 buckets.
+    Primarily used for Advanced Search function 'Wells containing File of type n'
+
+    get:
+    Increments or decrements the count for files stored of a given type.
+    """
+    
     def get(self, request, tag, **kwargs):
         # Verify user has permissions to edit wells
         if not self.request.user.groups.filter(name=WELLS_EDIT_ROLE).exists():
@@ -267,7 +277,8 @@ class FileSumView(APIView):
 class WellListAPIViewV1(ListAPIView):
     """List and create wells
 
-    get: returns a list of wells
+    get:
+    Returns a list of wells.
     """
 
     permission_classes = (WellsEditOrReadOnly,)
@@ -310,14 +321,16 @@ class WellListAPIViewV1(ListAPIView):
 
 
 class WellTagSearchAPIView(ListAPIView):
-    """ seach for wells by tag or owner """
+    """
+    get:
+    Search for wells by tag or owner.
+    """
 
     permission_classes = (WellsEditOrReadOnly,)
     model = Well
     pagination_class = None
     serializer_class = WellTagSearchSerializer
     lookup_field = 'well_tag_number'
-    swagger_schema = None
 
     filter_backends = (filters.SearchFilter, filters.OrderingFilter)
     ordering_fields = ('well_tag_number',)
@@ -343,7 +356,9 @@ class WellTagSearchAPIView(ListAPIView):
 class WellSubmissionsListAPIView(ListAPIView):
     """ lists submissions for a well
         See also:  submissions.SubmissionListAPIView (list all submission records)
-        get: returns submission records for a given well
+
+        get:
+        Returns submission records for a given well.
     """
 
     permission_classes = (WellsEditPermissions,)
@@ -360,14 +375,14 @@ class WellSubmissionsListAPIView(ListAPIView):
 
 
 class WellLocationListAPIViewV1(ListAPIView):
-    """ returns well locations for a given search
+    """ Returns well locations for a given search.
 
-        get: returns a list of wells with locations only
+        get:
+        Returns a list of wells with locations only.
     """
     permission_classes = (WellsEditOrReadOnly,)
     model = Well
     serializer_class = WellLocationSerializerV1
-    swagger_schema = None
 
     # Allow searching on name fields, names of related companies, etc.
     filter_backends = (WellListFilterBackend, BoundingBoxFilterBackend,
@@ -388,7 +403,12 @@ class WellLocationListAPIViewV1(ListAPIView):
         return qs
 
     def get(self, request, **kwargs):
-        """ cancels request if too many wells are found"""
+        """
+        Cancels request if too many wells are found.
+        
+        get:
+        Returns compact set of well information data for populating the maps.
+        """
 
         qs = self.get_queryset()
         locations = self.filter_queryset(qs)
@@ -557,9 +577,10 @@ class WellExportListAPIViewV1(ListAPIView):
 
 class PreSignedDocumentKey(APIView):
     """
-    Get a pre-signed document key to upload into an S3 compatible document store
+    Get a pre-signed document key to upload into an S3 compatible document store.
 
-    post: obtain a URL that is pre-signed to allow client-side uploads
+    post:
+    Obtain a URL that is pre-signed to allow client-side uploads.
     """
 
     queryset = Well.objects.all()
@@ -590,9 +611,10 @@ class PreSignedDocumentKey(APIView):
 
 class DeleteWellDocument(APIView):
     """
-    Delete a document from a S3 compatible store
+    Delete a document from a S3 compatible store.
 
-    delete: remove the specified object from the S3 store
+    delete:
+    Remove the specified object from the S3 store.
     """
 
     queryset = Well.objects.all()
@@ -623,16 +645,16 @@ class DeleteWellDocument(APIView):
 
 class WellHistory(APIView):
     """
-    get: returns a history of changes to a Well model record
+    get:
+    Returns a history of changes to a Well model record.
     """
     permission_classes = (WellsEditPermissions,)
     queryset = Well.objects.all()
-    swagger_schema = None
 
     def get(self, request, well_id, **kwargs):
         """
-        Retrieves version history for the specified Well record and creates a list of diffs
-        for each revision.
+        get:
+        Retrieves version history for the specified Well record and creates a list of diffs for each revision.
         """
         try:
             well = Well.objects.get(well_tag_number=well_id)
@@ -821,12 +843,17 @@ def well_licensing(request, **kwargs):
 
 # Deprecated. Use WellSubsurface instead
 class WellScreens(ListAPIView):
-    """ returns well screen info for a range of wells """
+    """
+    Returns well screen info for a range of wells
+
+    get:
+    Returns a compact list of wells including screen_set fields
+    """
+
 
     model = Well
     serializer_class = WellDrawdownSerializer
     filter_backends = (GeometryFilterBackend, RadiusFilterBackend)
-    swagger_schema = None
 
     def get_queryset(self):
         qs = Well.objects.all() \
@@ -873,12 +900,16 @@ class WellScreens(ListAPIView):
 
 
 class WellLithology(ListAPIView):
-    """ returns lithology info for a range of wells """
+    """
+    Returns the lithologydescription_set information for a range of wells.
+    
+    get:
+    Returns list of wells with lat/long and lithologydescription_set information.
+    """    
 
     model = Well
     serializer_class = WellLithologySerializer
     filter_backends = (GeometryFilterBackend,)
-    swagger_schema = None
 
     def get_queryset(self):
         qs = Well.objects.all()
@@ -901,6 +932,12 @@ class WellLithology(ListAPIView):
 
         return qs
 class AddressGeocoder(APIView):
+    """
+    Address Autocomplete Request handler
+    
+    get:
+    Takes Partial Address Values and returns list of possible auto complete values
+    """
     def get(self, request,**kwargs):
         GEOCODER_ADDRESS_URL = get_env_variable('GEOCODER_ADDRESS_API_BASE') + self.request.query_params.get('searchTag')
         response = requests.get(GEOCODER_ADDRESS_URL)

--- a/app/backend/wells/views_v2.py
+++ b/app/backend/wells/views_v2.py
@@ -65,11 +65,11 @@ logger = logging.getLogger(__name__)
 
 
 class WellLocationListV2APIView(ListAPIView):
-    """ returns well locations for a given search
+    """ Returns well locations for a given search.
 
-        get: returns a list of wells with locations only
+        get:
+        Returns a list of wells with locations only.
     """
-    swagger_schema = None
     permission_classes = (WellsEditOrReadOnly,)
     model = Well
     pagination_class = apiLimitedPagination(MAX_LOCATION_COUNT)
@@ -179,9 +179,8 @@ class WellLocationListV2APIView(ListAPIView):
 
 class WellAquiferListV2APIView(ListAPIView):
     """
-    Returns a list of aquifers with depth information for a well
+    Returns a list of aquifers with depth information for a well.
     """
-    swagger_schema = None
     permission_classes = (HasAquiferEditRole,)
     ordering = ('start',)
     serializer_class = WellVerticalAquiferExtentSerializerV2
@@ -320,10 +319,10 @@ class WellAquiferListV2APIView(ListAPIView):
 class WellListAPIViewV2(ListAPIView):
     """List and create wells
 
-    get: returns a list of wells
+    get:
+    Returns a list of wells.
     """
 
-    swagger_schema = None
     permission_classes = (WellsEditOrReadOnly,)
     model = Well
     pagination_class = APILimitOffsetPagination
@@ -366,7 +365,6 @@ class WellListAPIViewV2(ListAPIView):
 class WellExportListAPIViewV2(ListAPIView):
     """Returns CSV or Excel data for wells.
     """
-    swagger_schema = None
     permission_classes = (WellsEditOrReadOnly,)
     model = Well
 
@@ -515,13 +513,16 @@ class WellExportListAPIViewV2(ListAPIView):
 
 
 class WellSubsurface(ListAPIView):
-    """ Returns well subsurface info within a gemoetry or a list of wells """
-    """ This replaces WellScreen with the additional aquifer and lithology info"""
+    """
+    This replaces WellScreen with the additional aquifer and lithology info
+    
+    get:
+    Returns well subsurface info within a geometry or a list of wells.
+    """
 
     model = Well
     serializer_class = WellSubsurfaceSerializer
     filter_backends = (GeometryFilterBackend, RadiusFilterBackend)
-    swagger_schema = None
 
     def get_queryset(self):
         qs = Well.objects.all() \
@@ -571,5 +572,8 @@ class WellDetail(WellDetailV1):
     """
     Return well detail.
     This view is open to all, and has no permissions.
+
+    get:
+    Returns details for a given well matching the well_tag_number.a
     """
     serializer_class = WellDetailSerializer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,6 +187,7 @@ services:
       S3_USE_SECURE: 0
       EMAIL_NOTIFICATION_RECIPIENT: sustainment.team@gov.bc.ca
       GEOCODER_ADDRESS_API_BASE: https://geocoder.api.gov.bc.ca/addresses.json?
+      LOCAL: True
     command: /bin/bash -c "
       sleep 3 &&
       set -x &&


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- add `LOCAL` env to the docker-compose
    - This is used for the Swagger configuration to determine if we should show all or some of our Swagger docs
    - This also makes the swagger docs curl against your localhost instead of production
- Slightly modify a lot of class documentation
    - Some Class documentation gets picked up by auto-generated Swagger docs and becomes part of the overall swagger documentation. The existing comments just had formatting changes added to them (capitalization, end periods, groupped with 'get', 'post', etc)
- Removed auto_swagger param from most classes, this was preventing the auto generator from picking up majority of the endpoints.
- Swagger documentation two modes, a cleaner copy for public consumption, and an in-depth local copy that shows all http methods whether they're used internally or not