### PR TITLE
[FIX][GWELLS-2226] fix docker compose is generating an error in local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ app/backend/bulk
 *.spec
 pip-log.txt
 pip-delete-this-directory.txt
+app/backend/get-pip.py
 
 # Unit test / coverage reports
 htmlcov/

--- a/app/.s2i/bin/assemble
+++ b/app/.s2i/bin/assemble
@@ -30,7 +30,9 @@ mv /tmp/src/* ./
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" || ! -z "$ENABLE_PIPENV" ]]; then
   echo "---> Upgrading pip to latest version ..."
-  pip install -U pip setuptools==57.4.0 wheel
+  curl -s -o get-pip.py https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py --user
+  python3 -m pip install --user --upgrade setuptools wheel
+  rm get-pip.py
 fi
 
 cd backend

--- a/app/.s2i/bin/assemble
+++ b/app/.s2i/bin/assemble
@@ -30,8 +30,8 @@ mv /tmp/src/* ./
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" || ! -z "$ENABLE_PIPENV" ]]; then
   echo "---> Upgrading pip to latest version ..."
-  curl -s -o get-pip.py https://bootstrap.pypa.io/pip/3.6/get-pip.py  && python3 get-pip.py --user
-  python3 -m pip install --user --upgrade setuptools wheel
+  curl -s -o get-pip.py https://bootstrap.pypa.io/pip/3.6/get-pip.py && python3 get-pip.py --user
+  pip install --user --upgrade setuptools==57.4.0 wheel
   rm get-pip.py
 fi
 

--- a/app/.s2i/bin/assemble
+++ b/app/.s2i/bin/assemble
@@ -30,7 +30,7 @@ mv /tmp/src/* ./
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" || ! -z "$ENABLE_PIPENV" ]]; then
   echo "---> Upgrading pip to latest version ..."
-  curl -s -o get-pip.py https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py --user
+  curl -s -o get-pip.py https://bootstrap.pypa.io/pip/3.6/get-pip.py  && python3 get-pip.py --user
   python3 -m pip install --user --upgrade setuptools wheel
   rm get-pip.py
 fi

--- a/app/.s2i/bin/assemble
+++ b/app/.s2i/bin/assemble
@@ -30,7 +30,7 @@ mv /tmp/src/* ./
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" || ! -z "$ENABLE_PIPENV" ]]; then
   echo "---> Upgrading pip to latest version ..."
-  curl -s -o get-pip.py https://bootstrap.pypa.io/pip/3.6/get-pip.py && python3 get-pip.py --user
+  curl -s -o get-pip.py https://bootstrap.pypa.io/pip/3.6/get-pip.py && python3 get-pip.py
   python3 -m pip install -U setuptools==57.4.0 wheel
   rm get-pip.py
 fi

--- a/app/.s2i/bin/assemble
+++ b/app/.s2i/bin/assemble
@@ -31,7 +31,7 @@ mv /tmp/src/* ./
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" || ! -z "$ENABLE_PIPENV" ]]; then
   echo "---> Upgrading pip to latest version ..."
   curl -s -o get-pip.py https://bootstrap.pypa.io/pip/3.6/get-pip.py && python3 get-pip.py --user
-  pip install --user --upgrade setuptools==57.4.0 wheel
+  python3 -m pip install -U setuptools==57.4.0 wheel
   rm get-pip.py
 fi
 

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -16290,11 +16290,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
       "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
     },
-    "vue-analytics": {
-      "version": "5.16.4",
-      "resolved": "https://registry.npmjs.org/vue-analytics/-/vue-analytics-5.16.4.tgz",
-      "integrity": "sha512-M67cUqpPeyk2rftrvlx2uU+BQ/C4E8SkF2Ct9LizOYUoTccZtCCJwhMJfQ3XL8xep6p3K8KYz58FzRWvx5zlPw=="
-    },
     "vue-chartjs": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-3.5.1.tgz",

--- a/app/scripts/backend-command-script.sh
+++ b/app/scripts/backend-command-script.sh
@@ -5,7 +5,7 @@ if [ "$ENVIRONMENT" = "local" ]; then
   set -x &&
   cd /app/backend &&
   mkdir -p .pip &&
-  curl -s -o get-pip.py https://bootstrap.pypa.io/pip/3.5/get-pip.py && python3 get-pip.py &&
+  curl -s -o get-pip.py https://bootstrap.pypa.io/pip/3.5/get-pip.py && python3 get-pip.py && 
   python3 -m pip install --upgrade pip &&
   python3 -m pip install ptvsd &&
   python3 -m pip install --cache-dir=.pip -r requirements.txt &&

--- a/app/scripts/backend-command-script.sh
+++ b/app/scripts/backend-command-script.sh
@@ -5,6 +5,7 @@ if [ "$ENVIRONMENT" = "local" ]; then
   set -x &&
   cd /app/backend &&
   mkdir -p .pip &&
+  curl -s -o get-pip.py https://bootstrap.pypa.io/pip/3.5/get-pip.py && python3 get-pip.py &&
   python3 -m pip install --upgrade pip &&
   python3 -m pip install ptvsd &&
   python3 -m pip install --cache-dir=.pip -r requirements.txt &&


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

When running docker-compose up in local, the following error is generated in the backend container : Could not fetch URL https://pypi.python.org/simple/pip/: There was a problem confirming the ssl certificate: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852) , and the backend does not run.

This PR includes the following proposed change(s):

- One solution is to add trusted host flags when upgrading pip seen [here](https://stackoverflow.com/questions/25981703/pip-install-fails-with-connection-error-ssl-certificate-verify-failed-certi). As manually assigning trusted hosts is not an ideal solution,
a solution was found that did not require their use.