### PR TITLE
Gwells/2212pid dashes

### DIFF
--- a/app/backend/wells/filters.py
+++ b/app/backend/wells/filters.py
@@ -569,7 +569,7 @@ class WellListFilter(AnyOrAllFilterSet):
         # Check if we have a positive integer before querying the
         # legal_pid field.
         try:
-            int_value = int(value.replace("-",""))
+            int_value = int(value.replace("-", ""))
         except (TypeError, ValueError):
             pass
         else:

--- a/app/backend/wells/models.py
+++ b/app/backend/wells/models.py
@@ -1912,10 +1912,6 @@ class ActivitySubmission(AuditModelStructure):
             if not self.create_date:
                 self.create_date = timezone.now()
 
-        # Logic already on the frontend in filters.py
-        # if self.legal_pid:
-        #     self.legal_pid = self.legal_pid.replace('-', '')
-
         return super().save(*args, **kwargs)
 
 

--- a/app/backend/wells/models.py
+++ b/app/backend/wells/models.py
@@ -1912,8 +1912,9 @@ class ActivitySubmission(AuditModelStructure):
             if not self.create_date:
                 self.create_date = timezone.now()
 
-        if self.legal_pid:
-            self.legal_pid = self.legal_pid.replace('-', '')
+        # Logic already on the frontend in filters.py
+        # if self.legal_pid:
+        #     self.legal_pid = self.legal_pid.replace('-', '')
 
         return super().save(*args, **kwargs)
 

--- a/app/backend/wells/models.py
+++ b/app/backend/wells/models.py
@@ -1912,6 +1912,9 @@ class ActivitySubmission(AuditModelStructure):
             if not self.create_date:
                 self.create_date = timezone.now()
 
+        if self.legal_pid:
+            self.legal_pid = self.legal_pid.replace('-', '')
+
         return super().save(*args, **kwargs)
 
 

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -191,7 +191,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           <p class="font-weight-bold">3) Parcel Identifier (PID)</p>
           <form-input
               id="legalPID"
-              type="number"
+              type="text"
               hint="*Input a 9 digit number (including leading zeroes, if necessary)"
               v-model="legalPIDInput"
               :errors="errors['legal_pid']"

--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -702,7 +702,8 @@ export default {
       const locationAddressValidate = !!street_address && !!city;
       // for legalDescription a user is only required to fill in a minimum one field
       const legalDescriptionValidate = legalDescriptionFields.some((item) => !!item);
-      const pidAddressValidate = legal_pid > 0;
+      const pidNum = legal_pid.replace(/-/g, '');
+      const pidAddressValidate = Number(pidNum) > 0;
 
       if(locationAddressValidate || legalDescriptionValidate || pidAddressValidate) { return; }
       errors.well_location_section = ['Well location not filled out'];

--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -275,6 +275,10 @@ export default {
         data.well = data.well.well_tag_number
       }
 
+      if (data.legal_pid) {
+        data.legal_pid = data.legal_pid.replace(/-/g, '');
+      }
+
       if (!this.isStaffEdit) {
         let skipKeys = []
         // we need both ground elevation and its method to be sent for validation on submission
@@ -322,7 +326,7 @@ export default {
         if (window.location.href.indexOf('localhost:8080') > -1 ||
             window.location.href.indexOf('gwells-dev-pr') > -1 ||
             window.location.href.indexOf('gwells-staging') > -1
-        ) { 
+        ) {
           testEnv = true
         }
 
@@ -587,7 +591,7 @@ export default {
     },
     groundwaterProtectionRegulationValidation(errors) {
       const {
-        owner_full_name, 
+        owner_full_name,
         owner_mailing_address,
         owner_city,
         owner_province_state,
@@ -614,7 +618,7 @@ export default {
       }
     },
     validateWellIdentificationPlateFields(errors) {
-      const { 
+      const {
         well_class,
         identification_plate_number,
         well_identification_plate_attached,
@@ -622,7 +626,7 @@ export default {
 
       const validateWellClasses = [WELL_CLASS.WATER_SUPPLY, WELL_CLASS.INJECTION, WELL_CLASS.RECHARGE]
       const isWellIdentificationPlateToBeVerified = validateWellClasses.includes(well_class)
-      
+
       if (isWellIdentificationPlateToBeVerified == false) { return; }
 
       if (!identification_plate_number) {
@@ -633,11 +637,11 @@ export default {
       }
     },
     validateWellFields(errors) {
-      const { 
-        work_start_date, 
-        work_end_date, 
-        drilling_methods, 
-        total_depth_drilled, 
+      const {
+        work_start_date,
+        work_end_date,
+        drilling_methods,
+        total_depth_drilled,
         finished_well_depth
       } = this.form;
 
@@ -650,19 +654,19 @@ export default {
       if (drilling_methods.length === 0) {
         errors.drilling_methods = ['Drilling Methods Required.'];
       }
-      if (!total_depth_drilled) { 
-        errors.total_depth_drilled = ['Total Depth Drilled Required.']; 
+      if (!total_depth_drilled) {
+        errors.total_depth_drilled = ['Total Depth Drilled Required.'];
       }
-      if (!finished_well_depth) { 
-        errors.finished_well_depth = ['Finished Well Depth Required.']; 
+      if (!finished_well_depth) {
+        errors.finished_well_depth = ['Finished Well Depth Required.'];
       }
     },
     newlyConstructedWellValidation(errors) {
-      const { 
+      const {
         work_start_date,
         work_end_date,
       } = this.form
-      
+
       const mandatoryLicensingDate = NEW_WELL_CONSTRUCTION_VALIDATION_DATE;
 
       const workStartDatePastWorkEndDate = ((work_start_date !== '' && work_end_date !== '') && work_start_date > work_end_date);
@@ -730,14 +734,14 @@ export default {
           if (!this.form.latitude){
             errors.latitude = ['Valid Latitude Required'];
           }
-          if (!this.form.longitude) { 
+          if (!this.form.longitude) {
             errors.longitude = ['Valid Longitude Required']
           }
         } else if (wellCoordsNotWithinBC) {
           errors.position = ['Coordinates not within BC']
         }
       }
-      
+
       // Always validate well_class and intended_water_use except for ALT or DEC submissions with a
       // well_tag_number specified
       if (validateWellClassAndIntendedWaterUse) {

--- a/tests/api-tests/submissions_api_tests.json
+++ b/tests/api-tests/submissions_api_tests.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "e90dc2af-da89-4df4-a49c-71d29b09c874",
+		"_postman_id": "8f8fdc37-50fd-4fe6-a3b4-e51a83c1c108",
 		"name": "GWELLS Submissions API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "33152761"
+		"_exporter_id": "37028467"
 	},
 	"item": [
 		{
@@ -391,7 +391,6 @@
 									},
 									{
 										"key": "Content-Type",
-										"name": "Content-Type",
 										"value": "application/json",
 										"type": "text"
 									}
@@ -2018,6 +2017,74 @@
 					"name": "Decommission",
 					"item": [
 						{
+							"name": "Log in Copy",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											"var jsonData = pm.response.json()",
+											"pm.environment.set(\"token\", jsonData.access_token);",
+											"",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.expect(pm.response.code, \"Login was not successful\").to.equal(200);",
+											"})",
+											"",
+											"pm.test(\"A token was returned\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.access_token, \"a token was not returned\").to.be.ok;",
+											"    pm.expect(jsonData.access_token.length).to.be.above(36);",
+											"});",
+											""
+										]
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "{{client_secret}}",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "{{client_id}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded"
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "grant_type",
+											"value": "client_credentials",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{auth_server}}",
+									"host": [
+										"{{auth_server}}"
+									]
+								},
+								"description": "Get token (log in)"
+							},
+							"response": []
+						},
+						{
 							"name": "Decommission well",
 							"event": [
 								{
@@ -2598,6 +2665,74 @@
 							]
 						},
 						{
+							"name": "Log in Copy",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											"var jsonData = pm.response.json()",
+											"pm.environment.set(\"token\", jsonData.access_token);",
+											"",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.expect(pm.response.code, \"Login was not successful\").to.equal(200);",
+											"})",
+											"",
+											"pm.test(\"A token was returned\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.access_token, \"a token was not returned\").to.be.ok;",
+											"    pm.expect(jsonData.access_token.length).to.be.above(36);",
+											"});",
+											""
+										]
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "{{client_secret}}",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "{{client_id}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded"
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "grant_type",
+											"value": "client_credentials",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{auth_server}}",
+									"host": [
+										"{{auth_server}}"
+									]
+								},
+								"description": "Get token (log in)"
+							},
+							"response": []
+						},
+						{
 							"name": "staff_edit Get",
 							"event": [
 								{
@@ -2945,7 +3080,6 @@
 									},
 									{
 										"key": "Content-Type",
-										"name": "Content-Type",
 										"value": "application/json",
 										"type": "text"
 									}
@@ -3080,7 +3214,6 @@
 									},
 									{
 										"key": "Content-Type",
-										"name": "Content-Type",
 										"value": "application/x-www-form-urlencoded",
 										"type": "text"
 									}

--- a/tests/api-tests/submissions_v2_api_tests.json
+++ b/tests/api-tests/submissions_v2_api_tests.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "5af206dc-0c56-4a30-b354-9ba715416251",
+		"_postman_id": "d906d14c-be47-49d7-a5d0-524794bc2d59",
 		"name": "GWELLS Submissions API v2",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "33152761"
+		"_exporter_id": "37028467"
 	},
 	"item": [
 		{
@@ -349,7 +349,6 @@
 									},
 									{
 										"key": "Content-Type",
-										"name": "Content-Type",
 										"value": "application/json",
 										"type": "text"
 									}
@@ -1878,7 +1877,7 @@
 					"name": "Decommission",
 					"item": [
 						{
-							"name": "Log in Copy",
+							"name": "Log in Copy 3",
 							"event": [
 								{
 									"listen": "test",
@@ -2480,6 +2479,74 @@
 							]
 						},
 						{
+							"name": "Log in Copy 2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											"var jsonData = pm.response.json()",
+											"pm.environment.set(\"token\", jsonData.access_token);",
+											"",
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.expect(pm.response.code, \"Login was not successful\").to.equal(200);",
+											"})",
+											"",
+											"pm.test(\"A token was returned\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.access_token, \"a token was not returned\").to.be.ok;",
+											"    pm.expect(jsonData.access_token.length).to.be.above(36);",
+											"});",
+											""
+										]
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "password",
+											"value": "{{client_secret}}",
+											"type": "string"
+										},
+										{
+											"key": "username",
+											"value": "{{client_id}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded"
+									}
+								],
+								"body": {
+									"mode": "urlencoded",
+									"urlencoded": [
+										{
+											"key": "grant_type",
+											"value": "client_credentials",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{auth_server}}",
+									"host": [
+										"{{auth_server}}"
+									]
+								},
+								"description": "Get token (log in)"
+							},
+							"response": []
+						},
+						{
 							"name": "Construction Submission",
 							"event": [
 								{
@@ -2766,7 +2833,6 @@
 									},
 									{
 										"key": "Content-Type",
-										"name": "Content-Type",
 										"value": "application/json",
 										"type": "text"
 									}
@@ -2901,7 +2967,6 @@
 									},
 									{
 										"key": "Content-Type",
-										"name": "Content-Type",
 										"value": "application/x-www-form-urlencoded",
 										"type": "text"
 									}
@@ -3125,6 +3190,74 @@
 		{
 			"name": "Stacking",
 			"item": [
+				{
+					"name": "Log in Copy",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"exec": [
+									"var jsonData = pm.response.json()",
+									"pm.environment.set(\"token\", jsonData.access_token);",
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.expect(pm.response.code, \"Login was not successful\").to.equal(200);",
+									"})",
+									"",
+									"pm.test(\"A token was returned\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.access_token, \"a token was not returned\").to.be.ok;",
+									"    pm.expect(jsonData.access_token.length).to.be.above(36);",
+									"});",
+									""
+								]
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "{{client_secret}}",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "{{client_id}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "grant_type",
+									"value": "client_credentials",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{auth_server}}",
+							"host": [
+								"{{auth_server}}"
+							]
+						},
+						"description": "Get token (log in)"
+					},
+					"response": []
+				},
 				{
 					"name": "Submission - construction submission",
 					"event": [


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description
On the submit report page you can now enter the parcel identifier with dashes and it will be saved without dashes.

This PR includes the following proposed change(s):
- for pid number dashes are valid input for entry
- for pid number dashes are not saved to the database
- for pid number although it is now a text entry instead of number it still throws an error when characters other than dashes and numbers are entered
- Before changes: <img width="576" alt="Screenshot 2024-07-11 at 8 20 28 AM" src="https://github.com/bcgov/gwells/assets/127158867/412cb6de-5abf-4b35-abd1-0d89f3f60a84">
- After changes: <img width="594" alt="Screenshot 2024-07-11 at 8 22 57 AM" src="https://github.com/bcgov/gwells/assets/127158867/7195289c-6528-4108-8dff-004b80bae426">
- Displays with dashes but saves to database without <img width="1330" alt="Screenshot 2024-07-11 at 8 24 15 AM" src="https://github.com/bcgov/gwells/assets/127158867/fc0cc00f-d5fa-4fb8-a046-eb1ebf45447f">
- Characters other than dashes and numbers throws an error <img width="599" alt="Screenshot 2024-07-11 at 8 46 21 AM" src="https://github.com/bcgov/gwells/assets/127158867/4bc39491-0d21-4d33-bd8c-7102e2029f2d">
