### PR TITLE
Revert "[CHANGE][GWELLS-2186] Commenting out Google Analytics"

### DIFF
--- a/app/backend/gwells/templates/gwells/base_spa.html
+++ b/app/backend/gwells/templates/gwells/base_spa.html
@@ -50,7 +50,7 @@
     <![endif]-->
 
 
-<!--     {% if settings.ENABLE_GOOGLE_ANALYTICS %}
+    {% if settings.ENABLE_GOOGLE_ANALYTICS %}
     <script>
         (function(i, s, o, g, r, a, m) {
             i['GoogleAnalyticsObject'] = r;
@@ -68,7 +68,7 @@
         ga('set', 'anonymizeIp', true);
         ga('send', 'pageview');
     </script>
-    {% endif %} -->
+    {% endif %}
 </head>
 
 <body class="gwells-body">

--- a/app/frontend/src/aquifers/components/View.vue
+++ b/app/frontend/src/aquifers/components/View.vue
@@ -983,7 +983,7 @@ export default {
         this.waterWithdrawlVolume = sumBy(details.usage, 'total_qty')
       }
     },
-    /* // log a google analytics event when clicking on links to other sites
+    // log a google analytics event when clicking on links to other sites
     handleOutboundLinkClicks (link) {
       if (window.ga) {
         window.ga('send', 'event', {
@@ -1003,7 +1003,7 @@ export default {
           eventLabel: 'Aquifer Factsheet'
         })
       }
-    }, */
+    },
     sanitizeResourceUrl (url) {
       const sanitized = sanitizeUrl(url)
       return encodeURI(sanitized)

--- a/app/frontend/src/aquifers/store/search.js
+++ b/app/frontend/src/aquifers/store/search.js
@@ -131,14 +131,14 @@ const aquiferSearchStore = {
 
       // trigger the Google Analytics search event
       // trigger the search event, sending along the search params as a string
-      // if (window.ga) {
-      //   window.ga('send', {
-      //     hitType: 'event',
-      //     eventCategory: 'Button',
-      //     eventAction: 'AquiferSearch',
-      //     eventLabel: querystring.stringify(state.searchQuery)
-      //   })
-      // }
+      if (window.ga) {
+        window.ga('send', {
+          hitType: 'event',
+          eventCategory: 'Button',
+          eventAction: 'AquiferSearch',
+          eventLabel: querystring.stringify(state.searchQuery)
+        })
+      }
 
       if (state.pendingSearch) {
         state.pendingSearch.cancel()

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -18,6 +18,7 @@ import * as Integrations from '@sentry/integrations'
 import Vuex, { mapActions } from 'vuex'
 import VueNoty from 'vuejs-noty'
 import BootstrapVue from 'bootstrap-vue'
+import VueAnalytics from 'vue-analytics'
 import VueMatomo from 'vue-matomo'
 import App from './App'
 import router from './router.js'
@@ -36,10 +37,9 @@ import ApiService from '@/common/services/ApiService.js'
 
 const PRODUCTION_GWELLS_URL = 'https://apps.nrs.gov.bc.ca/gwells'
 const STAGING_GWELLS_URLS = ['testapps.nrs.gov.bc.ca', 'gwells-staging.apps.silver.devops.gov.bc.ca']
-const BASE_PATH = '/gwells/'
-const isProduction = () => (window.location.href.startsWith(PRODUCTION_GWELLS_URL) === PRODUCTION_GWELLS_URL)
+const isProduction = () => (window.location.href.substr(0, PRODUCTION_GWELLS_URL.length) === PRODUCTION_GWELLS_URL)
 const isStaging = () => (
-  window.location.pathname.startsWith(BASE_PATH) === BASE_PATH && STAGING_GWELLS_URLS.includes(window.location.hostname)
+  window.location.pathname === '/gwells/' && STAGING_GWELLS_URLS.includes(window.location.hostname)
 )
 if (isProduction()) {
   Sentry.init({
@@ -68,6 +68,16 @@ Vue.component('form-input', FormInput)
 
 // set baseURL and default headers
 ApiService.init()
+
+Vue.use(VueAnalytics, {
+  id: 'UA-106174915-1',
+  set: [
+    { field: 'anonymizeIp', value: true }
+  ],
+  disabled: ApiService.query('analytics', {}).then((response) => {
+    return response.data.enable_google_analytics !== true
+  })
+})
 
 if (isProduction()) {
   Vue.use(VueMatomo, {
@@ -105,5 +115,6 @@ new Vue({
   },
   created () {
     this.FETCH_CONFIG()
+    this.$ga.page()
   }
 })

--- a/app/frontend/src/wells/components/SearchResultExports.vue
+++ b/app/frontend/src/wells/components/SearchResultExports.vue
@@ -107,18 +107,18 @@ export default {
     exportHandler(format) {
       const exportUrl = this.getExportUrl(format);
       ApiService.download(exportUrl);
-     // this.sendAnalytics(format);
+      this.sendAnalytics(format);
     },
-    // sendAnalytics (format) {
-    //   if (window.ga) {
-    //     window.ga('send', {
-    //       hitType: 'event',
-    //       eventCategory: 'Button',
-    //       eventAction: 'WellSearchResultsExtract',
-    //       eventLabel: format
-    //     })
-    //   }
-    // }
+    sendAnalytics (format) {
+      if (window.ga) {
+        window.ga('send', {
+          hitType: 'event',
+          eventCategory: 'Button',
+          eventAction: 'WellSearchResultsExtract',
+          eventLabel: format
+        })
+      }
+    }
   }
 }
 </script>


### PR DESCRIPTION
Reverts bcgov/gwells#2217. This change was testing if Matomo tracking worked with all of the Google Analytics code commented out. This showed that the current implementation of Matomo does NOT work without the GA code.