### PR TITLE
chore(ci): codeowners

### DIFF
--- a/.github/codeowners
+++ b/.github/codeowners
@@ -1,0 +1,7 @@
+# Matched against repo root (asterisk)
+*                         @bcgov/sustainment-team @DerekRoberts
+
+# Matched against directories
+# /.github/workflows/       @mishraomp @DerekRoberts
+
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners


### PR DESCRIPTION
Codeowners file!  Anyone listed inside will be notified for PRs matching a pattern.  The one here is `*`, matching everything.  Later on we can potentially limit reviews to just codeowners.