### PR TITLE
[GWELLS-2239] FIX/text wrap on well results

### DIFF
--- a/app/frontend/src/wells/components/SearchResults.vue
+++ b/app/frontend/src/wells/components/SearchResults.vue
@@ -339,7 +339,7 @@ export default {
   min-height: 36rem;
 
   td.data {
-    white-space: nowrap;
+    white-space: wrap;
     overflow-wrap: break-word;
   }
 


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Wells search results now text wrap

This PR includes the following proposed change(s):
- changed css for searchResultsTable.td.data to wrap instead of nowrap

- ![image](https://github.com/bcgov/gwells/assets/127158867/ac87e49b-b114-443e-9030-61694a5767c6)
- <img width="1156" alt="Screenshot 2024-06-21 at 9 24 12 AM" src="https://github.com/bcgov/gwells/assets/127158867/b1c56fcd-4c4d-48dc-88e0-a824f6defc00">
