### PR TITLE
upgrade: [GWELLS-2248] Upgrade Python from 3.7 to 3.11

### DIFF
--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.11
 
 RUN apt -y update && apt -y install git build-essential gdal-bin libgdal-dev postgresql-client
 

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -1,6 +1,5 @@
 django==3.2.4
-pygdal==3.6.2.11
-gdal==3.0.0
+gdal==3.3.0
 pytz==2024.1
 sqlparse==0.4.4
 
@@ -29,8 +28,8 @@ coverage==7.2.0
 MarkupSafe==2.1.5
 
 gunicorn==19.9.0
-gevent==1.3.0
+gevent==23.7.0
 django-settings-export>=1.2.1
-lxml==4.6.3
+lxml==4.9.4
 urllib3>=1.24,<1.25
 pyjwt>=2.0,<=2.4.0


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [ ] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Updated Python to 3.11 ([This image](https://hub.docker.com/layers/library/python/3.11/images/sha256-417cb7e303d45183fe1673cad36cc4dfe3564d08e9d527e8cb9fa322c2f577f1) has no critical severity vulnerabilities, but 2 high. What is the bar?)
- Minimally updated Python requirements to work with new Python version
- Removed `pygdal` package