### PR TITLE
task: Switch Survey view from bootstrap to primevue

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -16,6 +16,7 @@
     <link rel="shortcut icon" href="favicon.ico" />
     <link href="/src/common/assets/css/index.css" rel="stylesheet">
     <link href="/src/common/assets/css/bootstrap-carryover.css" rel="stylesheet">
+    <link href="/src/common/assets/css/primevue.css" rel="stylesheet">
     <meta name="msapplication-TileColor" content="#ffffff" />
     <meta name="msapplication-TileImage" content="icons/ms-icon-144x144.png" />
     <meta name="theme-color" content="#ffffff" />

--- a/app/frontend/src/common/assets/css/bootstrap-carryover.css
+++ b/app/frontend/src/common/assets/css/bootstrap-carryover.css
@@ -30,6 +30,35 @@ h6 {
     font-size: 1rem
 }
 
+a {
+    color: #1a5a96;
+    text-decoration: none;
+    background-color: transparent;
+    -webkit-text-decoration-skip: objects
+}
+
+a:hover {
+    color: #00f;
+    text-decoration: underline
+}
+
+a:not([href]):not([tabindex]),a:not([href]):not([tabindex]):focus,a:not([href]):not([tabindex]):hover {
+    color: inherit;
+    text-decoration: none
+}
+
+a:not([href]):not([tabindex]):focus {
+    outline: 0
+}
+
+.container {
+    width: 100%;
+    padding-right: 15px;
+    padding-left: 15px;
+    margin-right: auto;
+    margin-left: auto
+}
+
 .table {
     width: 100%;
     max-width: 100%;

--- a/app/frontend/src/common/assets/css/primevue.css
+++ b/app/frontend/src/common/assets/css/primevue.css
@@ -1,0 +1,22 @@
+.p-card {
+    position: relative;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    min-width: 0;
+    word-wrap: break-word;
+}
+
+.p-fieldset {
+    border: none !important;
+    min-width: none;
+}
+
+.p-fieldset-legend {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    margin-bottom: .5rem;
+    font-size: 1.5rem;
+    line-height: inherit;
+    white-space: normal;
+}

--- a/app/frontend/src/common/components/Footer.vue
+++ b/app/frontend/src/common/components/Footer.vue
@@ -6,7 +6,7 @@
           :href="item.route"
           target="_blank"
           rel="noopener"
-          class="text-white px-3 hover:underline decoration-white">
+          class="px-3 hover:underline">
           {{ item.label }}
         </a>
       </template>
@@ -41,17 +41,17 @@ export default {
   border-bottom: 0px !important;
   border-radius: 0px !important;
 }
-.footer .nav-item {
+#footer .nav-item {
   font-size: 13px;
 }
-.footer .nav-link {
+#footer .nav-link {
   padding: .1rem .5rem;
 }
-.footer nav {
+#footer nav {
   min-height: 45px;
 }
-.footer a {
-  color: #fff!important;
+#footer a {
+  color: #ffffff !important;
 }
 
 </style>

--- a/app/frontend/src/common/components/Header.vue
+++ b/app/frontend/src/common/components/Header.vue
@@ -36,7 +36,7 @@
     </Menubar>
     <Menubar v-if="windowWidth > 640" class="bc-nav-links [&>ul>li+li]:border-l [&>ul>li]:border-white" :model="navItems">
       <template #item="{ item, label }">
-        <router-link v-if="item" :to="item.route" class="text-white px-3 hover:underline decoration-white">
+        <router-link v-if="item" :to="item.route" class="px-3 hover:underline">
           {{ label }}
         </router-link>
       </template>
@@ -108,6 +108,9 @@ export default {
 
 <style lang="scss">
 
+#header a {
+  color: #ffffff !important;
+}
 .navbar {
   margin-bottom: 0px;
 }

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -18,6 +18,7 @@ import * as Integrations from "@sentry/integrations";
 // import VueNoty from "vuejs-noty";
 import { createPinia } from "pinia";
 import PrimeVue from 'primevue/config';
+import { definePreset } from '@primeuix/themes';
 import Aura from '@primeuix/themes/aura';
 import {
   Button, InputText, InputMask, Card, Message,Panel,
@@ -154,9 +155,38 @@ app.config.globalProperties.excludeZeroDecimals = filters.excludeZeroDecimals;
 app.config.globalProperties.nullBooleanToYesNo = filters.nullBooleanToYesNo;
 app.config.globalProperties.booleanToYesNo = filters.booleanToYesNo;
 
+const MyPreset = definePreset(Aura, {
+  semantic: {
+    colorScheme: {
+      light: {
+        primary: {
+          color: "#003366",
+          hoverColor: "#002040",
+        }
+      }
+    }
+  },
+  components: {
+    card: {
+      root: {
+        borderRadius: 0,
+      }
+    },
+    fieldset: {
+      root: {
+        padding: 0,
+      },
+      legend: {
+        padding: 0,
+        fontWeight: "inherit",
+      }
+    }
+  }
+})
+
 app.use(PrimeVue, {
   theme: {
-    preset: Aura,
+    preset: MyPreset,
     options: {
       darkModeSelector: false,
     }

--- a/app/frontend/src/surveys/views/Surveys.vue
+++ b/app/frontend/src/surveys/views/Surveys.vue
@@ -1,18 +1,16 @@
 <template>
   <div>
-    <b-card v-if="commonStore.userRoles && commonStore.userRoles.surveys.edit" class="container">
+    <Card v-if="commonStore.userRoles && commonStore.userRoles.surveys.edit" class="container">
       <fieldset>
         <legend id="surveyList">Current Surveys</legend>
-        <b-table
+        <DataTable
           id="survey-table"
-          responsive
-          :fields="fields"
-          show-empty
-          empty-text="There are no surveys available."
-          :items="currentSurveys"
-          :per-page="perPage"
-          :current-page="currentPage"
+          :value="currentSurveys"
+          paginator
+          :totalRecords="totalSurveys"
+          :rows="perPage"
         >
+          <template #empty>There are no surveys available.</template>
           <template v-slot:cell(survey_page)="row">
             {{formatPageName(row.item.survey_page)}}
           </template>
@@ -20,22 +18,16 @@
             <a :href="row.item.survey_link" target="_blank">{{row.item.survey_link}}</a>
           </template>
           <template v-slot:cell(survey_enabled)="data">
-            <b-form-checkbox v-model="row.item.survey_enabled" name="check-button" @input="toggleSurveyEnabled(row.item.survey_guid, row.item.survey_enabled)"/>
+            <Checkbox v-model="row.item.survey_enabled" name="check-button" @input="toggleSurveyEnabled(row.item.survey_guid, row.item.survey_enabled)"/>
           </template>
           <template v-slot:cell(remove)="data">
-            <b-btn type="button" variant="outline-danger" size="sm" @click="handleRemoveSurvey(row.item.survey_guid)"><i class="fa fa-trash"></i></b-btn>
+            <Button type="button" severity="danger" outlined size="small" @click="handleRemoveSurvey(row.item.survey_guid)"><i class="fa fa-trash"></i></Button>
           </template>
-        </b-table>
-        <b-pagination v-if="totalSurveys > perPage"
-          v-model="currentPage"
-          :total-rows="totalSurveys"
-          :per-page="perPage"
-          aria-controls="survey-table"
-        ></b-pagination>
+        </DataTable>
       </fieldset>
       <fieldset>
         <legend>Add a Survey</legend>
-        <b-form @submit.prevent="submitForm" @reset.prevent="resetForm">
+        <Form @submit="submitForm" @reset="resetForm">
           <form-input
             id="surveyTextInput"
             label="Survey text"
@@ -49,8 +41,8 @@
             :errors="errors['survey_link']"
           ></form-input>
 
-          <b-row>
-            <b-col cols="12" sm="6">
+          <tr>
+            <td cols="12" sm="6">
               <form-input
                 id="surveyPageSelect"
                 label="Survey page"
@@ -60,43 +52,43 @@
                 :errors="errors['survey_page']"
                 v-model="form.survey_page"
               ></form-input>
-            </b-col>
-          </b-row>
-          <b-row class="mt-4">
-            <b-col cols="12" sm="6">
-              <b-form-checkbox v-model="form.survey_enabled" name="check-button">
+            </td>
+          </tr>
+          <tr class="mt-4">
+            <td cols="12" sm="6">
+              <Checkbox v-model="form.survey_enabled" name="check-button">
                 Enable survey immediately
-              </b-form-checkbox>
-            </b-col>
-          </b-row>
-          <b-row class="mt-6">
-            <b-col>
-              <b-btn type="submit" variant="primary">Save</b-btn>
-            </b-col>
-          </b-row>
-        </b-form>
+              </Checkbox>
+            </td>
+          </tr>
+          <tr class="mt-6">
+            <td>
+              <Button type="submit">Save</Button>
+            </td>
+          </tr>
+        </Form>
       </fieldset>
-      <b-modal
+      <Dialog
           v-model="removeSurveyModal"
           centered
           title="Confirm remove"
           @shown="focusRemoveModal">
         Are you sure you want to remove this survey?
         <div slot="modal-footer">
-          <b-btn variant="secondary" @click="removeSurveyModal=false;surveyToRemove=null" ref="cancelRemoveBtn">
+          <Button severity="secondary" @click="removeSurveyModal=false;surveyToRemove=null" ref="cancelRemoveBtn">
             Cancel
-          </b-btn>
-          <b-btn variant="danger" @click="removeSurveyModal=false;removeSurvey(surveyToRemove)">
+          </Button>
+          <Button severity="danger" @click="removeSurveyModal=false;removeSurvey(surveyToRemove)">
             Remove
-          </b-btn>
+          </Button>
         </div>
-      </b-modal>
-    </b-card>
-    <b-card v-else class="container">
+      </Dialog>
+    </Card>
+    <Card v-else class="container">
       <b-card-body>
         <div id="loginMsg">Please log in to continue.</div>
       </b-card-body>
-    </b-card>
+    </Card>
   </div>
 
 </template>

--- a/app/frontend/src/surveys/views/Surveys.vue
+++ b/app/frontend/src/surveys/views/Surveys.vue
@@ -1,104 +1,109 @@
 <template>
   <div>
     <Card v-if="commonStore.userRoles && commonStore.userRoles.surveys.edit" class="container">
-      <fieldset>
-        <legend id="surveyList">Current Surveys</legend>
-        <DataTable
-          id="survey-table"
-          :value="currentSurveys"
-          paginator
-          :totalRecords="totalSurveys"
-          :rows="perPage"
-        >
-          <template #empty>There are no surveys available.</template>
-          <template v-slot:cell(survey_page)="row">
-            {{formatPageName(row.item.survey_page)}}
-          </template>
-          <template v-slot:cell(survey_link)="row">
-            <a :href="row.item.survey_link" target="_blank">{{row.item.survey_link}}</a>
-          </template>
-          <template v-slot:cell(survey_enabled)="data">
-            <Checkbox v-model="row.item.survey_enabled" name="check-button" @input="toggleSurveyEnabled(row.item.survey_guid, row.item.survey_enabled)"/>
-          </template>
-          <template v-slot:cell(remove)="data">
-            <Button type="button" severity="danger" outlined size="small" @click="handleRemoveSurvey(row.item.survey_guid)"><i class="fa fa-trash"></i></Button>
-          </template>
-        </DataTable>
-      </fieldset>
-      <fieldset>
-        <legend>Add a Survey</legend>
-        <Form @submit="submitForm" @reset="resetForm">
-          <form-input
-            id="surveyTextInput"
-            label="Survey text"
-            :errors="errors['survey_introduction_text']"
-            v-model="form.survey_introduction_text"
-          ></form-input>
-          <form-input
-            id="surveyLinkInput"
-            label="Survey link"
-            v-model="form.survey_link"
-            :errors="errors['survey_link']"
-          ></form-input>
+      <template #content>
+        <Fieldset legend="Current Surveys" id="surveyList">
+          <DataTable
+            id="survey-table"
+            :value="currentSurveys"
+            paginator
+            :totalRecords="totalSurveys"
+            :rows="perPage"
+          >
+            <template #empty>There are no surveys available.</template>
+            <template v-slot:cell(survey_page)="row">
+              {{formatPageName(row.item.survey_page)}}
+            </template>
+            <template v-slot:cell(survey_link)="row">
+              <a :href="row.item.survey_link" target="_blank">{{row.item.survey_link}}</a>
+            </template>
+            <template v-slot:cell(survey_enabled)="data">
+              <Checkbox v-model="row.item.survey_enabled" name="check-button" @input="toggleSurveyEnabled(row.item.survey_guid, row.item.survey_enabled)" binary/>
+            </template>
+            <template v-slot:cell(remove)="data">
+              <Button type="button" severity="danger" outlined size="small" @click="handleRemoveSurvey(row.item.survey_guid)"><i class="fa fa-trash"></i></Button>
+            </template>
+          </DataTable>
+        </Fieldset>
+        <Fieldset legend="Add a Survey">
+          <Form @submit="submitForm" @reset="resetForm">
+            <form-input
+              id="surveyTextInput"
+              label="Survey text"
+              :errors="errors['survey_introduction_text']"
+              v-model="form.survey_introduction_text"
+            ></form-input>
+            <form-input
+              id="surveyLinkInput"
+              label="Survey link"
+              v-model="form.survey_link"
+              :errors="errors['survey_link']"
+            ></form-input>
 
-          <tr>
-            <td cols="12" sm="6">
-              <form-input
-                id="surveyPageSelect"
-                label="Survey page"
-                select
-                :options="pageOptions"
-                placeholder="Select page"
-                :errors="errors['survey_page']"
-                v-model="form.survey_page"
-              ></form-input>
-            </td>
-          </tr>
-          <tr class="mt-4">
-            <td cols="12" sm="6">
-              <Checkbox v-model="form.survey_enabled" name="check-button">
-                Enable survey immediately
-              </Checkbox>
-            </td>
-          </tr>
-          <tr class="mt-6">
-            <td>
-              <Button type="submit">Save</Button>
-            </td>
-          </tr>
-        </Form>
-      </fieldset>
-      <Dialog
-          v-model="removeSurveyModal"
-          centered
-          title="Confirm remove"
-          @shown="focusRemoveModal">
-        Are you sure you want to remove this survey?
-        <div slot="modal-footer">
-          <Button severity="secondary" @click="removeSurveyModal=false;surveyToRemove=null" ref="cancelRemoveBtn">
-            Cancel
-          </Button>
-          <Button severity="danger" @click="removeSurveyModal=false;removeSurvey(surveyToRemove)">
-            Remove
-          </Button>
-        </div>
-      </Dialog>
+            <div class="grid grid-cols-12 gap-4">
+              <div class="col-span-12 sm:col-span-6">
+                <form-input
+                  id="surveyPageSelect"
+                  label="Survey page"
+                  select
+                  :options="pageOptions"
+                  placeholder="Select page"
+                  :errors="errors['survey_page']"
+                  v-model="form.survey_page"
+                ></form-input>
+              </div>
+            </div>
+            <div class="grid grid-cols-12 gap-4 mt-4">
+              <div class="col-span-12 sm:col-span-6">
+                <div class="flex items-center gap-2">
+                  <Checkbox v-model="form" inputId="survey_enabled" name="check-button" binary />
+                  <label for="survey_enabled">Enable survey immediately</label>
+                </div>
+              </div>
+            </div>
+            <div class="grid grid-cols-12 gap-4 mt-6">
+              <div>
+                <Button type="submit">Save</Button>
+              </div>
+            </div>
+          </Form>
+        </Fieldset>
+        <Dialog
+            v-model="removeSurveyModal"
+            centered
+            title="Confirm remove"
+            @shown="focusRemoveModal">
+          Are you sure you want to remove this survey?
+          <div slot="modal-footer">
+            <Button severity="secondary" @click="removeSurveyModal=false;surveyToRemove=null" ref="cancelRemoveBtn">
+              Cancel
+            </Button>
+            <Button severity="danger" @click="removeSurveyModal=false;removeSurvey(surveyToRemove)">
+              Remove
+            </Button>
+          </div>
+        </Dialog>
+      </template>
     </Card>
     <Card v-else class="container">
-      <b-card-body>
-        <div id="loginMsg">Please log in to continue.</div>
-      </b-card-body>
+      <template #content>
+        <div id="loginMsg" class="p-6">Please log in to continue.</div>
+      </template>
     </Card>
   </div>
 
 </template>
 
 <script>
+import { Fieldset } from 'primevue';
 import ApiService from '@/common/services/ApiService.js'
 import { useCommonStore } from '@/stores/common.js'
 
 export default {
   name: 'Surveys',
+  components: {
+    Fieldset
+  },
   data () {
     return {
       currentSurveys: [],


### PR DESCRIPTION
e## Pull Request Standards

- [ ] The title of the PR is accurate
- [ ] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [ ] The PR title includes the ticket number in format of `[GWELLS-###]`
- [ ] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Changed Survey.vue components to primevue
- Added a few primevue theme changes and another file for properties w/o variables
- Copied over link styling from bootstrap
- Fixed footer styling logic

Here is the old vs new:

<img width="1440" height="921" alt="Screenshot 2026-05-06 at 3 46 17 PM" src="https://github.com/user-attachments/assets/7c7c0a7f-2d66-491c-a4cc-2b22bf7ae900" />

<img width="1436" height="516" alt="Screenshot 2026-05-06 at 3 46 24 PM" src="https://github.com/user-attachments/assets/8322ae95-89c9-4d8f-9328-30e503fcb82b" />

Still not 100% match but much closer than the QAQC page.