### PR TITLE
fix: Remove frontend service from caddy profile

### DIFF
--- a/app/frontend/Dockerfile
+++ b/app/frontend/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 
 RUN set -x
 RUN cd /app/frontend
-RUN npm ci
+RUN npm install
 RUN npm install -g serve
 RUN npm run build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,12 +112,13 @@ services:
   frontend:
     image: node:22.12.0
     container_name: frontend
+    profiles: [""]
     working_dir: /app/frontend
     environment:
       DEBUG: "True"
       VITE_FRONTEND_TILE_URL: "http://localhost:7800"
       VITE_AXIOS_BASE_URL: "http://localhost:8000/gwells/api/v2/"
-    command: /bin/bash -c "cd /frontend && npm install --legacy-peer-deps && npm run dev"
+    command: /bin/bash -c "cd /frontend && npm install && npm run dev"
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
## Pull Request Standards

- [ ] The title of the PR is accurate
- [ ] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [ ] The PR title includes the ticket number in format of `[GWELLS-###]`
- [ ] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Change ci to install, as package-lock.json syncs were causing issues
- Remove legacy dep flag from frontend and exclude from caddy profile
