### PR TITLE
[GWELLS-2198] FEATURE** CRUD Functionality for Persons Notes

### DIFF
--- a/app/backend/registries/serializers.py
+++ b/app/backend/registries/serializers.py
@@ -34,7 +34,6 @@ from registries.models import (
     AccreditedCertificateCode,
     WellClassCode,
     PersonNote,
-    PersonNote,
     OrganizationNote,
     RegionalArea
 )

--- a/app/frontend/src/registry/components/people/Notes.vue
+++ b/app/frontend/src/registry/components/people/Notes.vue
@@ -74,15 +74,16 @@
           </b-modal>
           <!-- Delete Note Modal  -->
           <b-modal
-              v-model="confirmDeleteModal"
-              centered
-              title="Confirm Deletion"
-              @shown="focusDeleteModal"
-              :return-focus="$refs.noteInputCancelBtn">
-              <p>Are you sure you want to delete this note?</p>
-              <div v-if="activeNote" class="">
-                <p class="font-weight-bold wb">"{{activeNote.note}}"</p>
-              </div>
+            v-model="confirmDeleteModal"
+            centered
+            title="Confirm Deletion"
+            @shown="focusDeleteModal"
+            :return-focus="$refs.noteInputCancelBtn"
+          >
+            <p>Are you sure you want to delete this note?</p>
+            <div v-if="activeNote" class="">
+              <p class="font-weight-bold wb">"{{activeNote.note}}"</p>
+            </div>
             <div slot="modal-footer" class="buttons">
               <b-btn
                 variant="light"

--- a/app/frontend/src/registry/components/people/PersonDetail.vue
+++ b/app/frontend/src/registry/components/people/PersonDetail.vue
@@ -649,7 +649,6 @@ export default {
       ApiService.query(`drillers/${this.$route.params.person_guid}/files`)
         .then((response) => {
           this.person_files = response.data
-          console.log(response.data)
         })
     }
   },

--- a/app/frontend/src/registry/components/people/PersonNotes.vue
+++ b/app/frontend/src/registry/components/people/PersonNotes.vue
@@ -94,12 +94,9 @@
                 rows="4"
                 max-rows="6"
               />
-              <p
-              class="font-weight-bold text-count"
-              :class="[invalidEditNoteLength ? 'error': '']"
-            >
+              <p class="font-weight-bold text-count" :class="[invalidEditNoteLength ? 'error': '']">
               {{ noteContentEdit.length }}/{{ maxNoteLength }}
-            </p>
+              </p>
             </div>
             <div slot="modal-footer" class="buttons">
               <b-btn variant="light" @click="confirmEditNoteModal=false" ref="cancelEditNoteCancelBtn">
@@ -174,7 +171,6 @@ export default {
   computed: {
     notes () {
       if (this.currentDriller && this.currentDriller.notes) {
-        console.log(this.currentDriller)
         return this.currentDriller.notes
       }
       return []
@@ -231,7 +227,7 @@ export default {
       this.$refs.cancelDeleteBtn.focus();
     },
     deleteNote() {
-      ApiService.delete(`${this.resourceType}/${this.guid}/notes`, this.activeNote.org_note_guid)
+      ApiService.delete(`drillers/${this.currentDriller.person_guid}/notes`, this.activeNote.person_note_guid)
       .then(() => {
         this.activeNote = null;
         this.alertText = "Note deleted.";
@@ -244,7 +240,6 @@ export default {
     },
     notePatchHandle() {
       const updatedNote = `(Edited ${new Date().toLocaleString()}) ` + this.noteContentEdit;
-      console.log(this.activeNote)
       ApiService.patch(`drillers/${this.currentDriller.person_guid}/notes`, this.activeNote.person_note_guid, {note: updatedNote})
         .then(() => {
           this.noteReset();

--- a/app/frontend/src/registry/components/people/PersonNotes.vue
+++ b/app/frontend/src/registry/components/people/PersonNotes.vue
@@ -10,8 +10,16 @@
               label-for="noteInput">
             <b-form-textarea id="noteInput" v-model="noteInput" :rows="3" :max-rows="6" :disabled="submitLoading"></b-form-textarea>
           </b-form-group>
-          <b-button type="submit" variant="primary" :disabled="!noteInput || submitLoading" ref="noteInputSaveBtn">Save</b-button>
-          <b-button type="reset" variant="light" :disabled="!noteInput" ref="noteInputCancelBtn">Cancel</b-button>
+          <div class="submit-row">
+            <b-button type="submit" variant="primary" :disabled="!noteInput || submitLoading" ref="noteInputSaveBtn">Save</b-button>
+            <b-button type="reset" variant="light" :disabled="!noteInput" ref="noteInputCancelBtn">Cancel</b-button>
+            <p
+              class="font-weight-bold text-count"
+              :class="[invalidNewNoteLength ? 'error': '']"
+            >
+              {{ noteInput.length }}/{{ maxNoteLength }}
+            </p>
+          </div>
           <b-alert
               class="mt-3"
               variant="success"

--- a/app/frontend/src/registry/components/people/PersonNotes.vue
+++ b/app/frontend/src/registry/components/people/PersonNotes.vue
@@ -50,16 +50,97 @@
               </b-btn>
             </div>
           </b-modal>
+          <!-- Delete Note Modal  -->
+          <b-modal
+            v-model="confirmDeleteModal"
+            centered
+            title="Confirm Deletion"
+            @shown="focusDeleteModal"
+            :return-focus="$refs.noteInputCancelBtn"
+          >
+            <p>Are you sure you want to delete this note?</p>
+            <div v-if="activeNote" class="">
+              <p class="font-weight-bold wb">"{{activeNote.note}}"</p>
+            </div>
+            <div slot="modal-footer" class="buttons">
+              <b-btn
+                variant="light"
+                @click="confirmDeleteModal=false"
+                ref="cancelDeleteBtn"
+              >
+                Cancel
+              </b-btn>
+              <b-btn
+                variant="danger"
+                @click="confirmDeleteModal=false;deleteNote()"
+              >
+                Delete
+              </b-btn>
+            </div>
+          </b-modal>
+          <!-- Edit Modal -->
+          <b-modal
+              v-model="confirmEditNoteModal"
+              centered
+              title="Editing Note"
+              @shown="focusEditNoteModal"
+              :return-focus="$refs.noteInputCancelBtn"
+            >
+            <div>
+              <b-form-textarea
+                id="editNoteTextArea"
+                v-model="noteContentEdit"
+                placeholder="Edit Note..."
+                rows="4"
+                max-rows="6"
+              />
+              <p
+              class="font-weight-bold text-count"
+              :class="[invalidEditNoteLength ? 'error': '']"
+            >
+              {{ noteContentEdit.length }}/{{ maxNoteLength }}
+            </p>
+            </div>
+            <div slot="modal-footer" class="buttons">
+              <b-btn variant="light" @click="confirmEditNoteModal=false" ref="cancelEditNoteCancelBtn">
+                Cancel
+              </b-btn>
+              <b-btn variant="primary" :disabled="invalidEditNoteLength || !noteContentEdit" @click="notePatchHandle()">
+                Submit
+              </b-btn>
+            </div>
+          </b-modal>
         </b-form>
       </div>
       <div id="notesList" ref="notes">
         <div v-if="!notes || !notes.length">
           <b-row><b-col>No notes for this person.</b-col></b-row>
         </div>
-        <div v-if="notes && notes.length">
-          <div class="mt-3" v-for="(note, index) in notes" :key="`note ${index}`" :id="`person-note-${index}`">
+        <div class="mt-5 note-container" v-if="notes && notes.length">
+          <div class="note wb" v-for="(note, index) in notes" :key="`note ${index}`" :id="`person-note-${index}`">
+            <p>
               <span class="font-weight-bold">{{ note.author }}</span> ({{ note.date | moment("MMMM Do YYYY [at] LT") }}):
               {{ note.note }}
+            </p>
+            <div class="crud-options">
+              <b-btn
+                :disabled="keycloak.idTokenParsed.display_name !== note.author" 
+                @click="noteEditHandler(note)"
+                size="sm"
+                variant="primary"
+              >
+                <i class="fa fa-edit"></i>
+                Edit
+              </b-btn>
+              <b-btn
+                :disabled="!userRoles.registry.admin && keycloak.idTokenParsed.display_name !== note.author"
+                @click="noteDeleteHandler(note)"
+                size="sm"
+                variant="danger"
+              >
+                &#x2715;
+              </b-btn>
+            </div>
           </div>
         </div>
       </div>
@@ -81,19 +162,28 @@ export default {
       submitLoading: false,
       submitSuccess: false,
       submitError: false,
+      confirmEditNoteModal: false,
       confirmSubmitModal: false,
-      confirmCancelModal: false
+      confirmCancelModal: false,
+      confirmDeleteModal: false,
+      noteContentEdit: "",
+      activeNote: null,
+      maxNoteLength: 900
     }
   },
   computed: {
     notes () {
       if (this.currentDriller && this.currentDriller.notes) {
+        console.log(this.currentDriller)
         return this.currentDriller.notes
       }
       return []
     },
+    invalidNewNoteLength () { return this.noteInput.length > this.maxNoteLength },
+    invalidEditNoteLength () { return this.noteContentEdit.length > this.maxNoteLength; },
     ...mapGetters([
-      'userRoles'
+      'userRoles',
+      'keycloak'
     ]),
     ...mapGetters('registriesStore', [
       'currentDriller'
@@ -118,6 +208,62 @@ export default {
           this.submitLoading = false
           this.submitError = e.response.data
         })
+    },
+    noteEditHandler (note) {
+      const editRegexChromium = /^\(Edited \d{1,2}\/\d{1,2}\/\d{4}, \d{1,2}:\d{2}:\d{2} (AM|PM)\)\s/;
+      const editRegexFirefox =  /^\(Edited \d{4}-\d{1,2}-\d{1,2}, \d{1,2}:\d{2}:\d{2} (a.m.|p.m.)\)\s/;
+      this.noteContentEdit = note.note.replace(editRegexChromium, "");
+      this.noteContentEdit = this.noteContentEdit.replace(editRegexFirefox, "");
+      this.activeNote = note;
+      this.confirmEditNoteModal = true;
+    },
+    noteDeleteHandler (note) {
+      this.activeNote = note;
+      this.confirmDeleteModal = true;
+    },
+    noteCancelDeleteHandler () {
+      this.activeNote = null;
+    },
+    focusEditNoteModal () {
+      this.$refs.cancelEditNoteCancelBtn.focus()
+    },
+    focusDeleteModal () {
+      this.$refs.cancelDeleteBtn.focus();
+    },
+    deleteNote() {
+      ApiService.delete(`${this.resourceType}/${this.guid}/notes`, this.activeNote.org_note_guid)
+      .then(() => {
+        this.activeNote = null;
+        this.alertText = "Note deleted.";
+        this.submitSuccess = true;
+        this.$emit('updated');
+      })
+      .catch((e) => {
+        this.errorHandler(e);
+      })
+    },
+    notePatchHandle() {
+      const updatedNote = `(Edited ${new Date().toLocaleString()}) ` + this.noteContentEdit;
+      console.log(this.activeNote)
+      ApiService.patch(`drillers/${this.currentDriller.person_guid}/notes`, this.activeNote.person_note_guid, {note: updatedNote})
+        .then(() => {
+          this.noteReset();
+          this.activeNote = null;
+          this.noteContentEdit = "";
+          this.confirmEditNoteModal = false;
+          this.alertText = "Note updated."
+          this.submitSuccess = true;
+          this.$emit('updated');
+        })
+        .catch((e) => {
+          this.errorHandler(e);
+        })
+    },
+    errorHandler(e){
+      this.submitLoading = false;
+      if (e.response.status === 500) { this.submitError = "Service unavailable - try again later"; }
+      else { this.submitError = e.response.data; }
+      alert(`An error has occured:\n\n${this.submitError}`);
     },
     noteReset () {
       this.submitSuccess = false
@@ -145,6 +291,48 @@ export default {
 }
 </script>
 
-<style>
-
+<style lang="scss">
+.crud-options {
+  display: flex;
+  margin-left: 0.5em;
+  width: auto;
+}
+.crud-options button:last-child {
+  margin-left: 0.5em;
+}
+.note {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.5em;
+  border-radius: 4pt;
+}
+.note:hover {
+  transition: 0.2s;
+  background-color: #F8F8F8;
+}
+.note p {
+  padding: 0;
+  margin: 0;
+}
+.buttons button:last-child {
+  margin-left: 0.5em;
+}
+.wb {
+  word-break: break-all;
+}
+.error {
+  color: red;
+}
+.text-count {
+  width: 100%;
+  text-align: right;
+  padding: 0.5em 1em 0 0;
+}
+.submit-row {
+  display: flex;
+  flex-direction: row;
+}
 </style>

--- a/app/frontend/tests/unit/specs/people/PersonDetail.spec.js
+++ b/app/frontend/tests/unit/specs/people/PersonDetail.spec.js
@@ -19,7 +19,8 @@ const GET_DEFAULT_STORE_MODULES = () => {
     auth: {
       getters: {
         user: () => null,
-        userRoles: () => ({ registry: { edit: true, view: true, approve: true } })
+        userRoles: () => ({ registry: { edit: true, view: true, approve: true } }),
+        keycloak: () => ({idTokenParsed: { displayName: fakePerson.first_name}})
       }
     },
     registriesStore: {
@@ -28,7 +29,8 @@ const GET_DEFAULT_STORE_MODULES = () => {
         loading: () => false,
         error: () => null,
         currentDriller: jest.fn().mockReturnValue(fakePerson),
-        searchResponse: () => []
+        searchResponse: () => [],
+        keycloak: () => ({idTokenParsed: { displayName: fakePerson.first_name}})
       },
       actions: {
         [FETCH_DRILLER]: jest.fn(),

--- a/app/frontend/tests/unit/specs/people/PersonNotes.spec.js
+++ b/app/frontend/tests/unit/specs/people/PersonNotes.spec.js
@@ -13,7 +13,8 @@ const GET_DEFAULT_STORE_MODULES = () => {
     auth: {
       getters: {
         user: () => null,
-        userRoles: () => ({ registry: { edit: true, view: true, approve: true } })
+        userRoles: () => ({ registry: { edit: true, view: true, approve: true } }),
+        keycloak: () => ({idTokenParsed: { displayName: fakePerson.first_name}})
       }
     },
     registriesStore: {
@@ -22,7 +23,7 @@ const GET_DEFAULT_STORE_MODULES = () => {
         loading: () => false,
         error: () => null,
         currentDriller: jest.fn().mockReturnValue(fakePerson),
-        searchResponse: () => []
+        searchResponse: () => [],
       },
       actions: {
       },


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

This PR is an expansion on the work done on [[GWELLS-2197]](https://github.com/bcgov/gwells/pull/2206) but targetting the `Persons` section of the application

- Added Get/Patch/Delete functionality to the GWELLS `drillers/{id}/notes/{note_id}` endpoint
- Updated frontend to make use of new crud functionality 
- Added Modals for editing and deleting notes
- Add a Edit flag to the note body to highlight if a user has updated a note at any time

Auth considerations:

- Only user who submits note can edit a note
- Creation User and Administrators can delete notes

**How to access:**
1. Log into Gwells
2. Select 'Registry Search' from nav bar
3. Search for driller
4. Select a driller from results

![image](https://github.com/bcgov/gwells/assets/62873746/e7dd8a67-dc35-44b0-b52d-bdfdf3769728)

