### PR TITLE
[GWELLS-2263] FIX** Add Warning Class to Text on Submission Form

### DIFF
--- a/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
@@ -50,7 +50,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </b-col>
         </b-row>
       <p v-if="!isStaffEdit">Submit activity on a well. <a href="/gwells/" target="_blank">Try a search</a> to see if the well exists in the system before submitting a report.</p>
-      <p>All form fields marked with a trailing asterisk are mandatory fields.</p>
+      <p class="bg-warning p-2">All form fields marked with a trailing asterisk are mandatory fields.</p>
 
       <!-- Form load/save -->
       <b-row v-if="!isStaffEdit">


### PR DESCRIPTION
## Pull Request Standards
- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description
This PR includes the following proposed change(s):
- Added `bg-warning` class to text "All form fields marked with a trailing asterisk are mandatory fields." on [Submit Report](https://gwells-staging.apps.silver.devops.gov.bc.ca/gwells/submissions) page.
- ![image](https://github.com/bcgov/gwells/assets/127158867/d3954a3d-3d79-417c-a6b0-a9d2b688fca5)
- ![Screenshot 2024-07-09 at 3 42 46 PM](https://github.com/bcgov/gwells/assets/127158867/d50af518-fe8e-4844-bc05-06e761200f54)


