### PR TITLE
[GWELLS-2197] FEATURE** CRUD operations for Organizations Notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ prep:
 	docker-compose pull
 	docker-compose build
 
+docker:
+	docker-compose up -d
+
+docker-staging:
+	docker-compose --env-file ./.env.test up
+
 down:
 	docker-compose down --volumes
 

--- a/app/backend/registries/views.py
+++ b/app/backend/registries/views.py
@@ -13,13 +13,13 @@
 """
 
 import reversion
-import re
+import re, json
 from collections import OrderedDict
-import re
 from django.db.models import Q, Prefetch, Count
 from django.http import HttpResponse, Http404, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from django.forms.models import model_to_dict
 from django.views.generic import TemplateView
 from django.contrib.gis.geos import Polygon, GEOSException
 from django_filters import rest_framework as restfilters
@@ -801,9 +801,6 @@ class OrganizationNoteDetailView(AuditUpdateMixin, RetrieveUpdateDestroyAPIView)
     get:
     Returns a OrganizationNote record.
 
-    put:
-    Replaces a OrganizationNote record with a new one.
-
     patch:
     Updates a OrganizationNote record with the set of fields provided in the request body.
 
@@ -814,49 +811,51 @@ class OrganizationNoteDetailView(AuditUpdateMixin, RetrieveUpdateDestroyAPIView)
     permission_classes = (RegistriesEditPermissions,)
     serializer_class = OrganizationNoteSerializer
 
-    def isAuth(self, author):
-        """Checks if user has permission to change Notes
+    def canDelete(self, author):
+        """Checks if user has permission to change Notes.
            Notes can only be edited by Admins and the note's creator
-
-        Args:
-            author (string): Creator of the note
-
-        Returns:
-            boolean: User meets criteria to edit or delete
         """
         return self.request.user.groups.filter(name="gwells_admin").exists() or \
             self.request.user.groups.filter(name="admin").exists() or \
             author == self.request.user
-         
-            
-    def get_queryset(self, request, org_guid, note_guid, **kwargs):
-        print("Get")
+    
+    def get_organization_note(self, org_guid, note_guid):
+        """Fetches the note requested"""
         if OrganizationNote.objects.filter(org_note_guid=note_guid, organization=org_guid).exists():
-            return OrganizationNote.objects.get(organization=org_guid, org_note_guid=note_guid)
-
+            return OrganizationNote.objects.get(org_note_guid=note_guid, organization=org_guid)
+        return None
+    
+    def get(self, request, org_guid, note_guid, **kwargs):
+        note = self.get_organization_note(org_guid, note_guid)
+        if note:
+            return Response(model_to_dict(note))
+        return HttpResponse(status=404)
+    
     def delete(self, request, org_guid, note_guid, **kwargs):
-        """Handles deletion for Organization Notes.
-
-        Args:
-            org_guid (string): UUID for Organization
-            note_guid (string): UUID for Note
-
-        Returns:
-            HttpResponse
-        """
-        print("Delete")
-        if OrganizationNote.objects.filter(org_note_guid=note_guid, organization=org_guid).exists():
-            note = OrganizationNote.objects.get(org_note_guid=note_guid, organization=org_guid)
-            if self.isAuth(note.author):
+        """Handles deletion for Organization Notes."""
+        note = self.get_organization_note(org_guid, note_guid)
+        if note:
+            if self.canDelete(note.author):
                 note.delete()
                 return HttpResponse(status=204)
             return HttpResponse(status=401)
         return HttpResponse(status=404)
     
     def patch(self, request, org_guid, note_guid, **kwargs):
-        print("Patch")
-        print(org_guid, note_guid)
-        return HttpResponse(200)
+        """Updates a Note with new content information.
+           Notes can only be updated by the user who created them
+        """
+        note = self.get_organization_note(org_guid, note_guid)
+        new_note_content = json.loads(request.body.decode('utf-8')).get("note", None)
+        if note:
+            if note.author == self.request.user:
+                if new_note_content:
+                    note.note = new_note_content
+                    note.save()
+                    return HttpResponse(status=200)
+                return HttpResponse(status=400)
+            return HttpResponse(status=403)
+        return HttpResponse(status=404)
 
 class OrganizationHistory(APIView):
     """

--- a/app/frontend/src/common/store/auth.js
+++ b/app/frontend/src/common/store/auth.js
@@ -31,7 +31,8 @@ const auth = {
           registry: {
             view: clientRoles.includes('registries_viewer'),
             edit: clientRoles.includes('registries_edit'),
-            approve: clientRoles.includes('registries_approve')
+            approve: clientRoles.includes('registries_approve'),
+            admin: clientRoles.includes('gwells_admin') || clientRoles.includes('admin') // Prod v. Dev
           },
           wells: {
             view: clientRoles.includes('wells_viewer'),

--- a/app/frontend/src/registry/components/people/Notes.vue
+++ b/app/frontend/src/registry/components/people/Notes.vue
@@ -21,6 +21,7 @@
           >
             {{ alertText }}
           </b-alert>
+          <!-- Submit Modal -->
           <b-modal
               v-model="confirmSubmitModal"
               centered
@@ -38,6 +39,7 @@
               </b-btn>
             </div>
           </b-modal>
+          <!-- Cancellation Modal -->
           <b-modal
               v-model="confirmCancelModal"
               centered
@@ -55,6 +57,7 @@
               </b-btn>
             </div>
           </b-modal>
+          <!-- Delete Note Modal  -->
           <b-modal
               v-model="confirmDeleteModal"
               centered
@@ -62,8 +65,8 @@
               @shown="focusDeleteModal"
               :return-focus="$refs.noteInputCancelBtn">
               <p>Are you sure you want to delete this note?</p>
-              <div v-if="activeNote" >
-                <p class="font-weight-bold">"{{activeNote.note}}"</p>
+              <div v-if="activeNote" class="">
+                <p class="font-weight-bold wb">"{{activeNote.note}}"</p>
               </div>
             <div slot="modal-footer" class="buttons">
               <b-btn
@@ -81,6 +84,7 @@
               </b-btn>
             </div>
           </b-modal>
+          <!-- Edit Modal -->
           <b-modal
               v-model="confirmEditNoteModal"
               centered
@@ -113,7 +117,7 @@
           <b-row><b-col>No notes for this record.</b-col></b-row>
         </div>
         <div class="mt-5 note-container" v-if="notes && notes.length">
-          <div class="note" v-for="(note, index) in notes" :key="`note ${index}`" :id="`note-${index}`">
+          <div class="note wb" v-for="(note, index) in notes" :key="`note ${index}`" :id="`note-${index}`">
             <p>
               <span class="font-weight-bold">{{ note.author }}</span> ({{ note.date | moment("MMMM Do YYYY [at] LT") }}):
               {{ note.note }}
@@ -314,5 +318,8 @@ export default {
 }
 .buttons button:last-child {
   margin-left: 0.5em;
+}
+.wb {
+  word-break: break-all;
 }
 </style>

--- a/app/frontend/src/registry/components/people/Notes.vue
+++ b/app/frontend/src/registry/components/people/Notes.vue
@@ -126,7 +126,7 @@
               <b-btn variant="light" @click="confirmEditNoteModal=false" ref="cancelEditNoteCancelBtn">
                 Cancel
               </b-btn>
-              <b-btn variant="primary" :disabled="invalidEditNoteLength" @click="notePatchHandle()">
+              <b-btn variant="primary" :disabled="invalidEditNoteLength || !noteContentEdit" @click="notePatchHandle()">
                 Submit
               </b-btn>
             </div>
@@ -261,7 +261,7 @@ export default {
         .then(() => {
           this.noteReset();
           this.activeNote = null;
-          this.noteContentEdit = null;
+          this.noteContentEdit = "";
           this.confirmEditNoteModal = false;
           this.alertText = "Note updated."
           this.submitSuccess = true;

--- a/app/frontend/src/registry/components/people/Notes.vue
+++ b/app/frontend/src/registry/components/people/Notes.vue
@@ -275,7 +275,6 @@ export default {
       this.submitLoading = false;
       if(e.response.status === 500) { this.submitError = "Service unavailable - try again later"; }
       else { this.submitError = e.response.data; }
-      console.log(this.submitError)
       alert(`An error has occured:\n\n${this.submitError}`);
     },
     noteReset () {

--- a/app/frontend/src/registry/components/people/Notes.vue
+++ b/app/frontend/src/registry/components/people/Notes.vue
@@ -300,8 +300,10 @@ export default {
      * @param {Object} note Note currently being edited
      */
     noteEditHandler (note) {
-      const editRegex = /^\(Edited \d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2} (AM|PM)\)\s/;
-      this.noteContentEdit = note.note.replace(editRegex, "");
+      const editRegexChromium = /^\(Edited \d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2} (AM|PM)\)\s/;
+      const editRegexFirefox =  /^\(Edited \d{4}-\d{1,2}-\d{1,2}, \d{1,2}:\d{2}:\d{2} (a.m.|p.m.)\)\s/;
+      this.noteContentEdit = note.note.replace(editRegexChromium, "");
+      this.noteContentEdit = this.noteContentEdit.replace(editRegexFirefox, "");
       this.activeNote = note;
       this.confirmEditNoteModal = true;
     },

--- a/app/frontend/tests/unit/specs/people/Notes.spec.js
+++ b/app/frontend/tests/unit/specs/people/Notes.spec.js
@@ -21,7 +21,8 @@ describe('Notes.vue', () => {
       user: () => null,
       currentDriller: jest.fn().mockReturnValue(fakePerson),
       drillers: () => [],
-      userRoles: () => ({ registry: { edit: true, view: true, approve: true } })
+      userRoles: () => ({ registry: { edit: true, view: true, approve: true } }),
+      keycloak: () => ({idTokenParsed: { displayName: fakePerson.first_name}})
     }
     store = new Vuex.Store({ getters, actions, mutations })
   })


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Added Get/Patch/Delete functionality to the GWELLS `organizations/{id}/notes/{note_id}` endpoint
- Updated frontend to make use of new crud functionality
- Added Modals for editing and deleting notes
- Add a Edit flag to the note body to highlight if a user has updated a note at any time

Auth considerations:

- Only user who submits note can edit a note
- Creation User and Administrators can delete notes

**How to access:**
1. Log into Gwells
2. Select 'Registry Search' from nav bar
3. Select 'Manage Companies' from admin options
4. Select a company

Previous notes section:

![image](https://github.com/bcgov/gwells/assets/62873746/c04642a6-8169-4dd0-9a4b-bb513b4fb688)

New note section:

![image](https://github.com/bcgov/gwells/assets/62873746/2f7e8c6b-3f08-4941-aaf6-047798ff64a5)

Edit Modal:

![image](https://github.com/bcgov/gwells/assets/62873746/658de7ef-4573-4d7b-be3c-9fa1d0a5d612)

Delete Modal: 

![image](https://github.com/bcgov/gwells/assets/62873746/26c77bcc-9c8d-446b-90fb-166f2c6e5083)

