### PR TITLE
[GWELLS-2268] Styling** Added CSS to make search result header sticky

### DIFF
--- a/app/frontend/src/wells/components/SearchResults.vue
+++ b/app/frontend/src/wells/components/SearchResults.vue
@@ -404,14 +404,5 @@ $spinner-border-width-sm: .2em !default;
   top: 0;
   background-color: white;
   z-index: 2;
-  margin: 0; /* Remove any margin */
-  padding: 0; /* Remove any padding */
-}
-
-.sticky-header tr {
-  width: 100%;
-  background-color: white; /* Ensure the background color matches the table */
-  margin: 0; /* Remove any margin */
-  padding: 0; /* Remove any padding */
 }
 </style>

--- a/app/frontend/src/wells/components/SearchResults.vue
+++ b/app/frontend/src/wells/components/SearchResults.vue
@@ -26,7 +26,7 @@
     </b-row>
     <div class="table-responsive">
       <table id="searchResultsTable" class="table table-striped">
-        <thead>
+        <thead class="sticky-header">
           <tr>
             <th
               v-for="column in columns"
@@ -397,5 +397,21 @@ $spinner-border-width-sm: .2em !default;
   width: $spinner-width-sm;
   height: $spinner-height-sm;
   border-width: $spinner-border-width-sm;
+}
+
+.sticky-header {
+  position: sticky;
+  top: 0;
+  background-color: white;
+  z-index: 2;
+  margin: 0; /* Remove any margin */
+  padding: 0; /* Remove any padding */
+}
+
+.sticky-header tr {
+  width: 100%;
+  background-color: white; /* Ensure the background color matches the table */
+  margin: 0; /* Remove any margin */
+  padding: 0; /* Remove any padding */
 }
 </style>


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [x] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description
Added CSS to make the search results header sticky so the user can always see the columns.

This PR includes the following proposed change(s):
 
-Updated SearchResults.vue to add a .sticky-header class to the <thead> element.

If you look in the photo you can see that the rows now scroll behind the headers while they remain stuck at the top:

<img width="656" alt="Screenshot 2024-08-06 at 4 28 04 PM" src="https://github.com/user-attachments/assets/ae71f5e6-8ed8-4973-92f4-b9d2b05008f4">
