### PR TITLE
[CHANGE][GWELLS-2186] Commenting out Google Analytics

### DIFF
--- a/app/backend/gwells/templates/gwells/base_spa.html
+++ b/app/backend/gwells/templates/gwells/base_spa.html
@@ -50,7 +50,7 @@
     <![endif]-->
 
 
-    {% if settings.ENABLE_GOOGLE_ANALYTICS %}
+<!--     {% if settings.ENABLE_GOOGLE_ANALYTICS %}
     <script>
         (function(i, s, o, g, r, a, m) {
             i['GoogleAnalyticsObject'] = r;
@@ -68,7 +68,7 @@
         ga('set', 'anonymizeIp', true);
         ga('send', 'pageview');
     </script>
-    {% endif %}
+    {% endif %} -->
 </head>
 
 <body class="gwells-body">

--- a/app/frontend/src/aquifers/components/View.vue
+++ b/app/frontend/src/aquifers/components/View.vue
@@ -983,7 +983,7 @@ export default {
         this.waterWithdrawlVolume = sumBy(details.usage, 'total_qty')
       }
     },
-    // log a google analytics event when clicking on links to other sites
+    /* // log a google analytics event when clicking on links to other sites
     handleOutboundLinkClicks (link) {
       if (window.ga) {
         window.ga('send', 'event', {
@@ -1003,7 +1003,7 @@ export default {
           eventLabel: 'Aquifer Factsheet'
         })
       }
-    },
+    }, */
     sanitizeResourceUrl (url) {
       const sanitized = sanitizeUrl(url)
       return encodeURI(sanitized)

--- a/app/frontend/src/aquifers/store/search.js
+++ b/app/frontend/src/aquifers/store/search.js
@@ -131,14 +131,14 @@ const aquiferSearchStore = {
 
       // trigger the Google Analytics search event
       // trigger the search event, sending along the search params as a string
-      if (window.ga) {
-        window.ga('send', {
-          hitType: 'event',
-          eventCategory: 'Button',
-          eventAction: 'AquiferSearch',
-          eventLabel: querystring.stringify(state.searchQuery)
-        })
-      }
+      // if (window.ga) {
+      //   window.ga('send', {
+      //     hitType: 'event',
+      //     eventCategory: 'Button',
+      //     eventAction: 'AquiferSearch',
+      //     eventLabel: querystring.stringify(state.searchQuery)
+      //   })
+      // }
 
       if (state.pendingSearch) {
         state.pendingSearch.cancel()

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -18,7 +18,6 @@ import * as Integrations from '@sentry/integrations'
 import Vuex, { mapActions } from 'vuex'
 import VueNoty from 'vuejs-noty'
 import BootstrapVue from 'bootstrap-vue'
-import VueAnalytics from 'vue-analytics'
 import VueMatomo from 'vue-matomo'
 import App from './App'
 import router from './router.js'
@@ -37,9 +36,10 @@ import ApiService from '@/common/services/ApiService.js'
 
 const PRODUCTION_GWELLS_URL = 'https://apps.nrs.gov.bc.ca/gwells'
 const STAGING_GWELLS_URLS = ['testapps.nrs.gov.bc.ca', 'gwells-staging.apps.silver.devops.gov.bc.ca']
-const isProduction = () => (window.location.href.substr(0, PRODUCTION_GWELLS_URL.length) === PRODUCTION_GWELLS_URL)
+const BASE_PATH = '/gwells/'
+const isProduction = () => (window.location.href.substring(0, PRODUCTION_GWELLS_URL.length) === PRODUCTION_GWELLS_URL)
 const isStaging = () => (
-  window.location.pathname === '/gwells/' && STAGING_GWELLS_URLS.includes(window.location.hostname)
+  window.location.pathname.substring(0, BASE_PATH.length) === BASE_PATH && STAGING_GWELLS_URLS.includes(window.location.hostname)
 )
 if (isProduction()) {
   Sentry.init({
@@ -68,16 +68,6 @@ Vue.component('form-input', FormInput)
 
 // set baseURL and default headers
 ApiService.init()
-
-Vue.use(VueAnalytics, {
-  id: 'UA-106174915-1',
-  set: [
-    { field: 'anonymizeIp', value: true }
-  ],
-  disabled: ApiService.query('analytics', {}).then((response) => {
-    return response.data.enable_google_analytics !== true
-  })
-})
 
 if (isProduction()) {
   Vue.use(VueMatomo, {
@@ -115,6 +105,5 @@ new Vue({
   },
   created () {
     this.FETCH_CONFIG()
-    this.$ga.page()
   }
 })

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -37,9 +37,9 @@ import ApiService from '@/common/services/ApiService.js'
 const PRODUCTION_GWELLS_URL = 'https://apps.nrs.gov.bc.ca/gwells'
 const STAGING_GWELLS_URLS = ['testapps.nrs.gov.bc.ca', 'gwells-staging.apps.silver.devops.gov.bc.ca']
 const BASE_PATH = '/gwells/'
-const isProduction = () => (window.location.href.substring(0, PRODUCTION_GWELLS_URL.length) === PRODUCTION_GWELLS_URL)
+const isProduction = () => (window.location.href.startsWith(PRODUCTION_GWELLS_URL) === PRODUCTION_GWELLS_URL)
 const isStaging = () => (
-  window.location.pathname.substring(0, BASE_PATH.length) === BASE_PATH && STAGING_GWELLS_URLS.includes(window.location.hostname)
+  window.location.pathname.startsWith(BASE_PATH) === BASE_PATH && STAGING_GWELLS_URLS.includes(window.location.hostname)
 )
 if (isProduction()) {
   Sentry.init({

--- a/app/frontend/src/wells/components/SearchResultExports.vue
+++ b/app/frontend/src/wells/components/SearchResultExports.vue
@@ -107,18 +107,18 @@ export default {
     exportHandler(format) {
       const exportUrl = this.getExportUrl(format);
       ApiService.download(exportUrl);
-      this.sendAnalytics(format);
+     // this.sendAnalytics(format);
     },
-    sendAnalytics (format) {
-      if (window.ga) {
-        window.ga('send', {
-          hitType: 'event',
-          eventCategory: 'Button',
-          eventAction: 'WellSearchResultsExtract',
-          eventLabel: format
-        })
-      }
-    }
+    // sendAnalytics (format) {
+    //   if (window.ga) {
+    //     window.ga('send', {
+    //       hitType: 'event',
+    //       eventCategory: 'Button',
+    //       eventAction: 'WellSearchResultsExtract',
+    //       eventLabel: format
+    //     })
+    //   }
+    // }
   }
 }
 </script>


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [ ] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Commenting out most references to Google Analytics. Even though there is an env var to disable GA, there is still js created. This change is to ensure that Matomo analytics continue to function without GA code. As prod is the only place that the Matomo analytics is working, decided on this path as most expedient way to test.

