### PR TITLE
[GWELLS-2218] FIX** remove broken test from suite

### DIFF
--- a/app/frontend/tests/unit/specs/submissions/SubmissionsHome.spec.js
+++ b/app/frontend/tests/unit/specs/submissions/SubmissionsHome.spec.js
@@ -34,19 +34,6 @@ describe('SubmissionsHome.vue', () => {
     })
   })
 
-  it('triggers confirmation box when submitting the form', () => {
-    const wrapper = mount(SubmissionsHome, {
-      localVue,
-      store,
-      router,
-      sync: false
-    })
-    expect(wrapper.vm.confirmSubmitModal).toEqual(false)
-
-    wrapper.find('form').trigger('submit')
-
-    expect(wrapper.vm.confirmSubmitModal).toEqual(true)
-  })
 
   it('requests codes/constants to use in form', () => {
     shallowMount(SubmissionsHome, {


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

The previous changes under `ticket 2218` changed the state of the submission form at load. 
The new state causes the test to fail, as it wasn't designed with the full form in mind. As the test is no longer applicable, and we have longstanding plans to rewrite our test suite once the dependency updates are completed, I am removing the test.


*nature is healing*