### PR TITLE
[GWELLS-2265] Feature** Stores user column preferences in local storagre

### DIFF
--- a/app/frontend/src/wells/components/SearchColumnSelect.vue
+++ b/app/frontend/src/wells/components/SearchColumnSelect.vue
@@ -272,9 +272,10 @@ export default {
       const columnIds = [...this.localSelectedColumnIds]
       columnIds.sort((columnA, columnB) => {
         return this.columnOrders[columnA] - this.columnOrders[columnB]
-      })
-      this.$store.commit(SET_SEARCH_RESULT_COLUMNS, columnIds)
-      this.hideModal()
+      });
+      localStorage.setItem('userColumnPreferences', JSON.stringify(columnIds));
+      this.$store.commit(SET_SEARCH_RESULT_COLUMNS, columnIds);
+      this.hideModal();
     },
     cancelChanges () {
       this.localSelectedColumnIds = [...this.selectedColumnIds]
@@ -283,9 +284,12 @@ export default {
     }
   },
   created () {
-    this.localSelectedColumnIds = [...this.selectedColumnIds]
-    this.initColumnOrders()
-
+    if (localStorage && localStorage.getItem('userColumnPreferences')) {
+      this.localSelectedColumnIds = JSON.parse(localStorage.getItem('userColumnPreferences'));
+    } else {
+      this.localSelectedColumnIds = [...this.selectedColumnIds];
+    }
+    this.initColumnOrders();
     // listen for reset wells search so we can adjust our selected search columns
     this.$store.subscribeAction((action, state) => {
       if (action.type === RESET_WELLS_SEARCH) {

--- a/app/frontend/src/wells/components/SearchResults.vue
+++ b/app/frontend/src/wells/components/SearchResults.vue
@@ -147,6 +147,7 @@ import SearchResultExports from '@/wells/components/SearchResultExports.vue'
 import SearchResultFilter from '@/wells/components/SearchResultFilter.vue'
 import SearchColumnSelect from '@/wells/components/SearchColumnSelect.vue'
 import filterMixin from '@/wells/components/mixins/filters.js'
+import { SET_SEARCH_RESULT_COLUMNS } from '../store/mutations.types'
 
 export default {
   mixins: [filterMixin],
@@ -328,6 +329,9 @@ export default {
     }
   },
   created () {
+    if(localStorage && localStorage.getItem('userColumnPreferences')) {
+      this.$store.commit(SET_SEARCH_RESULT_COLUMNS, JSON.parse(localStorage.getItem('userColumnPreferences')));
+    }
     this.initFilterParams()
   }
 }


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description
Saves the user's column preferences to local storage to ensure they persist across sessions, including when the user logs out, refreshes the page, or closes and reopens the app.

This PR includes the following proposed change(s):
- Saves user column preferences to local storage.
- Sets columns to local storage values upon refresh if they exist, otherwise falls back to default values.