### PR TITLE
[GWELLS-2270] FIX** Change to aquifer colour

### DIFF
--- a/app/frontend/src/common/mapbox/layers.js
+++ b/app/frontend/src/common/mapbox/layers.js
@@ -414,7 +414,7 @@ export function aquifersLineLayer (options = {}) {
       ['boolean', ['feature-state', 'focused'], false], 'purple',
       ['boolean', ['feature-state', 'selected'], false], 'green',
       ['boolean', ['feature-state', 'searchResult'], false], 'purple',
-      '#FF6500'
+      '#38A800'
     ],
     'line-width': [
       'case',
@@ -438,7 +438,7 @@ export function aquifersFillLayer (options = {}) {
       ['boolean', ['feature-state', 'focused'], false], 'purple',
       ['boolean', ['feature-state', 'selected'], false], 'green',
       ['boolean', ['feature-state', 'searchResult'], false], 'purple',
-      '#FF6500'
+      '#38A800'
     ],
     'fill-opacity': [
       'case',

--- a/app/frontend/src/common/mapbox/layers.js
+++ b/app/frontend/src/common/mapbox/layers.js
@@ -414,7 +414,7 @@ export function aquifersLineLayer (options = {}) {
       ['boolean', ['feature-state', 'focused'], false], 'purple',
       ['boolean', ['feature-state', 'selected'], false], 'green',
       ['boolean', ['feature-state', 'searchResult'], false], 'purple',
-      '#38A800'
+      '#de2d26'
     ],
     'line-width': [
       'case',
@@ -438,7 +438,7 @@ export function aquifersFillLayer (options = {}) {
       ['boolean', ['feature-state', 'focused'], false], 'purple',
       ['boolean', ['feature-state', 'selected'], false], 'green',
       ['boolean', ['feature-state', 'searchResult'], false], 'purple',
-      '#38A800'
+      '#de2d26'
     ],
     'fill-opacity': [
       'case',


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Change of aquifer line and fill colour to Hex #686868 (green)
- Before change cadastral and aquifers were both orange ![Screenshot 2024-08-06 at 2 10 58 PM](https://github.com/user-attachments/assets/96856568-dc0d-4bf3-ba13-0ba5e781e69e)
- ![Screenshot 2024-08-06 at 2 08 54 PM](https://github.com/user-attachments/assets/44339a02-88e2-4c1a-982c-62f28672b54f)
- On Hover ![Screenshot 2024-08-06 at 2 09 00 PM](https://github.com/user-attachments/assets/dc5136f0-55df-4a8c-b22f-35510ea8a068)
- Searched aquifer still shows as purple while others are now green instead of orange ![Screenshot 2024-08-06 at 2 10 36 PM](https://github.com/user-attachments/assets/7d44b987-9bd4-4810-8e10-d810ae6cd321)
