### PR TITLE
task: [GWELLS-2541] Migrate submissions components to PrimeVue

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -3929,6 +3929,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3968,6 +3969,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3988,6 +3990,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4008,6 +4011,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4028,6 +4032,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4048,6 +4053,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4068,6 +4074,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4088,6 +4095,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4108,6 +4116,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4128,6 +4137,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4148,6 +4158,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4168,6 +4179,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4188,6 +4200,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4208,6 +4221,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4225,6 +4239,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11930,7 +11945,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11970,7 +11985,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -16422,6 +16437,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },

--- a/app/frontend/src/common/assets/css/primevue.css
+++ b/app/frontend/src/common/assets/css/primevue.css
@@ -6,6 +6,10 @@
     word-wrap: break-word;
 }
 
+.p-card-title {
+    margin-bottom: 0.75rem;
+}
+
 .p-fieldset {
     border: none !important;
     min-width: none;

--- a/app/frontend/src/common/components/ResponsiveGrid.vue
+++ b/app/frontend/src/common/components/ResponsiveGrid.vue
@@ -24,6 +24,7 @@ export default {
     md: [Number, Array],
     lg: [Number, Array],
     xl: [Number, Array],
+    innerDivClass: [String, Array],
   },
   methods: {
     getClassNames (index) {
@@ -86,6 +87,16 @@ export default {
           }
         } else {
           classNames.push(`xl:col-span-${this.xl}`)
+        }
+      }
+      // Other styling classes
+      if (this.innerDivClass) {
+        if (Array.isArray(this.innerDivClass)) {
+          if (this.innerDivClass[index]) {
+            classNames.push(this.innerDivClass[index])
+          }
+        } else {
+          classNames.push(this.innerDivClass)
         }
       }
 

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -25,7 +25,9 @@ import {
   Select, MultiSelect, RadioButton, RadioButtonGroup,
   Checkbox, CheckboxGroup, Listbox, ProgressSpinner,
   Breadcrumb, Dialog, DataTable, Column, FileUpload,
-  Textarea, Menubar, ScrollTop, InputGroupAddon, Tabs, TabList, Tab, TabPanels, TabPanel, ConfirmDialog
+  Textarea, Menubar, ScrollTop, InputGroupAddon, Tabs,
+  TabList, Tab, TabPanels, TabPanel, ConfirmDialog,
+  Badge
 } from 'primevue';
 import { Form } from '@primevue/forms';
 import ConfirmationService from 'primevue/confirmationservice';
@@ -129,6 +131,7 @@ app.component("TabList", TabList);
 app.component("TabPanel", TabPanel);
 app.component("TabPanels", TabPanels);
 app.component("ConfirmDialog", ConfirmDialog);
+app.component("Badge", Badge);
 
 const pinia = createPinia();
 app.use(pinia);

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -179,6 +179,9 @@ const MyPreset = definePreset(Aura, {
     card: {
       root: {
         borderRadius: 0,
+      },
+      title: {
+        fontSize: "2.5rem",
       }
     },
     fieldset: {
@@ -188,6 +191,14 @@ const MyPreset = definePreset(Aura, {
       legend: {
         padding: 0,
         fontWeight: "inherit",
+      }
+    },
+    checkbox: {
+      root: {
+        background: "var(--p-gray-200)",
+        checkedBackground: "#017bff",
+        checkedBorderColor: "#017bff",
+        checkedHoverBackground: "#00f",
       }
     }
   }

--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -21,13 +21,11 @@ import PrimeVue from 'primevue/config';
 import { definePreset } from '@primeuix/themes';
 import Aura from '@primeuix/themes/aura';
 import {
-  Button, InputText, InputMask, Card, Message,Panel,
+  Button, InputText, InputMask, Card, Message,
   Select, MultiSelect, RadioButton, RadioButtonGroup,
   Checkbox, CheckboxGroup, Listbox, ProgressSpinner,
   Breadcrumb, Dialog, DataTable, Column, FileUpload,
-  Textarea, Menubar, ScrollTop, InputGroupAddon, Tabs,
-  TabList, Tab, TabPanels, TabPanel, ConfirmDialog,
-  Badge
+  Textarea, Menubar, ScrollTop, Tabs, TabList, Tab
 } from 'primevue';
 import { Form } from '@primevue/forms';
 import ConfirmationService from 'primevue/confirmationservice';
@@ -106,7 +104,6 @@ app.component("InputText", InputText);
 app.component("InputMask", InputMask)
 app.component("Card", Card);
 app.component("Message", Message);
-app.component("Panel", Panel);
 app.component("Select", Select);
 app.component("MultiSelect", MultiSelect)
 app.component("RadioButton", RadioButton);
@@ -124,14 +121,9 @@ app.component("FileUpload", FileUpload)
 app.component("Textarea", Textarea)
 app.component("Menubar", Menubar);
 app.component("ScrollTop", ScrollTop);
-app.component("InputGroupAddon", InputGroupAddon);
-app.component("Tab", Tab);
 app.component("Tabs", Tabs);
 app.component("TabList", TabList);
-app.component("TabPanel", TabPanel);
-app.component("TabPanels", TabPanels);
-app.component("ConfirmDialog", ConfirmDialog);
-app.component("Badge", Badge);
+app.component("Tab", Tab);
 
 const pinia = createPinia();
 app.use(pinia);

--- a/app/frontend/src/qaqc/components/QaQcFilters.vue
+++ b/app/frontend/src/qaqc/components/QaQcFilters.vue
@@ -44,14 +44,12 @@
         :value-field="valueField"
         :text-field="textField"
         v-model="localValue[paramNames[0]]"
-        @keyup.enter="applyFilter" />
-      <!-- There isn't a replacement. Will need to redo error logic later.
-      <b-form-invalid-feedback :id="`${id}InvalidFeedback`">
-        <div v-for="(error, index) in errors" :key="`${id}Input error ${index}`">
+        @keyup.enter="applyFilter"/>
+      <div :id="`${id}InvalidFeedback`">
+        <div v-for="(error, index) in errors" class="mt-1 text-sm text-red-600" :key="`${id}Input error ${index}`">
           {{ error }}
         </div>
-      </b-form-invalid-feedback>
-      -->
+      </div>
     </div>
     <div class="col-span-12" v-if="type === 'nullcheck'">
       <div>
@@ -63,13 +61,11 @@
           <span class="fa fa-sm mb-1 pl-1" :class="{'fa-check': !isActive, 'fa-times': isActive}" :aria-label="isActive ? 'Clear' : 'Apply'" />
         </Button>
       </div>
-      <!-- There isn't a replacement. Will need to redo error logic later.
-      <b-form-invalid-feedback :id="`${id}InvalidFeedback`">
-        <div v-for="(error, index) in errors" :key="`${id}Input error ${index}`">
+      <div :id="`${id}InvalidFeedback`">
+        <div v-for="(error, index) in errors" class="mt-1 text-sm text-red-600" :key="`${id}Input error ${index}`">
           {{ error }}
         </div>
-      </b-form-invalid-feedback>
-      -->
+      </div>
     </div>
     <div class="col-span-5" v-if="type === 'range' || type === 'dateRange'">
       <InputText

--- a/app/frontend/src/qaqc/components/QaQcTable.vue
+++ b/app/frontend/src/qaqc/components/QaQcTable.vue
@@ -160,7 +160,9 @@ export default {
   mixins: [filterMixin],
   components: {
     'qaqc-filters': QaQcFilters,
-    'qaqc-exports': QaQcExports
+    'qaqc-exports': QaQcExports,
+    Badge,
+    Popover
   },
   data () {
     return {

--- a/app/frontend/src/qaqc/views/QaQcDashboard.vue
+++ b/app/frontend/src/qaqc/views/QaQcDashboard.vue
@@ -14,7 +14,6 @@
 <script>
 
 // Import your table components
-import { Tabs, TabList, Tab } from 'primevue'
 import QaQcTable from '../components/QaQcTable.vue'
 import { useSubmissionStore } from '@/stores/submission'
 import { useQAQCStore } from '@/stores/qaqc'
@@ -22,10 +21,7 @@ import { useQAQCStore } from '@/stores/qaqc'
 export default {
   name: 'QaQcDashboard',
   components: {
-    QaQcTable,
-    Tab,
-    TabList,
-    Tabs
+    QaQcTable
   },
   computed: {
     submissionStore() { return useSubmissionStore() },

--- a/app/frontend/src/registry/components/people/ApplicationAddEdit.vue
+++ b/app/frontend/src/registry/components/people/ApplicationAddEdit.vue
@@ -20,7 +20,7 @@
             <span aria-hidden="true">&times;</span>
           </button>
         </h5>
-        <p v-if="loading">
+        <div v-if="loading">
           <div class="grid">
             <div class="row-span-full">
               <div class="fa-2x text-center">
@@ -28,8 +28,8 @@
               </div>
             </div>
           </div>
-        </p>
-        <p v-else>
+        </div>
+        <div v-else>
           <div class="grid">
             <div class="row-span-full">
               <div style="font-weight: bold;">Certification</div>
@@ -117,7 +117,7 @@
           </div>
           <!-- slot for child elements to be added by parent component -->
           <slot></slot>
-        </p>
+        </div>
       </div>
     </div>
   </div>

--- a/app/frontend/src/registry/components/people/ApplicationAddEdit.vue
+++ b/app/frontend/src/registry/components/people/ApplicationAddEdit.vue
@@ -47,7 +47,7 @@
           </div>
           <div class="grid grid-cols-3 gap-6">
             <label class="col-span-1">Select classification</label>
-              <RadioButtonGroup class="fixed-width font-weight-normal pt-2" :options="formOptions.classifications" @change="changedClassification" v-model="qualificationForm.subactivity.registries_subactivity_code" required></RadioButtonGroup>
+            <RadioButtonGroup class="fixed-width font-weight-normal pt-2" :options="formOptions.classifications" @change="changedClassification" v-model="qualificationForm.subactivity.registries_subactivity_code" required></RadioButtonGroup>
           </div>
           <div class="grid grid-cols-4 gap-6">
             <label class="col-span-1">Qualified{{activity === 'DRILL' ? ' to drill' : '' }}</label>

--- a/app/frontend/src/registry/components/search/SearchHome.vue
+++ b/app/frontend/src/registry/components/search/SearchHome.vue
@@ -181,7 +181,7 @@
                     :disabled="loading || isSearchInProgress">
                     <i v-if="isSearchInProgress" class="fa fa-circle-o-notch fa-spin ml-1"/>
                   </Button>
-                  <Button label="Reset" type="button" severity="warn" @click="resetSearch"/>
+                  <Button label="Reset" type="button" severity="secondary" @click="resetSearch"/>
                 </div>
               </Form>
             </div>

--- a/app/frontend/src/registry/components/search/SearchHome.vue
+++ b/app/frontend/src/registry/components/search/SearchHome.vue
@@ -246,6 +246,7 @@ import querystring from 'querystring-es3'
 import mapboxgl from 'mapbox-gl'
 import { omit } from 'lodash'
 import axios from 'axios'
+import { Panel } from 'primevue'
 
 import ApiService from '@/common/services/ApiService.js'
 import RegistryMap from '@/registry/components/search/RegistryMap.vue'
@@ -260,7 +261,8 @@ export default {
     'registry-table': SearchTable,
     'registry-map': RegistryMap,
     'api-error': APIErrorMessage,
-    'register-legal-text': LegalText
+    'register-legal-text': LegalText,
+    Panel
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/FormSubcomponents/FormSubsection.vue
+++ b/app/frontend/src/submissions/components/FormSubcomponents/FormSubsection.vue
@@ -1,0 +1,59 @@
+<template>
+  <fieldset>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 lg:col-span-6">
+        <legend :id="id">{{ title }}</legend>
+        <p v-if="subtitle">{{ subtitle }}</p>
+      </div>
+      <div v-if="!hideSave" class="col-span-12 lg:col-span-6">
+        <div class="float-right">
+          <Button v-if="isStaffEdit" label="Save" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
+          <back-to-top-link v-if="isStaffEdit"/>
+        </div>
+      </div>
+    </div>
+    <slot />
+  </fieldset>
+</template>
+
+
+<script>
+
+export default {
+  props: {
+    title: {
+      required: true,
+      type: String
+    },
+    subtitle: String,
+    hideSave: Boolean,
+    id: {
+      type: String,
+      isInput: false
+    },
+    isStaffEdit: {
+      type: Boolean,
+      isInput: false
+    },
+    saveDisabled: {
+      type: Boolean,
+      isInput: false
+    }
+  },
+  emits: ['save'],
+  computed: {
+  },
+  methods: {
+  },
+  watch: {
+  },
+  data () {
+    return {
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
@@ -536,6 +536,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 </template>
 
 <script>
+import { SelectButton } from 'primevue'
 import smoothScroll from 'smoothscroll'
 
 import ActivityType from './ActivityType.vue'
@@ -665,7 +666,8 @@ export default {
     ObservationWellInfo,
     SubmissionHistory,
     EditHistory,
-    AquiferParameters
+    AquiferParameters,
+    SelectButton
   },
   data () {
     return {
@@ -896,11 +898,13 @@ export default {
       const dateString = event
       const isNewWellConstruction = this.checkNewWellConstructionDates(dateString, dateInputType)
       this.handleNewWellConstruction(isNewWellConstruction)
+    },
+    onFormSave () {
+      // When the form is saved, reset the formValueChanged variable
+      this.formValueChanged = false
     }
   },
   created () {
-    // When the form is saved, reset the formValueChanged variable.
-    this.$parent.$on('formSaved', () => { this.formValueChanged = false })
     if (this.$route.hash) {
       this.step = 1
       this.changeRouteHash(this.step)

--- a/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
@@ -14,8 +14,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
 <template>
   <div>
     <h1 class="card-title">
-      <div class="grid grid-cols-12">
-        <div class="col-span-12">
+      <div class="flex">
+        <div>
           <div v-if="isStaffEdit" id="top">Update Well Information</div>
           <div v-else>Well Activity Submission</div>
           <b-form-group v-if="activityType !== 'STAFF_EDIT'">
@@ -29,8 +29,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
     </h1>
 
     <div v-if="loading">
-      <div class="grid grid-cols-12">
-        <div class="col-span-12">
+      <div class="flex">
+        <div>
           <div class="fa-2x text-center">
             Loading...
           </div>

--- a/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
@@ -39,9 +39,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </div>
     </div>
     <div v-else>
-      <b-alert show v-if="isStaffEdit && isUnpublished" variant="info">
+      <Message v-if="isStaffEdit && isUnpublished" severity="info">
         This well is unpublished and will be hidden from DataBC, iMapBC, GWELLS Well Search, and the CSV/XLS export.
-      </b-alert>
+      </Message>
       <div v-if="isStaffEdit" class="grid grid-cols-12">
         <div class="lg:col-span-3" v-for="step in stepCodes" :key='step'>
           <a :href="`#${step}`" @click.prevent="anchorLinkHandler(step)">{{formStepDescriptions[step] ? formStepDescriptions[step] : step}}</a>

--- a/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
@@ -48,18 +48,21 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
       <!-- Form load/save -->
       <div v-if="!isStaffEdit" class="flex text-right">
-        <b-btn size="sm" variant="outline-primary" class="mr-2" @click="saveForm">
-          Save report progress
-          <transition name="bounce" mode="out-in">
-            <i v-show="saveFormSuccess" class="fa fa-check text-success"></i>
-          </transition>
-        </b-btn>
-        <b-btn size="sm" variant="outline-primary" @click="loadConfirmation" ref="confirmLoadBtn" :disabled="isLoadFormDisabled">
-          Load saved report
-          <transition name="bounce">
-            <i v-show="loadFormSuccess" class="fa fa-check text-success"></i>
-          </transition>
-        </b-btn>
+        <Button
+          label="Save report progress"
+          :icon="saveFormSuccess ? 'fa fa-check text-success animate-bounce':''"
+          size="small"
+          severity="secondary"
+          class="mr-2"
+          @click="saveForm"/>
+        <Button
+          label="Load saved report"
+          :icon="loadFormSuccess ? 'fa fa-check text-success animate-bounce':''"
+          size="small"
+          severity="secondary"
+          @click="loadConfirmation"
+          ref="confirmLoadBtn"
+          :disabled="isLoadFormDisabled"/>
       </div>
 
       <!-- Type of work performed -->

--- a/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
@@ -15,26 +15,22 @@ Licensed under the Apache License, Version 2.0 (the "License");
   <div>
     <h1 class="card-title">
       <div class="flex">
-        <div>
-          <div v-if="isStaffEdit" id="top">Update Well Information</div>
-          <div v-else>Well Activity Submission</div>
-          <b-form-radio-group v-if="activityType !== 'STAFF_EDIT'" button-variant="outline-primary" size="sm" buttons v-model="formIsFlatInput" label="Form layout" class="float-right">
-            <b-form-radio v-bind:value="true" id="singleSubmissionPage">Single page</b-form-radio>
-            <b-form-radio v-bind:value="false" id="multiSubmissionPage">Multi page</b-form-radio>
-          </b-form-radio-group>
+        <div v-if="isStaffEdit" id="top">Update Well Information</div>
+        <div v-else>Well Activity Submission</div>
+        <div class="flex flex-col gap-2 float-right">
+          <label for="formIsFlatInput">Form layout</label>
+          <SelectButton  v-if="activityType !== 'STAFF_EDIT'" size="small" v-model="formIsFlatInput" id="formIsFlatInput" :options="selectOptions"/>
         </div>
       </div>
     </h1>
 
     <div v-if="loading">
       <div class="flex">
-        <div>
-          <div class="fa-2x text-center">
-            Loading...
-          </div>
-          <div class="fa-2x text-center">
-            <i class="fa fa-circle-o-notch fa-spin"></i>
-          </div>
+        <div class="fa-2x text-center">
+          Loading...
+        </div>
+        <div class="fa-2x text-center">
+          <i class="fa fa-circle-o-notch fa-spin"></i>
         </div>
       </div>
     </div>
@@ -51,21 +47,19 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <p class="bg-yellow-400 p-2">All form fields marked with a trailing asterisk are mandatory fields.</p>
 
       <!-- Form load/save -->
-      <div v-if="!isStaffEdit">
-        <div class="text-right">
-          <b-btn size="sm" variant="outline-primary" class="mr-2" @click="saveForm">
-            Save report progress
-            <transition name="bounce" mode="out-in">
-              <i v-show="saveFormSuccess" class="fa fa-check text-success"></i>
-            </transition>
-          </b-btn>
-          <b-btn size="sm" variant="outline-primary" @click="loadConfirmation" ref="confirmLoadBtn" :disabled="isLoadFormDisabled">
-            Load saved report
-            <transition name="bounce">
-              <i v-show="loadFormSuccess" class="fa fa-check text-success"></i>
-            </transition>
-          </b-btn>
-        </div>
+      <div v-if="!isStaffEdit" class="flex text-right">
+        <b-btn size="sm" variant="outline-primary" class="mr-2" @click="saveForm">
+          Save report progress
+          <transition name="bounce" mode="out-in">
+            <i v-show="saveFormSuccess" class="fa fa-check text-success"></i>
+          </transition>
+        </b-btn>
+        <b-btn size="sm" variant="outline-primary" @click="loadConfirmation" ref="confirmLoadBtn" :disabled="isLoadFormDisabled">
+          Load saved report
+          <transition name="bounce">
+            <i v-show="loadFormSuccess" class="fa fa-check text-success"></i>
+          </transition>
+        </b-btn>
       </div>
 
       <!-- Type of work performed -->
@@ -522,7 +516,12 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </div>
 
       <!-- Form reload (load from save) confirmation -->
-      <Dialog v-model:visible="confirmLoadModal" modal header="Confirm load submission data" @show="$refs.confirmLoadConfirmBtn.focus()">
+      <Dialog
+        v-model:visible="confirmLoadModal"
+        modal
+        header="Confirm load submission data"
+        @show="$refs.confirmLoadConfirmBtn.focus()"
+        @after-hide="$refs.loadFormBtn.focus()">
         Are you sure you want to load the previously saved activity report? Your current report will be overwritten.
         <template #footer>
           <Button label="Load" @click="confirmLoadModal=false;loadForm()" ref="confirmLoadConfirmBtn"/>
@@ -720,7 +719,11 @@ export default {
       wellIdentificationPlateAttachedLabel: WELL_SUBMISSION_STRINGS.WELL_IDENTIFICATION_PLATE_ATTACHED,
       totalDepthDrilledLabel: WELL_SUBMISSION_STRINGS.TOTAL_DEPTH_DRILLED,
       finishedWellDepthLabel: WELL_SUBMISSION_STRINGS.FINISHED_WELL_DEPTH,
-      drillingMethodsLabel: WELL_SUBMISSION_STRINGS.DRILLING_METHODS
+      drillingMethodsLabel: WELL_SUBMISSION_STRINGS.DRILLING_METHODS,
+      selectOptions: [
+        { name: "Single page", value: true},
+        { name: "Multi page", value: false },
+      ],
     }
   },
   watch: {

--- a/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
@@ -18,12 +18,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <div>
           <div v-if="isStaffEdit" id="top">Update Well Information</div>
           <div v-else>Well Activity Submission</div>
-          <b-form-group v-if="activityType !== 'STAFF_EDIT'">
-            <b-form-radio-group button-variant="outline-primary" size="sm" buttons v-model="formIsFlatInput" label="Form layout" class="float-right">
-              <b-form-radio v-bind:value="true" id="singleSubmissionPage">Single page</b-form-radio>
-              <b-form-radio v-bind:value="false" id="multiSubmissionPage">Multi page</b-form-radio>
-            </b-form-radio-group>
-          </b-form-group>
+          <b-form-radio-group v-if="activityType !== 'STAFF_EDIT'" button-variant="outline-primary" size="sm" buttons v-model="formIsFlatInput" label="Form layout" class="float-right">
+            <b-form-radio v-bind:value="true" id="singleSubmissionPage">Single page</b-form-radio>
+            <b-form-radio v-bind:value="false" id="multiSubmissionPage">Multi page</b-form-radio>
+          </b-form-radio-group>
         </div>
       </div>
     </h1>
@@ -44,11 +42,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <b-alert show v-if="isStaffEdit && isUnpublished" variant="info">
         This well is unpublished and will be hidden from DataBC, iMapBC, GWELLS Well Search, and the CSV/XLS export.
       </b-alert>
-      <b-row v-if="isStaffEdit">
-          <b-col lg="3" v-for="step in stepCodes" :key='step'>
-            <a :href="`#${step}`" @click.prevent="anchorLinkHandler(step)">{{formStepDescriptions[step] ? formStepDescriptions[step] : step}}</a>
-          </b-col>
-        </b-row>
+      <div v-if="isStaffEdit" class="grid grid-cols-12">
+        <div class="lg:col-span-3" v-for="step in stepCodes" :key='step'>
+          <a :href="`#${step}`" @click.prevent="anchorLinkHandler(step)">{{formStepDescriptions[step] ? formStepDescriptions[step] : step}}</a>
+        </div>
+      </div>
       <p v-if="!isStaffEdit">Submit activity on a well. <a href="/gwells/" target="_blank">Try a search</a> to see if the well exists in the system before submitting a report.</p>
       <p class="bg-yellow-400 p-2">All form fields marked with a trailing asterisk are mandatory fields.</p>
 
@@ -524,20 +522,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </div>
 
       <!-- Form reload (load from save) confirmation -->
-      <b-modal
-        v-model="confirmLoadModal"
-        centered
-        title="Confirm load submission data"
-        @shown="$refs.confirmLoadConfirmBtn.focus()"
-        :return-focus="$refs.loadFormBtn">
+      <Dialog v-model:visible="confirmLoadModal" modal header="Confirm load submission data" @show="$refs.confirmLoadConfirmBtn.focus()">
         Are you sure you want to load the previously saved activity report? Your current report will be overwritten.
-        <div slot="modal-footer">
+        <template #footer>
           <Button label="Load" @click="confirmLoadModal=false;loadForm()" ref="confirmLoadConfirmBtn"/>
-          <b-btn variant="light" @click="confirmLoadModal=false">
-            Cancel
-          </b-btn>
-        </div>
-      </b-modal>
+          <Button label="Cancel" severity="secondary" @click="confirmLoadModal=false"/>
+        </template>
+      </Dialog>
     </div>
   </div>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivitySubmissionForm.vue
@@ -14,8 +14,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
 <template>
   <div>
     <h1 class="card-title">
-      <b-row>
-        <b-col cols="12">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12">
           <div v-if="isStaffEdit" id="top">Update Well Information</div>
           <div v-else>Well Activity Submission</div>
           <b-form-group v-if="activityType !== 'STAFF_EDIT'">
@@ -24,21 +24,21 @@ Licensed under the Apache License, Version 2.0 (the "License");
               <b-form-radio v-bind:value="false" id="multiSubmissionPage">Multi page</b-form-radio>
             </b-form-radio-group>
           </b-form-group>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
     </h1>
 
     <div v-if="loading">
-      <b-row>
-        <b-col cols="12">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12">
           <div class="fa-2x text-center">
             Loading...
           </div>
           <div class="fa-2x text-center">
             <i class="fa fa-circle-o-notch fa-spin"></i>
           </div>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
     </div>
     <div v-else>
       <b-alert show v-if="isStaffEdit && isUnpublished" variant="info">
@@ -50,11 +50,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </b-col>
         </b-row>
       <p v-if="!isStaffEdit">Submit activity on a well. <a href="/gwells/" target="_blank">Try a search</a> to see if the well exists in the system before submitting a report.</p>
-      <p class="bg-warning p-2">All form fields marked with a trailing asterisk are mandatory fields.</p>
+      <p class="bg-yellow-400 p-2">All form fields marked with a trailing asterisk are mandatory fields.</p>
 
       <!-- Form load/save -->
-      <b-row v-if="!isStaffEdit">
-        <b-col class="text-right">
+      <div v-if="!isStaffEdit">
+        <div class="text-right">
           <b-btn size="sm" variant="outline-primary" class="mr-2" @click="saveForm">
             Save report progress
             <transition name="bounce" mode="out-in">
@@ -67,8 +67,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
               <i v-show="loadFormSuccess" class="fa fa-check text-success"></i>
             </transition>
           </b-btn>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
 
       <!-- Type of work performed -->
       <activity-type class="my-12"
@@ -511,17 +511,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
       ></edit-history>
 
       <!-- Back / Next / Submit controls -->
-      <b-row v-else class="mt-12">
-        <b-col v-if="!formIsFlat">
-          <b-btn v-if="step > 1 && !formIsFlat" @click="gotoPrevStep" variant="primary">Back</b-btn>
-        </b-col>
-        <b-col class="pr-6 text-right">
-          <b-btn v-if="step < maxSteps && !formIsFlat" @click="gotoNextStep" variant="primary" id="nextSubmissionStep">Next</b-btn>
+      <div v-else class="flex mt-12">
+        <div v-if="!formIsFlat">
+          <Button v-if="step > 1 && !formIsFlat" label="Back" @click="gotoPrevStep"/>
+        </div>
+        <div class="pr-6 text-right">
+          <Button v-if="step < maxSteps && !formIsFlat" label="Next" @click="gotoNextStep" id="nextSubmissionStep"/>
           <span v-else>
-            <b-btn variant="primary" @click="$emit('preview')" id="formPreviewButton">Preview &amp; Submit</b-btn>
+            <Button label="Preview &amp; Submit" @click="$emit('preview')" id="formPreviewButton"/>
           </span>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
 
       <!-- Form reload (load from save) confirmation -->
       <b-modal
@@ -532,9 +532,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         :return-focus="$refs.loadFormBtn">
         Are you sure you want to load the previously saved activity report? Your current report will be overwritten.
         <div slot="modal-footer">
-          <b-btn variant="primary" @click="confirmLoadModal=false;loadForm()" ref="confirmLoadConfirmBtn">
-            Load
-          </b-btn>
+          <Button label="Load" @click="confirmLoadModal=false;loadForm()" ref="confirmLoadConfirmBtn"/>
           <b-btn variant="light" @click="confirmLoadModal=false">
             Cancel
           </b-btn>

--- a/app/frontend/src/submissions/components/SubmissionForm/ActivityType.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivityType.vue
@@ -16,14 +16,20 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <legend :id="id">Type of Work</legend>
     <responsive-grid :cols="12" :md="6">
       <b-form-group label="Type of Work *">
-        <b-form-radio-group v-model="wellActivityTypeInput"
-          stacked
-          name="submissionTypeRadio"
-          id="reportType">
-          <b-form-radio value="CON" v-if="show.edit">Construction</b-form-radio>
-          <b-form-radio value="ALT" v-if="show.edit">Alteration</b-form-radio>
-          <b-form-radio value="DEC" v-if="show.edit">Decommission</b-form-radio>
-        </b-form-radio-group>
+        <RadioButtonGroup v-if="show.edit" v-model="wellActivityTypeInput">
+          <div class="flex align-items-center">
+            <RadioButton inputId="wellActivityTypeInput.CON" value="CON"/>
+            <label for="wellActivityTypeInput.CDN" class="ml-2">Construction</label>
+          </div>
+          <div class="flex align-items-center">
+            <RadioButton inputId="wellActivityTypeInput.ALT" value="ALT"/>
+            <label for="wellActivityTypeInput.ALT" class="ml-2">Alteration</label>
+          </div>
+          <div class="flex align-items-center">
+            <RadioButton inputId="wellActivityTypeInput.DEC" value="DEC"/>
+            <label for="wellActivityTypeInput.DEC" class="ml-2">Decommission</label>
+          </div>
+        </RadioButtonGroup>
       </b-form-group>
     </responsive-grid>
   </fieldset>

--- a/app/frontend/src/submissions/components/SubmissionForm/ActivityType.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivityType.vue
@@ -14,8 +14,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
 <template>
   <fieldset>
     <legend :id="id">Type of Work</legend>
-    <b-row>
-      <b-col cols="12" md="6">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6">
         <b-form-group label="Type of Work *">
           <b-form-radio-group v-model="wellActivityTypeInput"
                               stacked
@@ -26,8 +26,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
             <b-form-radio value="DEC" v-if="show.edit">Decommission</b-form-radio>
           </b-form-radio-group>
         </b-form-group>
-      </b-col>
-    </b-row>
+      </div>
+    </div>
   </fieldset>
 </template>
 

--- a/app/frontend/src/submissions/components/SubmissionForm/ActivityType.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivityType.vue
@@ -14,26 +14,26 @@ Licensed under the Apache License, Version 2.0 (the "License");
 <template>
   <fieldset>
     <legend :id="id">Type of Work</legend>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6">
-        <b-form-group label="Type of Work *">
-          <b-form-radio-group v-model="wellActivityTypeInput"
-                              stacked
-                              name="submissionTypeRadio"
-                              id="reportType">
-            <b-form-radio value="CON" v-if="show.edit">Construction</b-form-radio>
-            <b-form-radio value="ALT" v-if="show.edit">Alteration</b-form-radio>
-            <b-form-radio value="DEC" v-if="show.edit">Decommission</b-form-radio>
-          </b-form-radio-group>
-        </b-form-group>
-      </div>
-    </div>
+    <responsive-grid :cols="12" :md="6">
+      <b-form-group label="Type of Work *">
+        <b-form-radio-group v-model="wellActivityTypeInput"
+          stacked
+          name="submissionTypeRadio"
+          id="reportType">
+          <b-form-radio value="CON" v-if="show.edit">Construction</b-form-radio>
+          <b-form-radio value="ALT" v-if="show.edit">Alteration</b-form-radio>
+          <b-form-radio value="DEC" v-if="show.edit">Decommission</b-form-radio>
+        </b-form-radio-group>
+      </b-form-group>
+    </responsive-grid>
   </fieldset>
 </template>
 
 <script>
 import { useCommonStore } from '@/stores/common.js'
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
+
 export default {
   mixins: [inputBindingsMixin],
   props: {
@@ -42,6 +42,9 @@ export default {
       type: String,
       isInput: false
     }
+  },
+  components: {
+    ResponsiveGrid
   },
   computed: {
     commonStore () { return useCommonStore() },

--- a/app/frontend/src/submissions/components/SubmissionForm/ActivityType.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ActivityType.vue
@@ -15,8 +15,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
   <fieldset>
     <legend :id="id">Type of Work</legend>
     <responsive-grid :cols="12" :md="6">
-      <b-form-group label="Type of Work *">
-        <RadioButtonGroup v-if="show.edit" v-model="wellActivityTypeInput">
+      <div class="flex flex-col gap-2">
+        <label for="wellActivityTypeInput">Type of Work *</label>
+        <RadioButtonGroup v-if="show.edit" v-model="wellActivityTypeInput" id="wellActivityTypeInput">
           <div class="flex align-items-center">
             <RadioButton inputId="wellActivityTypeInput.CON" value="CON"/>
             <label for="wellActivityTypeInput.CDN" class="ml-2">Construction</label>
@@ -30,7 +31,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             <label for="wellActivityTypeInput.DEC" class="ml-2">Decommission</label>
           </div>
         </RadioButtonGroup>
-      </b-form-group>
+      </div>
     </responsive-grid>
   </fieldset>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
@@ -13,21 +13,22 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 lg:col-span-6">
         <legend :id="id">Aquifer Information</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
+      </div>
+      <div class="col-span-12 lg:col-span-6">
         <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
+          <Button v-if="isStaffEdit" label="Save" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
           <back-to-top-link v-if="isStaffEdit"/>
         </div>
-      </b-col>
-    </b-row>
+      </div>
+    </div>
 
-    <b-row>
-      <b-col cols="12" md="6" xl="3">
-        <b-form-group label="Associated Aquifer">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 xl:col-span-3">
+        <div class="flex flex-col gap-2">
+          <label for="aquiferSelect">Associated Aquifer</label>
           <v-select
             v-model="aquiferInput"
             id="aquiferSelect"
@@ -51,9 +52,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </div>
             </template>
           </v-select>
-        </b-form-group>
-      </b-col>
-      <b-col cols="12" md="4">
+        </div>
+      </div>
+      <div class="col-span-12 md:col-span-4">
         <b-form-group
           id="aquiferLithology"
           label="Aquifer Material">
@@ -69,8 +70,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
             </template>
           </b-form-select>
         </b-form-group>
-      </b-col>
-    </b-row>
+      </div>
+    </div>
   </fieldset>
 </template>
 

--- a/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
@@ -45,7 +45,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <div class="col-span-12 md:col-span-4">
         <div class="flex flex-col gap-2">
           <label for="aquiferLithology">Aquifer Material</label>
-          <Dropdown
+          <Select
             id="aquiferLithology"
             v-model="aquiferLithologyInput"
             optionValue="aquifer_lithology_code"

--- a/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
@@ -13,49 +13,45 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Aquifer Information" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 xl:col-span-3">
-        <div class="flex flex-col gap-2">
-          <label for="aquiferSelect">Associated Aquifer</label>
-          <v-select
-            v-model="aquiferInput"
-            id="aquiferSelect"
-            :filterable="false"
-            :options="aquiferList"
-            :reduce="aquifer => aquifer.aquifer_id"
-            label="description"
-            index="aquifer_id"
-            @search="onAquiferSearch">
-            <template v-slot:no-options>
-                Search for an aquifer by name or id number
-            </template>
-            <template v-slot:cell(option)="option">
-              <div>
-                {{ option.description }}
-              </div>
-            </template>
-            <template v-slot:cell(selected-option)="option">
-              <div>
-                {{ option.description }}
-              </div>
-            </template>
-          </v-select>
-        </div>
+    <responsive-grid :cols="12" :md="[6, 4]" :xl="[3, undefined]">
+      <div class="flex flex-col gap-2">
+        <label for="aquiferSelect">Associated Aquifer</label>
+        <v-select
+          v-model="aquiferInput"
+          id="aquiferSelect"
+          :filterable="false"
+          :options="aquiferList"
+          :reduce="aquifer => aquifer.aquifer_id"
+          label="description"
+          index="aquifer_id"
+          @search="onAquiferSearch">
+          <template v-slot:no-options>
+              Search for an aquifer by name or id number
+          </template>
+          <template v-slot:cell(option)="option">
+            <div>
+              {{ option.description }}
+            </div>
+          </template>
+          <template v-slot:cell(selected-option)="option">
+            <div>
+              {{ option.description }}
+            </div>
+          </template>
+        </v-select>
       </div>
-      <div class="col-span-12 md:col-span-4">
-        <div class="flex flex-col gap-2">
-          <label for="aquiferLithology">Aquifer Material</label>
-          <Select
-            id="aquiferLithology"
-            v-model="aquiferLithologyInput"
-            optionValue="aquifer_lithology_code"
-            :options="codes?.aquifer_lithology_codes"
-            :loading="!fieldsLoaded['aquifer_lithology']"
-            optionLabel="description"
-            placeholder="Select Lithology"/>
-        </div>
+      <div class="flex flex-col gap-2">
+        <label for="aquiferLithology">Aquifer Material</label>
+        <Select
+          id="aquiferLithology"
+          v-model="aquiferLithologyInput"
+          optionValue="aquifer_lithology_code"
+          :options="codes?.aquifer_lithology_codes"
+          :loading="!fieldsLoaded['aquifer_lithology']"
+          optionLabel="description"
+          placeholder="Select Lithology"/>
       </div>
-    </div>
+    </responsive-grid>
   </form-subsection>
 </template>
 
@@ -65,6 +61,7 @@ import { useSubmissionStore } from '@/stores/submission'
 
 import ApiService from '@/common/services/ApiService.js'
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
@@ -104,7 +101,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   fields: {
     aquiferInput: 'aquifer',

--- a/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
@@ -12,19 +12,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 lg:col-span-6">
-        <legend :id="id">Aquifer Information</legend>
-      </div>
-      <div class="col-span-12 lg:col-span-6">
-        <div class="float-right">
-          <Button v-if="isStaffEdit" label="Save" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </div>
-    </div>
-
+  <form-subsection title="Aquifer Information" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <div class="grid grid-cols-12">
       <div class="col-span-12 md:col-span-6 xl:col-span-3">
         <div class="flex flex-col gap-2">
@@ -72,7 +60,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </b-form-group>
       </div>
     </div>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
@@ -81,6 +69,7 @@ import { useSubmissionStore } from '@/stores/submission'
 
 import ApiService from '@/common/services/ApiService.js'
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -117,6 +106,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   fields: {
     aquiferInput: 'aquifer',

--- a/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
@@ -46,17 +46,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <b-form-group
           id="aquiferLithology"
           label="Aquifer Material">
-          <b-form-select
+          <Dropdown
             v-model="aquiferLithologyInput"
-            value-field="aquifer_lithology_code"
+            optionValue="aquifer_lithology_code"
             :options="codes?.aquifer_lithology_codes"
-            :errors="errors['aquifer_lithology']"
-            :loaded="fieldsLoaded['aquifer_lithology']"
-            text-field="description">
-            <template v-slot:first>
-              <option :value="null" disabled>Select Lithology</option>
-            </template>
-          </b-form-select>
+            :loading="!fieldsLoaded['aquifer_lithology']"
+            optionLabel="description"
+            placeholder="Select Lithology"/>
         </b-form-group>
       </div>
     </div>

--- a/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/AquiferData.vue
@@ -43,17 +43,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </div>
       </div>
       <div class="col-span-12 md:col-span-4">
-        <b-form-group
-          id="aquiferLithology"
-          label="Aquifer Material">
+        <div class="flex flex-col gap-2">
+          <label for="aquiferLithology">Aquifer Material</label>
           <Dropdown
+            id="aquiferLithology"
             v-model="aquiferLithologyInput"
             optionValue="aquifer_lithology_code"
             :options="codes?.aquifer_lithology_codes"
             :loading="!fieldsLoaded['aquifer_lithology']"
             optionLabel="description"
             placeholder="Select Lithology"/>
-        </b-form-group>
+        </div>
       </div>
     </div>
   </form-subsection>

--- a/app/frontend/src/submissions/components/SubmissionForm/AquiferParameters.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/AquiferParameters.vue
@@ -13,17 +13,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 lg:col-span-6">
         <legend :id="id">Pumping Test Information and Aquifer Parameters</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
+      </div>
+      <div class="col-span-12 lg:col-span-6">
         <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
+          <Button v-if="isStaffEdit" label="Save" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
           <back-to-top-link v-if="isStaffEdit"/>
         </div>
-      </b-col>
-    </b-row>
+      </div>
+    </div>
     <div class="table-responsive" id="aquiferParametersTable">
       <table class="table" aria-describedby="aquiferParameters">
         <thead>
@@ -187,12 +187,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
         @shown="focusRemoveModal">
       Are you sure you want to remove this row?
       <div slot="modal-footer">
-        <b-btn variant="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn">
-          Cancel
-        </b-btn>
-        <b-btn variant="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)">
-          Remove
-        </b-btn>
+        <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
+        <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
       </div>
     </b-modal>
   </fieldset>

--- a/app/frontend/src/submissions/components/SubmissionForm/AquiferParameters.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/AquiferParameters.vue
@@ -161,14 +161,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </tr>
               <tr>
                 <td class="pt-2 pb-4">
-                  <b-btn size="sm" variant="primary" :id="`removeAquiferParameterRowBtn${index}`" @click="removeRowIfOk(aquiferParameter)" class="mt-2"><i class="fa fa-minus-square-o"></i> Remove</b-btn>
+                  <Button label="Remove" icon="fa fa-minus-square-o" size="small" :id="`removeAquiferParameterRowBtn${index}`" @click="removeRowIfOk(aquiferParameter)" class="mt-2"/>
                 </td>
               </tr>
           </template>
         </tbody>
       </table>
     </div>
-    <b-btn size="sm" id="addAquiferParameterRowBtn" variant="primary" @click="addRow"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
+    <Button label="Add row" icon="fa fa-plus-square-o" size="small" id="addAquiferParameterRowBtn" @click="addRow"/>
     <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
       Are you sure you want to remove this row?
       <template #footer>

--- a/app/frontend/src/submissions/components/SubmissionForm/AquiferParameters.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/AquiferParameters.vue
@@ -169,16 +169,12 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </table>
     </div>
     <b-btn size="sm" id="addAquiferParameterRowBtn" variant="primary" @click="addRow"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
-    <Dialog
-      v-model:visible="confirmRemoveModal"
-      modal
-      header="Confirm remove"
-      @shown="focusRemoveModal">
+    <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
       Are you sure you want to remove this row?
-      <div slot="modal-footer">
+      <template #footer>
         <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
         <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
-      </div>
+      </template>
     </Dialog>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/AquiferParameters.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/AquiferParameters.vue
@@ -12,18 +12,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 lg:col-span-6">
-        <legend :id="id">Pumping Test Information and Aquifer Parameters</legend>
-      </div>
-      <div class="col-span-12 lg:col-span-6">
-        <div class="float-right">
-          <Button v-if="isStaffEdit" label="Save" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </div>
-    </div>
+  <form-subsection title="Pumping Test Information and Aquifer Parameters" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <div class="table-responsive" id="aquiferParametersTable">
       <table class="table" aria-describedby="aquiferParameters">
         <thead>
@@ -191,7 +180,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
       </div>
     </b-modal>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
@@ -199,6 +188,7 @@ import { useSubmissionStore } from '@/stores/submission'
 import { omit } from 'lodash'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   name: 'AquiferParameters',
@@ -225,6 +215,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/AquiferParameters.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/AquiferParameters.vue
@@ -169,17 +169,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </table>
     </div>
     <b-btn size="sm" id="addAquiferParameterRowBtn" variant="primary" @click="addRow"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
-    <b-modal
-        v-model="confirmRemoveModal"
-        centered
-        title="Confirm remove"
-        @shown="focusRemoveModal">
+    <Dialog
+      v-model:visible="confirmRemoveModal"
+      modal
+      header="Confirm remove"
+      @shown="focusRemoveModal">
       Are you sure you want to remove this row?
       <div slot="modal-footer">
         <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
         <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
       </div>
-    </b-modal>
+    </Dialog>
   </form-subsection>
 </template>
 

--- a/app/frontend/src/submissions/components/SubmissionForm/Backfill.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Backfill.vue
@@ -25,21 +25,21 @@ Licensed under the Apache License, Version 2.0 (the "License");
           text-field="description"
           value-field="surface_seal_material_code"
           :errors="errors['surface_seal_material']"
-          :loaded="fieldsLoaded['surface_seal_material']"></form-input>
+          :loaded="fieldsLoaded['surface_seal_material']"/>
         <form-input
           label="Surface Seal Depth (ft)"
           id="surfaceSealDepth"
           type="number"
           v-model="surfaceSealDepthInput"
           :errors="errors['surface_seal_depth']"
-          :loaded="fieldsLoaded['surface_seal_depth']"></form-input>
+          :loaded="fieldsLoaded['surface_seal_depth']"/>
         <form-input
           label="Surface Seal Thickness (in)"
           id="surfaceSealThickness"
           type="number"
           v-model="surfaceSealThicknessInput"
           :errors="errors['surface_seal_thickness']"
-          :loaded="fieldsLoaded['surface_seal_thickness']"></form-input>
+          :loaded="fieldsLoaded['surface_seal_thickness']"/>
       </responsive-grid>
       <responsive-grid :cols="12" :sm="6" :md="4">
         <form-input
@@ -52,7 +52,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           value-field="surface_seal_method_code"
           v-model="surfaceSealMethodInput"
           :errors="errors['surface_seal_method']"
-          :loaded="fieldsLoaded['surface_seal_method']"></form-input>
+          :loaded="fieldsLoaded['surface_seal_method']"/>
       </responsive-grid>
     </form-subsection>
     <fieldset>
@@ -63,14 +63,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
           id="backfillAboveSurfaceSeal"
           v-model="backfillAboveSurfaceSealInput"
           :errors="errors['backfill_type']"
-          :loaded="fieldsLoaded['backfill_type']"></form-input>
+          :loaded="fieldsLoaded['backfill_type']"/>
         <form-input
           label="Backfill Depth (ft)"
           id="backfillDepth"
           type="number"
           v-model="backfillDepthInput"
           :errors="errors['backfill_depth']"
-          :loaded="fieldsLoaded['backfill_depth']"></form-input>
+          :loaded="fieldsLoaded['backfill_depth']"/>
       </responsive-grid>
     </fieldset>
   </div>

--- a/app/frontend/src/submissions/components/SubmissionForm/Backfill.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Backfill.vue
@@ -13,18 +13,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <div>
-    <fieldset>
-      <b-row>
-        <b-col cols="12" lg="6">
-          <legend :id="id">Surface Seal and Backfill Information</legend>
-        </b-col>
-        <b-col cols="12" lg="6">
-          <div class="float-right">
-            <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-            <back-to-top-link v-if="isStaffEdit"/>
-          </div>
-        </b-col>
-      </b-row>
+    <form-subsection title="Surface Seal and Backfill Information" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
       <b-row>
         <b-col cols="12" sm="4" md="3">
           <form-input
@@ -73,7 +62,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
               :loaded="fieldsLoaded['surface_seal_method']"></form-input>
         </b-col>
       </b-row>
-    </fieldset>
+    </form-subsection>
     <fieldset>
       <legend>Backfill Information</legend>
       <b-row>
@@ -103,6 +92,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -133,6 +123,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   fields: {
     surfaceSealMaterialInput: 'surfaceSealMaterial',

--- a/app/frontend/src/submissions/components/SubmissionForm/Backfill.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Backfill.vue
@@ -14,76 +14,64 @@ Licensed under the Apache License, Version 2.0 (the "License");
 <template>
   <div>
     <form-subsection title="Surface Seal and Backfill Information" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-      <b-row>
-        <b-col cols="12" sm="4" md="3">
-          <form-input
-              label="Surface Seal Material"
-              id="surfaceSealMaterial"
-              select
-              v-model="surfaceSealMaterialInput"
-              :options="codes?.surface_seal_materials"
-              placeholder="Select material"
-              text-field="description"
-              value-field="surface_seal_material_code"
-              :errors="errors['surface_seal_material']"
-              :loaded="fieldsLoaded['surface_seal_material']"></form-input>
-        </b-col>
-        <b-col cols="12" sm="4" md="3">
-          <form-input
-              label="Surface Seal Depth (ft)"
-              id="surfaceSealDepth"
-              type="number"
-              v-model="surfaceSealDepthInput"
-              :errors="errors['surface_seal_depth']"
-              :loaded="fieldsLoaded['surface_seal_depth']"></form-input>
-        </b-col>
-        <b-col cols="12" sm="4" md="3">
-          <form-input
-              label="Surface Seal Thickness (in)"
-              id="surfaceSealThickness"
-              type="number"
-              v-model="surfaceSealThicknessInput"
-              :errors="errors['surface_seal_thickness']"
-              :loaded="fieldsLoaded['surface_seal_thickness']"></form-input>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" sm="6" md="4">
-          <form-input
-              label="Surface Seal Method of Installation"
-              id="surfaceSealMethod"
-              select
-              :options="codes?.surface_seal_methods"
-              placeholder="Select method"
-              text-field="description"
-              value-field="surface_seal_method_code"
-              v-model="surfaceSealMethodInput"
-              :errors="errors['surface_seal_method']"
-              :loaded="fieldsLoaded['surface_seal_method']"></form-input>
-        </b-col>
-      </b-row>
+      <responsive-grid :cols="12" :sm="4" :md="3">
+        <form-input
+          label="Surface Seal Material"
+          id="surfaceSealMaterial"
+          select
+          v-model="surfaceSealMaterialInput"
+          :options="codes?.surface_seal_materials"
+          placeholder="Select material"
+          text-field="description"
+          value-field="surface_seal_material_code"
+          :errors="errors['surface_seal_material']"
+          :loaded="fieldsLoaded['surface_seal_material']"></form-input>
+        <form-input
+          label="Surface Seal Depth (ft)"
+          id="surfaceSealDepth"
+          type="number"
+          v-model="surfaceSealDepthInput"
+          :errors="errors['surface_seal_depth']"
+          :loaded="fieldsLoaded['surface_seal_depth']"></form-input>
+        <form-input
+          label="Surface Seal Thickness (in)"
+          id="surfaceSealThickness"
+          type="number"
+          v-model="surfaceSealThicknessInput"
+          :errors="errors['surface_seal_thickness']"
+          :loaded="fieldsLoaded['surface_seal_thickness']"></form-input>
+      </responsive-grid>
+      <responsive-grid :cols="12" :sm="6" :md="4">
+        <form-input
+          label="Surface Seal Method of Installation"
+          id="surfaceSealMethod"
+          select
+          :options="codes?.surface_seal_methods"
+          placeholder="Select method"
+          text-field="description"
+          value-field="surface_seal_method_code"
+          v-model="surfaceSealMethodInput"
+          :errors="errors['surface_seal_method']"
+          :loaded="fieldsLoaded['surface_seal_method']"></form-input>
+      </responsive-grid>
     </form-subsection>
     <fieldset>
       <legend>Backfill Information</legend>
-      <b-row>
-        <b-col cols="12" sm="4" md="3">
-          <form-input
-              label="Backfill Material Above Surface Seal"
-              id="backfillAboveSurfaceSeal"
-              v-model="backfillAboveSurfaceSealInput"
-              :errors="errors['backfill_type']"
-              :loaded="fieldsLoaded['backfill_type']"></form-input>
-        </b-col>
-        <b-col cols="12" sm="4" md="3">
-          <form-input
-              label="Backfill Depth (ft)"
-              id="backfillDepth"
-              type="number"
-              v-model="backfillDepthInput"
-              :errors="errors['backfill_depth']"
-              :loaded="fieldsLoaded['backfill_depth']"></form-input>
-        </b-col>
-      </b-row>
+      <responsive-grid :cols="12" :sm="4" :md="3">
+        <form-input
+          label="Backfill Material Above Surface Seal"
+          id="backfillAboveSurfaceSeal"
+          v-model="backfillAboveSurfaceSealInput"
+          :errors="errors['backfill_type']"
+          :loaded="fieldsLoaded['backfill_type']"></form-input>
+        <form-input
+          label="Backfill Depth (ft)"
+          id="backfillDepth"
+          type="number"
+          v-model="backfillDepthInput"
+          :errors="errors['backfill_depth']"
+          :loaded="fieldsLoaded['backfill_depth']"></form-input>
+      </responsive-grid>
     </fieldset>
   </div>
 </template>
@@ -92,6 +80,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
@@ -125,7 +114,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   fields: {
     surfaceSealMaterialInput: 'surfaceSealMaterial',

--- a/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
@@ -142,17 +142,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </table>
     </div>
     <b-btn size="sm" id="addCasingRowBtn" variant="primary" @click="addRow"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
-    <b-modal
-        v-model="confirmRemoveModal"
-        centered
-        title="Confirm remove"
-        @shown="focusRemoveModal">
+    <Dialog
+      v-model:visible="confirmRemoveModal"
+      modal
+      header="Confirm remove"
+      @shown="focusRemoveModal">
       Are you sure you want to remove this row?
       <div slot="modal-footer">
         <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
         <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
       </div>
-    </b-modal>
+    </Dialog>
   </form-subsection>
 </template>
 

--- a/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
@@ -31,8 +31,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <tbody>
           <tr v-for="(casing, index) in casingsData" :key="casing.id">
             <td>
-              <b-form-checkbox
-                :checked="!casing.length_required"
+              <Checkbox
+                v-model="casing.length_not_required"
                 inline
                 class="mr-0 mt-2"
                 @change="toggleCasingLengthRequired(index)"/>
@@ -43,7 +43,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 :id="'casingFrom_' + index"
                 type="number"
                 v-model="casing.start"
-                :disabled="!casing.length_required"
+                :disabled="casing.length_not_required"
                 :errors="getCasingError(index).start"
                 :loaded="getFieldsLoaded(index).start"/>
             </td>
@@ -53,7 +53,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 :id="'casingTo_' + index"
                 type="number"
                 v-model="casing.end"
-                :disabled="!casing.length_required"
+                :disabled="casing.length_not_required"
                 :errors="getCasingError(index).end"
                 :loaded="getFieldsLoaded(index).end"/>
             </td>
@@ -62,16 +62,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 :id="'casingCode_' + index"
                 class="mt-1 mb-0"
                 :aria-describedby="`casingCodeInvalidFeedback${index}`">
-                <b-form-select
-                    v-model="casing.casing_code"
-                    :options="codes?.casing_codes"
-                    value-field="code"
-                    text-field="description"
-                    :state="getCasingError(index).casing_code ? false : null">
-                  <template v-slot:first>
-                    <option :value="null">Select a type</option>
-                  </template>
-                </b-form-select>
+                <Dropdown
+                  v-model="casing.casing_code"
+                  :options="codes?.casing_codes"
+                  optionValue="code"
+                  optionLabel="description"
+                  :invalid="getCasingError(index).casing_code ? true : false"
+                  placeholder="Select a type"/>
                 <b-form-invalid-feedback :id="`casingCodeInvalidFeedback${index}`">
                   <div v-for="(error, error_index) in getCasingError(index).casing_code" :key="`Casing type input error ${error_index}`">
                     {{ error }}
@@ -84,16 +81,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 :id="'casingMaterial_' + index"
                 class="mt-1 mb-0"
                 :aria-describedby="`casingMaterialInvalidFeedback${index}`">
-                <b-form-select
-                    v-model="casing.casing_material"
-                    :options="codes?.casing_materials"
-                    value-field="code"
-                    text-field="description"
-                    :state="getCasingError(index).casing_material ? false : null">
-                  <template v-slot:first>
-                    <option :value="null" enabled>Select a material</option>
-                  </template>
-                </b-form-select>
+                <Dropdown
+                  v-model="casing.casing_material"
+                  :options="codes?.casing_materials"
+                  optionValue="code"
+                  optionLabel="description"
+                  :invalid="getCasingError(index).casing_material ? true : false"
+                  placeholder="Select a material"/>
                 <b-form-invalid-feedback :id="`casingCodeInvalidFeedback${index}`">
                   <div v-for="(error, error_index) in getCasingError(index).casing_material" :key="`Material input error ${error_index}`">
                     {{ error }}
@@ -120,19 +114,15 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 :loaded="getFieldsLoaded(index).wall_thickness"/>
             </td>
             <td>
-              <b-form-group :id="'casingDriveShoe_' + index" class="mt-1 mb-0">
-                <b-form-select
-                  v-model="casing.drive_shoe_status"
-                  value-field="drive_shoe_code"
-                  text-field="drive_shoe_code"
-                  :options="codes?.drive_shoe_codes"
-                  :errors="errors['drive_shoe_status']"
-                  :loaded="fieldsLoaded['drive_shoe_status']">
-                  <template v-slot:first>
-                    <option :value="null" enabled>Select drive shoe</option>
-                  </template>
-                </b-form-select>
-              </b-form-group>
+              <Dropdown
+                :id="'casingDriveShoe_' + index"
+                class="mt-1 mb-0"
+                v-model="casing.drive_shoe_status"
+                optionValue="drive_shoe_code"
+                optionLabel="drive_shoe_code"
+                :options="codes?.drive_shoe_codes"
+                :loading="!fieldsLoaded['drive_shoe_status']"
+                placeholder="Select drive shoe"/>
             </td>
             <td class="pt-1 py-0">
               <b-btn size="sm" variant="primary" :id="`removeCasingRowBtn${index}`" @click="removeRowIfOk(casing)" class="mt-2 float-right"><i class="fa fa-minus-square-o"></i> Remove</b-btn>
@@ -142,16 +132,12 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </table>
     </div>
     <b-btn size="sm" id="addCasingRowBtn" variant="primary" @click="addRow"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
-    <Dialog
-      v-model:visible="confirmRemoveModal"
-      modal
-      header="Confirm remove"
-      @shown="focusRemoveModal">
+    <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
       Are you sure you want to remove this row?
-      <div slot="modal-footer">
+      <template #footer>
         <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
         <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
-      </div>
+      </template>
     </Dialog>
   </form-subsection>
 </template>
@@ -211,7 +197,7 @@ export default {
         casing_code: null,
         casing_material: null,
         drive_shoe_status: null,
-        length_required: true
+        length_not_required: false
       }
     },
     removeRowByIndex (index) {
@@ -229,7 +215,7 @@ export default {
     },
     toggleCasingLengthRequired (index) {
       const instance = this.casingsData[index]
-      instance.length_required = !instance.length_required
+      instance.length_not_required = !instance.length_not_required
       this.casingsData[index] = instance
     },
     getCasingError (index) {
@@ -255,7 +241,7 @@ export default {
       this.$refs.cancelRemoveBtn.focus()
     },
     casingIsEmpty (casing) {
-      const fieldsToTest = omit(casing, 'length_required')
+      const fieldsToTest = omit(casing, 'length_not_required')
       return Object.values(fieldsToTest).every((x) => !x)
     }
   },

--- a/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
@@ -67,11 +67,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   optionLabel="description"
                   :invalid="getCasingError(index).casing_code ? true : false"
                   placeholder="Select a type"/>
-                <b-form-invalid-feedback :id="`casingCodeInvalidFeedback${index}`">
-                  <div v-for="(error, error_index) in getCasingError(index).casing_code" :key="`Casing type input error ${error_index}`">
+                <div :id="`casingCodeInvalidFeedback${index}`">
+                  <div v-for="(error, e_index) in getCasingError(index).casing_code" class="mt-1 text-sm text-red-600" :key="`Casing type input error ${e_index}`">
                     {{ error }}
                   </div>
-                </b-form-invalid-feedback>
+                </div>
               </div>
             </td>
             <td>
@@ -84,11 +84,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   optionLabel="description"
                   :invalid="getCasingError(index).casing_material ? true : false"
                   placeholder="Select a material"/>
-                <b-form-invalid-feedback :id="`casingCodeInvalidFeedback${index}`">
-                  <div v-for="(error, error_index) in getCasingError(index).casing_material" :key="`Material input error ${error_index}`">
+                <div :id="`casingCodeInvalidFeedback${index}`">
+                  <div v-for="(error, e_index) in getCasingError(index).casing_material" class="mt-1 text-sm text-red-600" :key="`Material input error ${e_index}`">
                     {{ error }}
                   </div>
-                </b-form-invalid-feedback>
+                </div>
               </div>
             </td>
             <td>

--- a/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
@@ -75,11 +75,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </div>
             </td>
             <td>
-              <b-form-group
-                :id="'casingMaterial_' + index"
-                class="mt-1 mb-0"
-                :aria-describedby="`casingMaterialInvalidFeedback${index}`">
+              <div class="flex flex-col gap-2 mt-1 mb-0" :aria-describedby="`casingMaterialInvalidFeedback${index}`">
                 <Select
+                  :id="'casingMaterial_' + index"
                   v-model="casing.casing_material"
                   :options="codes?.casing_materials"
                   optionValue="code"
@@ -91,7 +89,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     {{ error }}
                   </div>
                 </b-form-invalid-feedback>
-              </b-form-group>
+              </div>
             </td>
             <td>
               <form-input

--- a/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
@@ -12,18 +12,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 lg:col-span-6">
-        <legend :id="id">Casing Details</legend>
-      </div>
-      <div class="col-span-12 lg:col-span-6">
-        <div class="float-right">
-          <Button v-if="isStaffEdit" label="Save" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </div>
-    </div>
+  <form-subsection title="Casing Details" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <div class="table-responsive" id="casingTable">
       <table class="table table-sm" aria-describedby="casingsDetails">
         <thead>
@@ -164,7 +153,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
       </div>
     </b-modal>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
@@ -172,6 +161,7 @@ import { useSubmissionStore } from '@/stores/submission'
 import { omit } from 'lodash'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   name: 'Casings',
@@ -198,6 +188,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
@@ -13,17 +13,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 lg:col-span-6">
         <legend :id="id">Casing Details</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
+      </div>
+      <div class="col-span-12 lg:col-span-6">
         <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
+          <Button v-if="isStaffEdit" label="Save" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
           <back-to-top-link v-if="isStaffEdit"/>
         </div>
-      </b-col>
-    </b-row>
+      </div>
+    </div>
     <div class="table-responsive" id="casingTable">
       <table class="table table-sm" aria-describedby="casingsDetails">
         <thead>
@@ -160,12 +160,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
         @shown="focusRemoveModal">
       Are you sure you want to remove this row?
       <div slot="modal-footer">
-        <b-btn variant="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn">
-          Cancel
-        </b-btn>
-        <b-btn variant="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)">
-          Remove
-        </b-btn>
+        <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
+        <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
       </div>
     </b-modal>
   </fieldset>

--- a/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
@@ -58,11 +58,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 :loaded="getFieldsLoaded(index).end"/>
             </td>
             <td>
-              <b-form-group
-                :id="'casingCode_' + index"
-                class="mt-1 mb-0"
-                :aria-describedby="`casingCodeInvalidFeedback${index}`">
+              <div class="flex flex-col gap-2 mt-1 mb-0" :aria-describedby="`casingCodeInvalidFeedback${index}`">
                 <Dropdown
+                  :id="'casingCode_' + index"
                   v-model="casing.casing_code"
                   :options="codes?.casing_codes"
                   optionValue="code"
@@ -74,7 +72,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     {{ error }}
                   </div>
                 </b-form-invalid-feedback>
-              </b-form-group>
+              </div>
             </td>
             <td>
               <b-form-group
@@ -125,13 +123,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 placeholder="Select drive shoe"/>
             </td>
             <td class="pt-1 py-0">
-              <b-btn size="sm" variant="primary" :id="`removeCasingRowBtn${index}`" @click="removeRowIfOk(casing)" class="mt-2 float-right"><i class="fa fa-minus-square-o"></i> Remove</b-btn>
+              <Button label="Remove" icon="fa fa-minus-square-o" size="small" :id="`removeCasingRowBtn${index}`" @click="removeRowIfOk(casing)" class="mt-2 float-right"/>
             </td>
           </tr>
         </tbody>
       </table>
     </div>
-    <b-btn size="sm" id="addCasingRowBtn" variant="primary" @click="addRow"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
+    <Button label="Add row" icon="fa fa-plus-square-o" size="small" id="addCasingRowBtn" @click="addRow"/>
     <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
       Are you sure you want to remove this row?
       <template #footer>

--- a/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Casings.vue
@@ -59,7 +59,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             </td>
             <td>
               <div class="flex flex-col gap-2 mt-1 mb-0" :aria-describedby="`casingCodeInvalidFeedback${index}`">
-                <Dropdown
+                <Select
                   :id="'casingCode_' + index"
                   v-model="casing.casing_code"
                   :options="codes?.casing_codes"
@@ -79,7 +79,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 :id="'casingMaterial_' + index"
                 class="mt-1 mb-0"
                 :aria-describedby="`casingMaterialInvalidFeedback${index}`">
-                <Dropdown
+                <Select
                   v-model="casing.casing_material"
                   :options="codes?.casing_materials"
                   optionValue="code"
@@ -112,7 +112,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 :loaded="getFieldsLoaded(index).wall_thickness"/>
             </td>
             <td>
-              <Dropdown
+              <Select
                 :id="'casingDriveShoe_' + index"
                 class="mt-1 mb-0"
                 v-model="casing.drive_shoe_status"

--- a/app/frontend/src/submissions/components/SubmissionForm/ClosureDescription.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ClosureDescription.vue
@@ -12,21 +12,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Decommission Description</legend>
-        <p>Enter depth intervals from the top of the hole to the bottom.</p>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12">
+  <form-subsection
+    title="Decommission Description"
+    subtitle="Enter depth intervals from the top of the hole to the bottom."
+    :id="id" :isStaffEdit="isStaffEdit"
+    :saveDisabled="saveDisabled">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12">
         <div class="table-responsive">
           <table class="table table-sm" aria-describedby="decommissionDescriptions">
             <thead>
@@ -95,8 +87,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </table>
         </div>
         <b-btn size="sm" variant="primary" @click="addClosureRow" id="addClosureRowButton"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
-      </b-col>
-    </b-row>
+      </div>
+    </div>
     <b-modal
         v-model="confirmRemoveModal"
         centered
@@ -112,13 +104,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </b-btn>
       </div>
     </b-modal>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -144,6 +137,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/ClosureDescription.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ClosureDescription.vue
@@ -15,75 +15,74 @@ Licensed under the Apache License, Version 2.0 (the "License");
   <form-subsection
     title="Decommission Description"
     subtitle="Enter depth intervals from the top of the hole to the bottom."
-    :id="id" :isStaffEdit="isStaffEdit"
+    :id="id"
+    :isStaffEdit="isStaffEdit"
     :saveDisabled="saveDisabled">
-    <div class="grid grid-cols-12">
-      <div class="col-span-12">
-        <div class="table-responsive">
-          <table class="table table-sm" aria-describedby="decommissionDescriptions">
-            <thead>
-              <tr>
-                <th>From</th>
-                <th>To</th>
-                <th>Decommission Material</th>
-                <th>Observations</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="(item, index) in closureDescriptionSetData"
-                :key="`closureDescription${index}`"
-                :id="`closureDescription${index}`">
-                <td class="input-width-small">
-                  <form-input
-                    group-class="mt-1 mb-0"
-                    :id="`closureFrom${index}`"
-                    type="number"
-                    v-model="item.start"
-                    :errors="getClosureError(index).start"
-                    :loaded="getFieldsLoaded(index).start"/>
-                </td>
-                <td class="input-width-small">
-                  <form-input
-                    group-class="mt-1 mb-0"
-                    :id="`closureTo${index}`"
-                    v-model="item.end"
-                    type="number"
-                    :errors="getClosureError(index).end"
-                    :loaded="getFieldsLoaded(index).end"/>
-                </td>
-                <td>
-                  <form-input
-                    group-class="mt-1 mb-0"
-                    select
-                    :id="`decommissionMaterial${index}`"
-                    :options="codes?.decommission_materials"
-                    text-field="description"
-                    value-field="code"
-                    placeholder="Select material"
-                    value="Select material"
-                    v-model="item.material"
-                    :errors="getClosureError(index).material"
-                    :loaded="getFieldsLoaded(index).material"/>
-                </td>
-                <td>
-                  <form-input
-                    group-class="mt-1 mb-0"
-                    :id="`closureObservations${index}`"
-                    v-model="item.observations"
-                    :errors="getClosureError(index).observations"
-                    :loaded="getFieldsLoaded(index).observations"/>
-                </td>
-                <td class="pt-1 py-0">
-                  <Button label="Remove" icon="fa fa-minus-square-o" size="small" :id="`removeClosureDescriptionRowBtn${index}`" @click="removeRowIfOk(item)" class="mt-2 float-right"/>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <Button label="Add row" icon="fa fa-plus-square-o" size="small" @click="addClosureRow" id="addClosureRowButton"/>
+    <div class="flex">
+      <div class="table-responsive">
+        <table class="table table-sm" aria-describedby="decommissionDescriptions">
+          <thead>
+            <tr>
+              <th>From</th>
+              <th>To</th>
+              <th>Decommission Material</th>
+              <th>Observations</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="(item, index) in closureDescriptionSetData"
+              :key="`closureDescription${index}`"
+              :id="`closureDescription${index}`">
+              <td class="input-width-small">
+                <form-input
+                  group-class="mt-1 mb-0"
+                  :id="`closureFrom${index}`"
+                  type="number"
+                  v-model="item.start"
+                  :errors="getClosureError(index).start"
+                  :loaded="getFieldsLoaded(index).start"/>
+              </td>
+              <td class="input-width-small">
+                <form-input
+                  group-class="mt-1 mb-0"
+                  :id="`closureTo${index}`"
+                  v-model="item.end"
+                  type="number"
+                  :errors="getClosureError(index).end"
+                  :loaded="getFieldsLoaded(index).end"/>
+              </td>
+              <td>
+                <form-input
+                  group-class="mt-1 mb-0"
+                  select
+                  :id="`decommissionMaterial${index}`"
+                  :options="codes?.decommission_materials"
+                  text-field="description"
+                  value-field="code"
+                  placeholder="Select material"
+                  value="Select material"
+                  v-model="item.material"
+                  :errors="getClosureError(index).material"
+                  :loaded="getFieldsLoaded(index).material"/>
+              </td>
+              <td>
+                <form-input
+                  group-class="mt-1 mb-0"
+                  :id="`closureObservations${index}`"
+                  v-model="item.observations"
+                  :errors="getClosureError(index).observations"
+                  :loaded="getFieldsLoaded(index).observations"/>
+              </td>
+              <td class="pt-1 py-0">
+                <Button label="Remove" icon="fa fa-minus-square-o" size="small" :id="`removeClosureDescriptionRowBtn${index}`" @click="removeRowIfOk(item)" class="mt-2 float-right"/>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
+      <Button label="Add row" icon="fa fa-plus-square-o" size="small" @click="addClosureRow" id="addClosureRowButton"/>
     </div>
     <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
       Are you sure you want to remove this row?

--- a/app/frontend/src/submissions/components/SubmissionForm/ClosureDescription.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ClosureDescription.vue
@@ -32,52 +32,48 @@ Licensed under the Apache License, Version 2.0 (the "License");
             </thead>
             <tbody>
               <tr
-                  v-for="(item, index) in closureDescriptionSetData"
-                  :key="`closureDescription${index}`"
-                  :id="`closureDescription${index}`">
+                v-for="(item, index) in closureDescriptionSetData"
+                :key="`closureDescription${index}`"
+                :id="`closureDescription${index}`">
                 <td class="input-width-small">
                   <form-input
-                      group-class="mt-1 mb-0"
-                      :id="`closureFrom${index}`"
-                      type="number"
-                      v-model="item.start"
-                      :errors="getClosureError(index).start"
-                      :loaded="getFieldsLoaded(index).start"
-                  />
+                    group-class="mt-1 mb-0"
+                    :id="`closureFrom${index}`"
+                    type="number"
+                    v-model="item.start"
+                    :errors="getClosureError(index).start"
+                    :loaded="getFieldsLoaded(index).start"/>
                 </td>
                 <td class="input-width-small">
                   <form-input
-                      group-class="mt-1 mb-0"
-                      :id="`closureTo${index}`"
-                      v-model="item.end"
-                      type="number"
-                      :errors="getClosureError(index).end"
-                      :loaded="getFieldsLoaded(index).end"
-                  />
+                    group-class="mt-1 mb-0"
+                    :id="`closureTo${index}`"
+                    v-model="item.end"
+                    type="number"
+                    :errors="getClosureError(index).end"
+                    :loaded="getFieldsLoaded(index).end"/>
                 </td>
                 <td>
                   <form-input
-                      group-class="mt-1 mb-0"
-                      select
-                      :id="`decommissionMaterial${index}`"
-                      :options="codes?.decommission_materials"
-                      text-field="description"
-                      value-field="code"
-                      placeholder="Select material"
-                      value="Select material"
-                      v-model="item.material"
-                      :errors="getClosureError(index).material"
-                      :loaded="getFieldsLoaded(index).material"
-                  />
+                    group-class="mt-1 mb-0"
+                    select
+                    :id="`decommissionMaterial${index}`"
+                    :options="codes?.decommission_materials"
+                    text-field="description"
+                    value-field="code"
+                    placeholder="Select material"
+                    value="Select material"
+                    v-model="item.material"
+                    :errors="getClosureError(index).material"
+                    :loaded="getFieldsLoaded(index).material"/>
                 </td>
                 <td>
                   <form-input
-                      group-class="mt-1 mb-0"
-                      :id="`closureObservations${index}`"
-                      v-model="item.observations"
-                      :errors="getClosureError(index).observations"
-                      :loaded="getFieldsLoaded(index).observations"
-                  />
+                    group-class="mt-1 mb-0"
+                    :id="`closureObservations${index}`"
+                    v-model="item.observations"
+                    :errors="getClosureError(index).observations"
+                    :loaded="getFieldsLoaded(index).observations"/>
                 </td>
                 <td class="pt-1 py-0">
                   <b-btn size="sm" variant="primary" :id="`removeClosureDescriptionRowBtn${index}`" @click="removeRowIfOk(item)" class="mt-2 float-right"><i class="fa fa-minus-square-o"></i> Remove</b-btn>
@@ -89,16 +85,12 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <b-btn size="sm" variant="primary" @click="addClosureRow" id="addClosureRowButton"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
       </div>
     </div>
-    <Dialog
-      v-model:visible="confirmRemoveModal"
-      modal
-      header="Confirm remove"
-      @shown="focusRemoveModal">
+    <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
       Are you sure you want to remove this row?
-      <div slot="modal-footer">
+      <template #footer>
         <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
         <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
-      </div>
+      </template>
     </Dialog>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/ClosureDescription.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ClosureDescription.vue
@@ -76,13 +76,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     :loaded="getFieldsLoaded(index).observations"/>
                 </td>
                 <td class="pt-1 py-0">
-                  <b-btn size="sm" variant="primary" :id="`removeClosureDescriptionRowBtn${index}`" @click="removeRowIfOk(item)" class="mt-2 float-right"><i class="fa fa-minus-square-o"></i> Remove</b-btn>
+                  <Button label="Remove" icon="fa fa-minus-square-o" size="small" :id="`removeClosureDescriptionRowBtn${index}`" @click="removeRowIfOk(item)" class="mt-2 float-right"/>
                 </td>
               </tr>
             </tbody>
           </table>
         </div>
-        <b-btn size="sm" variant="primary" @click="addClosureRow" id="addClosureRowButton"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
+        <Button label="Add row" icon="fa fa-plus-square-o" size="small" @click="addClosureRow" id="addClosureRowButton"/>
       </div>
     </div>
     <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">

--- a/app/frontend/src/submissions/components/SubmissionForm/ClosureDescription.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ClosureDescription.vue
@@ -89,21 +89,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <b-btn size="sm" variant="primary" @click="addClosureRow" id="addClosureRowButton"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
       </div>
     </div>
-    <b-modal
-        v-model="confirmRemoveModal"
-        centered
-        title="Confirm remove"
-        @shown="focusRemoveModal">
+    <Dialog
+      v-model:visible="confirmRemoveModal"
+      modal
+      header="Confirm remove"
+      @shown="focusRemoveModal">
       Are you sure you want to remove this row?
       <div slot="modal-footer">
-        <b-btn variant="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn">
-          Cancel
-        </b-btn>
-        <b-btn variant="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)">
-          Remove
-        </b-btn>
+        <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
+        <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
       </div>
-    </b-modal>
+    </Dialog>
   </form-subsection>
 </template>
 

--- a/app/frontend/src/submissions/components/SubmissionForm/Comments.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Comments.vue
@@ -15,52 +15,50 @@ Licensed under the Apache License, Version 2.0 (the "License");
   <form-subsection title="Comments" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <responsive-grid :cols="12" :md="8">
       <b-form-group label="Comments" id="commentsGroup">
-        <b-form-textarea
-          id="commentsEntry"
-          :rows="3"
-          :max-rows="12"
-          v-model="commentsInput"></b-form-textarea>
+        <Textarea id="commentsEntry" :rows="3" autoResize v-model="commentsInput"/>
       </b-form-group>
     </responsive-grid>
     <responsive-grid class="mt-4 mb-4" :cols="12" :md="8">
       <b-form-group label="Internal Office Comments" id="commentsGroup">
-        <b-form-textarea
-          id="internalCommentsEntry"
-          :rows="3"
-          :max-rows="12"
-          v-model="internalCommentsInput"></b-form-textarea>
+        <Textarea id="internalCommentsEntry" :rows="3" autoResize v-model="internalCommentsInput"/>
       </b-form-group>
     </responsive-grid>
     <responsive-grid :cols="12" :sm="6" :gap="4">
       <b-form-group label="Alternative Specs Submitted">
-        <b-form-radio-group
-          id="alternativeSpecsCheckbox"
-          class="mt-1"
-          v-model="alternativeSpecsSubmittedInput"
-        >
-          <b-form-radio :value="false">No</b-form-radio>
-          <b-form-radio :value="true">Yes</b-form-radio>
-        </b-form-radio-group>
+        <RadioButtonGroup class="mt-1" v-model="alternativeSpecsSubmittedInput">
+          <div>
+            <RadioButton inputId="alternativeSpecsSubmittedInput.false" :value="false"/>
+            <label for="alternativeSpecsSubmittedInput.false" class="ml-2">No</label>
+          </div>
+          <div>
+            <RadioButton inputId="alternativeSpecsSubmittedInput.true" :value="true"/>
+            <label for="alternativeSpecsSubmittedInput.true" class="ml-2">Yes</label>
+          </div>
+        </RadioButtonGroup>
       </b-form-group>
       <b-form-group label="Technical Report">
-        <b-form-radio-group
-          id="technicalReportCheckbox"
-          class="mt-1"
-          v-model="technicalReportInput"
-        >
-          <b-form-radio :value="false">No</b-form-radio>
-          <b-form-radio :value="true">Yes</b-form-radio>
-        </b-form-radio-group>
+        <RadioButtonGroup class="mt-1" v-model="technicalReportInput">
+          <div>
+            <RadioButton inputId="technicalReportInput.false" :value="false"/>
+            <label for="technicalReportInput.false" class="ml-2">No</label>
+          </div>
+          <div>
+            <RadioButton inputId="technicalReportInput.true" :value="true"/>
+            <label for="technicalReportInput.true" class="ml-2">Yes</label>
+          </div>
+        </RadioButtonGroup>
       </b-form-group>
       <b-form-group label="Drinking Water Area Indicator">
-        <b-form-radio-group
-          id="drinkingWaterProtectionAreaCheckbox"
-          class="mt-1"
-          v-model="drinkingWaterProtectionAreaInput"
-        >
-          <b-form-radio :value="false">No</b-form-radio>
-          <b-form-radio :value="true">Yes</b-form-radio>
-        </b-form-radio-group>
+        <RadioButtonGroup class="mt-1" v-model="drinkingWaterProtectionAreaInput">
+          <div>
+            <RadioButton inputId="drinkingWaterProtectionAreaInput.false" :value="false"/>
+            <label for="drinkingWaterProtectionAreaInput.false" class="ml-2">No</label>
+          </div>
+          <div>
+            <RadioButton inputId="drinkingWaterProtectionAreaInput.true" :value="true"/>
+            <label for="drinkingWaterProtectionAreaInput.true" class="ml-2">Yes</label>
+          </div>
+        </RadioButtonGroup>
       </b-form-group>
     </responsive-grid>
   </form-subsection>

--- a/app/frontend/src/submissions/components/SubmissionForm/Comments.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Comments.vue
@@ -13,71 +13,56 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Comments" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <b-row>
-      <b-col cols="12" md="8">
-        <b-form-group label="Comments" id="commentsGroup">
-          <b-form-textarea
-              id="commentsEntry"
-              :rows="3"
-              :max-rows="12"
-              v-model="commentsInput"></b-form-textarea>
-        </b-form-group>
-      </b-col>
-    </b-row>
-
-    <b-row class="mt-4">
-      <b-col cols="12" md="8">
-        <b-form-group label="Internal Office Comments" id="commentsGroup">
-          <b-form-textarea
-              id="internalCommentsEntry"
-              :rows="3"
-              :max-rows="12"
-              v-model="internalCommentsInput"></b-form-textarea>
-        </b-form-group>
-      </b-col>
-    </b-row>
-    <b-row class="mt-4">
-      <b-col cols="12" sm="6">
-        <b-form-group label="Alternative Specs Submitted">
-          <b-form-radio-group
-            id="alternativeSpecsCheckbox"
-            class="mt-1"
-            v-model="alternativeSpecsSubmittedInput"
-          >
-            <b-form-radio :value="false">No</b-form-radio>
-            <b-form-radio :value="true">Yes</b-form-radio>
-          </b-form-radio-group>
-        </b-form-group>
-      </b-col>
-    </b-row>
-    <b-row class="mt-4">
-      <b-col cols="12" sm="6">
-        <b-form-group label="Technical Report">
-          <b-form-radio-group
-            id="technicalReportCheckbox"
-            class="mt-1"
-            v-model="technicalReportInput"
-          >
-            <b-form-radio :value="false">No</b-form-radio>
-            <b-form-radio :value="true">Yes</b-form-radio>
-          </b-form-radio-group>
-        </b-form-group>
-      </b-col>
-    </b-row>
-    <b-row class="mt-4">
-      <b-col cols="12" sm="6">
-        <b-form-group label="Drinking Water Area Indicator">
-          <b-form-radio-group
-            id="drinkingWaterProtectionAreaCheckbox"
-            class="mt-1"
-            v-model="drinkingWaterProtectionAreaInput"
-          >
-            <b-form-radio :value="false">No</b-form-radio>
-            <b-form-radio :value="true">Yes</b-form-radio>
-          </b-form-radio-group>
-        </b-form-group>
-      </b-col>
-    </b-row>
+    <responsive-grid :cols="12" :md="8">
+      <b-form-group label="Comments" id="commentsGroup">
+        <b-form-textarea
+          id="commentsEntry"
+          :rows="3"
+          :max-rows="12"
+          v-model="commentsInput"></b-form-textarea>
+      </b-form-group>
+    </responsive-grid>
+    <responsive-grid class="mt-4 mb-4" :cols="12" :md="8">
+      <b-form-group label="Internal Office Comments" id="commentsGroup">
+        <b-form-textarea
+          id="internalCommentsEntry"
+          :rows="3"
+          :max-rows="12"
+          v-model="internalCommentsInput"></b-form-textarea>
+      </b-form-group>
+    </responsive-grid>
+    <responsive-grid :cols="12" :sm="6" :gap="4">
+      <b-form-group label="Alternative Specs Submitted">
+        <b-form-radio-group
+          id="alternativeSpecsCheckbox"
+          class="mt-1"
+          v-model="alternativeSpecsSubmittedInput"
+        >
+          <b-form-radio :value="false">No</b-form-radio>
+          <b-form-radio :value="true">Yes</b-form-radio>
+        </b-form-radio-group>
+      </b-form-group>
+      <b-form-group label="Technical Report">
+        <b-form-radio-group
+          id="technicalReportCheckbox"
+          class="mt-1"
+          v-model="technicalReportInput"
+        >
+          <b-form-radio :value="false">No</b-form-radio>
+          <b-form-radio :value="true">Yes</b-form-radio>
+        </b-form-radio-group>
+      </b-form-group>
+      <b-form-group label="Drinking Water Area Indicator">
+        <b-form-radio-group
+          id="drinkingWaterProtectionAreaCheckbox"
+          class="mt-1"
+          v-model="drinkingWaterProtectionAreaInput"
+        >
+          <b-form-radio :value="false">No</b-form-radio>
+          <b-form-radio :value="true">Yes</b-form-radio>
+        </b-form-radio-group>
+      </b-form-group>
+    </responsive-grid>
   </form-subsection>
 </template>
 
@@ -85,6 +70,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
@@ -117,7 +103,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   fields: {
     commentsInput: 'comments',

--- a/app/frontend/src/submissions/components/SubmissionForm/Comments.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Comments.vue
@@ -14,18 +14,21 @@ Licensed under the Apache License, Version 2.0 (the "License");
 <template>
   <form-subsection title="Comments" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <responsive-grid :cols="12" :md="8">
-      <b-form-group label="Comments" id="commentsGroup">
+      <div class="flex flex-col gap-2">
+        <label for="commentsEntry">Comments</label>
         <Textarea id="commentsEntry" :rows="3" autoResize v-model="commentsInput"/>
-      </b-form-group>
+      </div>
     </responsive-grid>
     <responsive-grid class="mt-4 mb-4" :cols="12" :md="8">
-      <b-form-group label="Internal Office Comments" id="commentsGroup">
+      <div class="flex flex-col gap-2">
+        <label for="internalCommentsEntry">Internal Office Comments</label>
         <Textarea id="internalCommentsEntry" :rows="3" autoResize v-model="internalCommentsInput"/>
-      </b-form-group>
+      </div>
     </responsive-grid>
     <responsive-grid :cols="12" :sm="6" :gap="4">
-      <b-form-group label="Alternative Specs Submitted">
-        <RadioButtonGroup class="mt-1" v-model="alternativeSpecsSubmittedInput">
+      <div class="flex flex-col gap-2">
+        <label for="alternativeSpecsSubmittedInput">Alternative Specs Submitted</label>
+        <RadioButtonGroup class="mt-1" v-model="alternativeSpecsSubmittedInput" id="alternativeSpecsSubmittedInput">
           <div>
             <RadioButton inputId="alternativeSpecsSubmittedInput.false" :value="false"/>
             <label for="alternativeSpecsSubmittedInput.false" class="ml-2">No</label>
@@ -35,9 +38,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
             <label for="alternativeSpecsSubmittedInput.true" class="ml-2">Yes</label>
           </div>
         </RadioButtonGroup>
-      </b-form-group>
-      <b-form-group label="Technical Report">
-        <RadioButtonGroup class="mt-1" v-model="technicalReportInput">
+      </div>
+      <div class="flex flex-col gap-2">
+        <label for="technicalReportInput">Technical Report</label>
+        <RadioButtonGroup class="mt-1" v-model="technicalReportInput" id="technicalReportInput">
           <div>
             <RadioButton inputId="technicalReportInput.false" :value="false"/>
             <label for="technicalReportInput.false" class="ml-2">No</label>
@@ -47,9 +51,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
             <label for="technicalReportInput.true" class="ml-2">Yes</label>
           </div>
         </RadioButtonGroup>
-      </b-form-group>
-      <b-form-group label="Drinking Water Area Indicator">
-        <RadioButtonGroup class="mt-1" v-model="drinkingWaterProtectionAreaInput">
+      </div>
+      <div class="flex flex-col gap-2">
+        <label for="drinkingWaterProtectionAreaInput">Drinking Water Area Indicator</label>
+        <RadioButtonGroup class="mt-1" v-model="drinkingWaterProtectionAreaInput" id="drinkingWaterProtectionAreaInput">
           <div>
             <RadioButton inputId="drinkingWaterProtectionAreaInput.false" :value="false"/>
             <label for="drinkingWaterProtectionAreaInput.false" class="ml-2">No</label>
@@ -59,7 +64,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             <label for="drinkingWaterProtectionAreaInput.true" class="ml-2">Yes</label>
           </div>
         </RadioButtonGroup>
-      </b-form-group>
+      </div>
     </responsive-grid>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/Comments.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Comments.vue
@@ -13,13 +13,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Comments" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <responsive-grid :cols="12" :md="8">
+    <responsive-grid :cols="12" :md="8" :gap="4">
       <div class="flex flex-col gap-2">
         <label for="commentsEntry">Comments</label>
         <Textarea id="commentsEntry" :rows="3" autoResize v-model="commentsInput"/>
       </div>
     </responsive-grid>
-    <responsive-grid class="mt-4 mb-4" :cols="12" :md="8">
+    <responsive-grid :cols="12" :md="8" :gap="4">
       <div class="flex flex-col gap-2">
         <label for="internalCommentsEntry">Internal Office Comments</label>
         <Textarea id="internalCommentsEntry" :rows="3" autoResize v-model="internalCommentsInput"/>
@@ -39,6 +39,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </div>
         </RadioButtonGroup>
       </div>
+    </responsive-grid>
+    <responsive-grid :cols="12" :sm="6" :gap="4">
       <div class="flex flex-col gap-2">
         <label for="technicalReportInput">Technical Report</label>
         <RadioButtonGroup class="mt-1" v-model="technicalReportInput" id="technicalReportInput">
@@ -52,6 +54,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </div>
         </RadioButtonGroup>
       </div>
+    </responsive-grid>
+    <responsive-grid :cols="12" :sm="6" :gap="4">
       <div class="flex flex-col gap-2">
         <label for="drinkingWaterProtectionAreaInput">Drinking Water Area Indicator</label>
         <RadioButtonGroup class="mt-1" v-model="drinkingWaterProtectionAreaInput" id="drinkingWaterProtectionAreaInput">

--- a/app/frontend/src/submissions/components/SubmissionForm/Comments.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Comments.vue
@@ -12,18 +12,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Comments</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
+  <form-subsection title="Comments" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <b-row>
       <b-col cols="12" md="8">
         <b-form-group label="Comments" id="commentsGroup">
@@ -50,52 +39,53 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <b-row class="mt-4">
       <b-col cols="12" sm="6">
         <b-form-group label="Alternative Specs Submitted">
-        <b-form-radio-group
-          id="alternativeSpecsCheckbox"
-          class="mt-1"
-          v-model="alternativeSpecsSubmittedInput"
-        >
-          <b-form-radio :value="false">No</b-form-radio>
-          <b-form-radio :value="true">Yes</b-form-radio>
-        </b-form-radio-group>
-      </b-form-group>
-    </b-col>
+          <b-form-radio-group
+            id="alternativeSpecsCheckbox"
+            class="mt-1"
+            v-model="alternativeSpecsSubmittedInput"
+          >
+            <b-form-radio :value="false">No</b-form-radio>
+            <b-form-radio :value="true">Yes</b-form-radio>
+          </b-form-radio-group>
+        </b-form-group>
+      </b-col>
     </b-row>
     <b-row class="mt-4">
       <b-col cols="12" sm="6">
         <b-form-group label="Technical Report">
-        <b-form-radio-group
-          id="technicalReportCheckbox"
-          class="mt-1"
-          v-model="technicalReportInput"
-        >
-          <b-form-radio :value="false">No</b-form-radio>
-          <b-form-radio :value="true">Yes</b-form-radio>
-        </b-form-radio-group>
-      </b-form-group>
-    </b-col>
+          <b-form-radio-group
+            id="technicalReportCheckbox"
+            class="mt-1"
+            v-model="technicalReportInput"
+          >
+            <b-form-radio :value="false">No</b-form-radio>
+            <b-form-radio :value="true">Yes</b-form-radio>
+          </b-form-radio-group>
+        </b-form-group>
+      </b-col>
     </b-row>
     <b-row class="mt-4">
       <b-col cols="12" sm="6">
         <b-form-group label="Drinking Water Area Indicator">
-        <b-form-radio-group
-          id="drinkingWaterProtectionAreaCheckbox"
-          class="mt-1"
-          v-model="drinkingWaterProtectionAreaInput"
-        >
-          <b-form-radio :value="false">No</b-form-radio>
-          <b-form-radio :value="true">Yes</b-form-radio>
-        </b-form-radio-group>
-      </b-form-group>
-    </b-col>
+          <b-form-radio-group
+            id="drinkingWaterProtectionAreaCheckbox"
+            class="mt-1"
+            v-model="drinkingWaterProtectionAreaInput"
+          >
+            <b-form-radio :value="false">No</b-form-radio>
+            <b-form-radio :value="true">Yes</b-form-radio>
+          </b-form-radio-group>
+        </b-form-group>
+      </b-col>
     </b-row>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -125,6 +115,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   fields: {
     commentsInput: 'comments',

--- a/app/frontend/src/submissions/components/SubmissionForm/Completion.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Completion.vue
@@ -21,7 +21,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         type="number"
         hint="ft (bgl)"
         :errors="errors['total_depth_drilled']"
-        :loaded="fieldsLoaded['total_depth_drilled']"></form-input>
+        :loaded="fieldsLoaded['total_depth_drilled']"/>
       <form-input
         id="finishedWellDepth"
         :label="finishedWellDepthLabel"
@@ -29,7 +29,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         type="number"
         hint="ft (bgl)"
         :errors="errors['finished_well_depth']"
-        :loaded="fieldsLoaded['finished_well_depth']"></form-input>
+        :loaded="fieldsLoaded['finished_well_depth']"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="6" :lg="4">
       <form-input
@@ -39,7 +39,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="finalCasingStickUpInput"
         hint="in"
         :errors="errors['final_casing_stick_up']"
-        :loaded="fieldsLoaded['final_casing_stick_up']"></form-input>
+        :loaded="fieldsLoaded['final_casing_stick_up']"/>
       <form-input
         id="bedrockDepth"
         label="Depth to Bedrock"
@@ -47,7 +47,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="bedrockDepthInput"
         hint="ft (bgl)"
         :errors="errors['depth_to_bedrock']"
-        :loaded="fieldsLoaded['depth_to_bedrock']"></form-input>
+        :loaded="fieldsLoaded['depth_to_bedrock']"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="6" :lg="4">
       <form-input
@@ -57,7 +57,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         type="number"
         hint="ft (btoc)"
         :errors="errors['static_water_level']"
-        :loaded="fieldsLoaded['static_water_level']"></form-input>
+        :loaded="fieldsLoaded['static_water_level']"/>
       <form-input
         id="wellYield"
         label="Estimated Well Yield"
@@ -65,11 +65,12 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="wellYieldInput"
         hint="USgpm"
         :errors="errors['well_yield']"
-        :loaded="fieldsLoaded['well_yield']"></form-input>
+        :loaded="fieldsLoaded['well_yield']"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="6" :lg="4">
-      <b-form-group label="Artesian Well">
-        <RadioButtonGroup class="mt-1"v-model="artesianConditionsInput">
+      <div class="flex flex-col gap-2">
+        <label for="artesianConditionsInput">Artesian Well</label>
+        <RadioButtonGroup class="mt-1" v-model="artesianConditionsInput" id="artesianConditionsInput">
           <div>
             <RadioButton inputId="artesianConditionsInput.false" :value="false"/>
             <label for="artesianConditionsInput.false" class="ml-2">No</label>
@@ -79,7 +80,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             <label for="artesianConditionsInput.true" class="ml-2">Yes</label>
           </div>
         </RadioButtonGroup>
-      </b-form-group>
+      </div>
       <form-input
         id="artesianFlow"
         label="Artesian Flow"
@@ -87,7 +88,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         hint="USgpm"
         type="number"
         :errors="errors['artesian_flow']"
-        :loaded="fieldsLoaded['artesian_flow']"></form-input>
+        :loaded="fieldsLoaded['artesian_flow']"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="6" :lg="4">
       <form-input
@@ -98,7 +99,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         hint="ft (agl)"
         type="number"
         :errors="errors['artesian_pressure_head']"
-        :loaded="fieldsLoaded['artesian_pressure_head']"></form-input>
+        :loaded="fieldsLoaded['artesian_pressure_head']"/>
       <form-input
         id="artesianPressurePSI"
         label="Artesian Pressure (PSI)"
@@ -107,7 +108,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         hint="PSI"
         type="number"
         :errors="errors['artesian_pressure']"
-        :loaded="fieldsLoaded['artesian_pressure']"></form-input>
+        :loaded="fieldsLoaded['artesian_pressure']"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="6" :lg="4">
       <form-input
@@ -115,15 +116,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
         label="Well Cap Type"
         v-model="wellCapTypeInput"
         :errors="errors['well_cap_type']"
-        :loaded="fieldsLoaded['well_cap_type']"></form-input>
-      <b-form-group label="Well Disinfected Status" id="wellDisinfectedStatusInput">
-        <Dropdown
+        :loaded="fieldsLoaded['well_cap_type']"/>
+      <div class="flex flex-col gap-2">
+        <label for="wellDisinfectedStatusInput">Well Disinfected Status</label>
+        <Select
+          id="wellDisinfectedStatusInput"
           v-model="wellDisinfectedInput"
           optionValue="well_disinfected_code"
           optionLabel="well_disinfected_code"
           :options="disinfected_codes()"
           :loading="!fieldsLoaded['well_disinfected_status']"/>
-      </b-form-group>
+      </div>
     </responsive-grid>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/Completion.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Completion.vue
@@ -13,151 +13,127 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Well Completion Data" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-            id="totalDepthDrilled"
-            :label="totalDepthDrilledLabel"
-            v-model="totalDepthDrilledInput"
-            type="number"
-            hint="ft (bgl)"
-            :errors="errors['total_depth_drilled']"
-            :loaded="fieldsLoaded['total_depth_drilled']">
-        </form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-            id="finishedWellDepth"
-            :label="finishedWellDepthLabel"
-            v-model="finishedWellDepthInput"
-            type="number"
-            hint="ft (bgl)"
-            :errors="errors['finished_well_depth']"
-            :loaded="fieldsLoaded['finished_well_depth']">
-        </form-input>
-      </div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-            id="finalCasingStickUp"
-            label="Final Casing Stick Up"
-            type="number"
-            v-model="finalCasingStickUpInput"
-            hint="in"
-            :errors="errors['final_casing_stick_up']"
-            :loaded="fieldsLoaded['final_casing_stick_up']">
-        </form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-            id="bedrockDepth"
-            label="Depth to Bedrock"
-            type="number"
-            v-model="bedrockDepthInput"
-            hint="ft (bgl)"
-            :errors="errors['depth_to_bedrock']"
-            :loaded="fieldsLoaded['depth_to_bedrock']">
-        </form-input>
-      </div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-            id="staticWaterLevel"
-            label="Static Water Level"
-            v-model="staticWaterLevelInput"
-            type="number"
-            hint="ft (btoc)"
-            :errors="errors['static_water_level']"
-            :loaded="fieldsLoaded['static_water_level']">
-        </form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-            id="wellYield"
-            label="Estimated Well Yield"
-            type="number"
-            v-model="wellYieldInput"
-            hint="USgpm"
-            :errors="errors['well_yield']"
-            :loaded="fieldsLoaded['well_yield']">
-        </form-input>
-      </div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <b-form-group label="Artesian Well">
-          <b-form-radio-group
-            id="artesianConditionsRadio"
-            class="mt-1"
-            v-model="artesianConditionsInput">
-              <b-form-radio :value="false">No</b-form-radio>
-              <b-form-radio :value="true">Yes</b-form-radio>
-          </b-form-radio-group>
-        </b-form-group>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-          id="artesianFlow"
-          label="Artesian Flow"
-          v-model="artesianFlowInput"
-          hint="USgpm"
-          type="number"
-          :errors="errors['artesian_flow']"
-          :loaded="fieldsLoaded['artesian_flow']">
-        </form-input>
-      </div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-          id="artesianPressureHead"
-          label="Artesian Pressure (head)"
-          @input="handleArtesianPressureHeadChange"
-          v-model="artesianPressure.head"
-          hint="ft (agl)"
-          type="number"
-          :errors="errors['artesian_pressure_head']"
-          :loaded="fieldsLoaded['artesian_pressure_head']">
-        </form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-          id="artesianPressurePSI"
-          label="Artesian Pressure (PSI)"
-          @input="handleArtesianPressurePSIChange"
-          v-model="artesianPressure.psi"
-          hint="PSI"
-          type="number"
-          :errors="errors['artesian_pressure']"
-          :loaded="fieldsLoaded['artesian_pressure']">
-        </form-input>
-      </div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-            id="wellCapType"
-            label="Well Cap Type"
-            v-model="wellCapTypeInput"
-            :errors="errors['well_cap_type']"
-            :loaded="fieldsLoaded['well_cap_type']">
-        </form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <b-form-group label="Well Disinfected Status" id="wellDisinfectedStatusInput">
-          <b-form-select
-            v-model="wellDisinfectedInput"
-            value-field="well_disinfected_code"
-            text-field="well_disinfected_code"
-            :options="disinfected_codes()"
-            :errors="errors['well_disinfected_status']"
-            :loaded="fieldsLoaded['well_disinfected_status']">
-          </b-form-select>
-        </b-form-group>
-      </div>
-    </div>
+    <responsive-grid :cols="12" :md="6" :lg="4">
+      <form-input
+        id="totalDepthDrilled"
+        :label="totalDepthDrilledLabel"
+        v-model="totalDepthDrilledInput"
+        type="number"
+        hint="ft (bgl)"
+        :errors="errors['total_depth_drilled']"
+        :loaded="fieldsLoaded['total_depth_drilled']">
+      </form-input>
+      <form-input
+        id="finishedWellDepth"
+        :label="finishedWellDepthLabel"
+        v-model="finishedWellDepthInput"
+        type="number"
+        hint="ft (bgl)"
+        :errors="errors['finished_well_depth']"
+        :loaded="fieldsLoaded['finished_well_depth']">
+      </form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="6" :lg="4">
+      <form-input
+        id="finalCasingStickUp"
+        label="Final Casing Stick Up"
+        type="number"
+        v-model="finalCasingStickUpInput"
+        hint="in"
+        :errors="errors['final_casing_stick_up']"
+        :loaded="fieldsLoaded['final_casing_stick_up']">
+      </form-input>
+      <form-input
+        id="bedrockDepth"
+        label="Depth to Bedrock"
+        type="number"
+        v-model="bedrockDepthInput"
+        hint="ft (bgl)"
+        :errors="errors['depth_to_bedrock']"
+        :loaded="fieldsLoaded['depth_to_bedrock']">
+      </form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="6" :lg="4">
+      <form-input
+        id="staticWaterLevel"
+        label="Static Water Level"
+        v-model="staticWaterLevelInput"
+        type="number"
+        hint="ft (btoc)"
+        :errors="errors['static_water_level']"
+        :loaded="fieldsLoaded['static_water_level']">
+      </form-input>
+      <form-input
+        id="wellYield"
+        label="Estimated Well Yield"
+        type="number"
+        v-model="wellYieldInput"
+        hint="USgpm"
+        :errors="errors['well_yield']"
+        :loaded="fieldsLoaded['well_yield']">
+      </form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="6" :lg="4">
+      <b-form-group label="Artesian Well">
+        <b-form-radio-group
+          id="artesianConditionsRadio"
+          class="mt-1"
+          v-model="artesianConditionsInput">
+            <b-form-radio :value="false">No</b-form-radio>
+            <b-form-radio :value="true">Yes</b-form-radio>
+        </b-form-radio-group>
+      </b-form-group>
+      <form-input
+        id="artesianFlow"
+        label="Artesian Flow"
+        v-model="artesianFlowInput"
+        hint="USgpm"
+        type="number"
+        :errors="errors['artesian_flow']"
+        :loaded="fieldsLoaded['artesian_flow']">
+      </form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="6" :lg="4">
+      <form-input
+        id="artesianPressureHead"
+        label="Artesian Pressure (head)"
+        @input="handleArtesianPressureHeadChange"
+        v-model="artesianPressure.head"
+        hint="ft (agl)"
+        type="number"
+        :errors="errors['artesian_pressure_head']"
+        :loaded="fieldsLoaded['artesian_pressure_head']">
+      </form-input>
+      <form-input
+        id="artesianPressurePSI"
+        label="Artesian Pressure (PSI)"
+        @input="handleArtesianPressurePSIChange"
+        v-model="artesianPressure.psi"
+        hint="PSI"
+        type="number"
+        :errors="errors['artesian_pressure']"
+        :loaded="fieldsLoaded['artesian_pressure']">
+      </form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="6" :lg="4">
+      <form-input
+        id="wellCapType"
+        label="Well Cap Type"
+        v-model="wellCapTypeInput"
+        :errors="errors['well_cap_type']"
+        :loaded="fieldsLoaded['well_cap_type']">
+      </form-input>
+      <b-form-group label="Well Disinfected Status" id="wellDisinfectedStatusInput">
+        <b-form-select
+          v-model="wellDisinfectedInput"
+          value-field="well_disinfected_code"
+          text-field="well_disinfected_code"
+          :options="disinfected_codes()"
+          :errors="errors['well_disinfected_status']"
+          :loaded="fieldsLoaded['well_disinfected_status']">
+        </b-form-select>
+      </b-form-group>
+    </responsive-grid>
   </form-subsection>
 </template>
 
@@ -166,6 +142,7 @@ import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -206,7 +183,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   fields: {
     totalDepthDrilledInput: 'totalDepthDrilled',

--- a/app/frontend/src/submissions/components/SubmissionForm/Completion.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Completion.vue
@@ -21,8 +21,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         type="number"
         hint="ft (bgl)"
         :errors="errors['total_depth_drilled']"
-        :loaded="fieldsLoaded['total_depth_drilled']">
-      </form-input>
+        :loaded="fieldsLoaded['total_depth_drilled']"></form-input>
       <form-input
         id="finishedWellDepth"
         :label="finishedWellDepthLabel"
@@ -30,8 +29,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         type="number"
         hint="ft (bgl)"
         :errors="errors['finished_well_depth']"
-        :loaded="fieldsLoaded['finished_well_depth']">
-      </form-input>
+        :loaded="fieldsLoaded['finished_well_depth']"></form-input>
     </responsive-grid>
     <responsive-grid :cols="12" :md="6" :lg="4">
       <form-input
@@ -41,8 +39,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="finalCasingStickUpInput"
         hint="in"
         :errors="errors['final_casing_stick_up']"
-        :loaded="fieldsLoaded['final_casing_stick_up']">
-      </form-input>
+        :loaded="fieldsLoaded['final_casing_stick_up']"></form-input>
       <form-input
         id="bedrockDepth"
         label="Depth to Bedrock"
@@ -50,8 +47,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="bedrockDepthInput"
         hint="ft (bgl)"
         :errors="errors['depth_to_bedrock']"
-        :loaded="fieldsLoaded['depth_to_bedrock']">
-      </form-input>
+        :loaded="fieldsLoaded['depth_to_bedrock']"></form-input>
     </responsive-grid>
     <responsive-grid :cols="12" :md="6" :lg="4">
       <form-input
@@ -61,8 +57,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         type="number"
         hint="ft (btoc)"
         :errors="errors['static_water_level']"
-        :loaded="fieldsLoaded['static_water_level']">
-      </form-input>
+        :loaded="fieldsLoaded['static_water_level']"></form-input>
       <form-input
         id="wellYield"
         label="Estimated Well Yield"
@@ -70,18 +65,20 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="wellYieldInput"
         hint="USgpm"
         :errors="errors['well_yield']"
-        :loaded="fieldsLoaded['well_yield']">
-      </form-input>
+        :loaded="fieldsLoaded['well_yield']"></form-input>
     </responsive-grid>
     <responsive-grid :cols="12" :md="6" :lg="4">
       <b-form-group label="Artesian Well">
-        <b-form-radio-group
-          id="artesianConditionsRadio"
-          class="mt-1"
-          v-model="artesianConditionsInput">
-            <b-form-radio :value="false">No</b-form-radio>
-            <b-form-radio :value="true">Yes</b-form-radio>
-        </b-form-radio-group>
+        <RadioButtonGroup class="mt-1"v-model="artesianConditionsInput">
+          <div>
+            <RadioButton inputId="artesianConditionsInput.false" :value="false"/>
+            <label for="artesianConditionsInput.false" class="ml-2">No</label>
+          </div>
+          <div>
+            <RadioButton inputId="artesianConditionsInput.true" :value="true"/>
+            <label for="artesianConditionsInput.true" class="ml-2">Yes</label>
+          </div>
+        </RadioButtonGroup>
       </b-form-group>
       <form-input
         id="artesianFlow"
@@ -90,8 +87,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         hint="USgpm"
         type="number"
         :errors="errors['artesian_flow']"
-        :loaded="fieldsLoaded['artesian_flow']">
-      </form-input>
+        :loaded="fieldsLoaded['artesian_flow']"></form-input>
     </responsive-grid>
     <responsive-grid :cols="12" :md="6" :lg="4">
       <form-input
@@ -102,8 +98,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         hint="ft (agl)"
         type="number"
         :errors="errors['artesian_pressure_head']"
-        :loaded="fieldsLoaded['artesian_pressure_head']">
-      </form-input>
+        :loaded="fieldsLoaded['artesian_pressure_head']"></form-input>
       <form-input
         id="artesianPressurePSI"
         label="Artesian Pressure (PSI)"
@@ -112,8 +107,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         hint="PSI"
         type="number"
         :errors="errors['artesian_pressure']"
-        :loaded="fieldsLoaded['artesian_pressure']">
-      </form-input>
+        :loaded="fieldsLoaded['artesian_pressure']"></form-input>
     </responsive-grid>
     <responsive-grid :cols="12" :md="6" :lg="4">
       <form-input
@@ -121,17 +115,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
         label="Well Cap Type"
         v-model="wellCapTypeInput"
         :errors="errors['well_cap_type']"
-        :loaded="fieldsLoaded['well_cap_type']">
-      </form-input>
+        :loaded="fieldsLoaded['well_cap_type']"></form-input>
       <b-form-group label="Well Disinfected Status" id="wellDisinfectedStatusInput">
-        <b-form-select
+        <Dropdown
           v-model="wellDisinfectedInput"
-          value-field="well_disinfected_code"
-          text-field="well_disinfected_code"
+          optionValue="well_disinfected_code"
+          optionLabel="well_disinfected_code"
           :options="disinfected_codes()"
-          :errors="errors['well_disinfected_status']"
-          :loaded="fieldsLoaded['well_disinfected_status']">
-        </b-form-select>
+          :loading="!fieldsLoaded['well_disinfected_status']"/>
       </b-form-group>
     </responsive-grid>
   </form-subsection>

--- a/app/frontend/src/submissions/components/SubmissionForm/Completion.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Completion.vue
@@ -12,20 +12,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Well Completion Data</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="6" lg="4">
+  <form-subsection title="Well Completion Data" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
             id="totalDepthDrilled"
             :label="totalDepthDrilledLabel"
@@ -35,8 +24,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :errors="errors['total_depth_drilled']"
             :loaded="fieldsLoaded['total_depth_drilled']">
         </form-input>
-      </b-col>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
             id="finishedWellDepth"
             :label="finishedWellDepthLabel"
@@ -46,10 +35,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :errors="errors['finished_well_depth']"
             :loaded="fieldsLoaded['finished_well_depth']">
         </form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
             id="finalCasingStickUp"
             label="Final Casing Stick Up"
@@ -59,8 +48,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :errors="errors['final_casing_stick_up']"
             :loaded="fieldsLoaded['final_casing_stick_up']">
         </form-input>
-      </b-col>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
             id="bedrockDepth"
             label="Depth to Bedrock"
@@ -70,10 +59,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :errors="errors['depth_to_bedrock']"
             :loaded="fieldsLoaded['depth_to_bedrock']">
         </form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
             id="staticWaterLevel"
             label="Static Water Level"
@@ -83,8 +72,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :errors="errors['static_water_level']"
             :loaded="fieldsLoaded['static_water_level']">
         </form-input>
-      </b-col>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
             id="wellYield"
             label="Estimated Well Yield"
@@ -94,10 +83,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :errors="errors['well_yield']"
             :loaded="fieldsLoaded['well_yield']">
         </form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <b-form-group label="Artesian Well">
           <b-form-radio-group
             id="artesianConditionsRadio"
@@ -107,8 +96,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
               <b-form-radio :value="true">Yes</b-form-radio>
           </b-form-radio-group>
         </b-form-group>
-      </b-col>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
           id="artesianFlow"
           label="Artesian Flow"
@@ -118,10 +107,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
           :errors="errors['artesian_flow']"
           :loaded="fieldsLoaded['artesian_flow']">
         </form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
           id="artesianPressureHead"
           label="Artesian Pressure (head)"
@@ -132,8 +121,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           :errors="errors['artesian_pressure_head']"
           :loaded="fieldsLoaded['artesian_pressure_head']">
         </form-input>
-      </b-col>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
           id="artesianPressurePSI"
           label="Artesian Pressure (PSI)"
@@ -144,10 +133,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
           :errors="errors['artesian_pressure']"
           :loaded="fieldsLoaded['artesian_pressure']">
         </form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
             id="wellCapType"
             label="Well Cap Type"
@@ -155,8 +144,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :errors="errors['well_cap_type']"
             :loaded="fieldsLoaded['well_cap_type']">
         </form-input>
-      </b-col>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <b-form-group label="Well Disinfected Status" id="wellDisinfectedStatusInput">
           <b-form-select
             v-model="wellDisinfectedInput"
@@ -167,15 +156,16 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :loaded="fieldsLoaded['well_disinfected_status']">
           </b-form-select>
         </b-form-group>
-      </b-col>
-    </b-row>
-  </fieldset>
+      </div>
+    </div>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -214,6 +204,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   fields: {
     totalDepthDrilledInput: 'totalDepthDrilled',

--- a/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
@@ -44,8 +44,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </Card>
           <div class="flex"><p class="p-4 m-0">OR</p></div>
           <div class="container p-4 mx-1 mx-md-1">
-            <b-row>
-              <b-col cols="12" md="6" lg="6">
+            <div class="grid grid-cols-12">
+              <div class="col-span-12 md:col-span-6 lg:col-span-6">
                 <div class="mb-2">Latitude</div>
                 <responsive-grid :cols="12" :sm="4" :innerDivClass="['px-2', 'px-2', 'px-1']">
                   <form-input
@@ -73,8 +73,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     :errors="errors['latitude']"
                     :loaded="fieldsLoaded['latitude']"></form-input>
                 </responsive-grid>
-              </b-col>
-              <b-col cols="12" md="6" lg="6" offset-lg="0">
+              </div>
+              <div class="col-span-12 md:col-span-6 lg:col-span-6 lg:col-start-1">
                 <div class="flex mb-2">Longitude</div>
                 <responsive-grid :cols="12" :sm="4" :innerDivClass="['px-2', 'px-2', 'px-1']">
                   <form-input
@@ -102,8 +102,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     :errors="errors['longitude']"
                     :loaded="fieldsLoaded['longitude']"></form-input>
                 </responsive-grid>
-              </b-col>
-            </b-row>
+              </div>
+            </div>
           </div>
           <div class="flex"><p class="p-4 m-0">OR</p></div>
           <div class="container p-4 mx-1 mx-md-1">
@@ -178,9 +178,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </Dialog>
       </Card>
       <!-- Error message when coordinates not entered in at least one of the 3 input groups -->
-      <b-alert class="mt-4" variant="danger" :show="errorCoordsNotProvided">
+      <Message class="mt-4" severity="error" v-if="errorCoordsNotProvided">
         Must enter geographic coordinates in either decimal degrees, degrees/minutes/seconds, or UTM format.
-      </b-alert>
+      </Message>
     </form-subsection>
   </div>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
@@ -14,49 +14,51 @@ Licensed under the Apache License, Version 2.0 (the "License");
 <template>
   <div>
     <fieldset>
-      <b-row>
-        <b-col cols="12" lg="6">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-6">
           <legend :id="id">Geographic Coordinates</legend>
-        </b-col>
-        <b-col cols="12" lg="6">
+        </div>
+        <div class="col-span-12 lg:col-span-6">
           <div class="float-right">
-            <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
+            <Button label="Save" v-if="isStaffEdit" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
             <back-to-top-link v-if="isStaffEdit"/>
           </div>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
       <p>To determine coordinates using a Global Positioning System (GPS), set the datum to North America Datum of 1983 (NAD 83), the current ministry standard for mapping.</p>
-      <p class="bg-warning p-2">The map pin can be placed manually, by clicking, or by dragging on the map. The GPS coordinates will be updated automatically.</p>
+      <p class="bg-yellow-400 p-2">The map pin can be placed manually, by clicking, or by dragging on the map. The GPS coordinates will be updated automatically.</p>
       <b-row>
         <b-col sm="12" md="6">
-          <b-card no-body class="p-4 m-1 m-md-1">
-            <b-row>
-              <b-col cols="12" sm="6" lg="3">
-                <form-input
-                  id="latitude"
-                  type="text"
-                  label="Latitude"
-                  hint="Decimal degrees"
-                  @input="handleDegreesChange"
-                  v-model.number="degrees.latitude"
-                  :errors="errors['latitude']"
-                  :loaded="fieldsLoaded['latitude']"
-                ></form-input>
-              </b-col>
-              <b-col cols="12" sm="6" lg="3" offset-lg="2">
-                <form-input
-                  id="longitude"
-                  type="text"
-                  @input="handleDegreesChange"
-                  label="Longitude"
-                  hint="Decimal degrees"
-                  v-model.number="degrees.longitude"
-                  :errors="errors['longitude']"
-                  :loaded="fieldsLoaded['longitude']"
-                ></form-input>
-              </b-col>
-            </b-row>
-          </b-card>
+          <Card class="p-4 m-1 md:m-1">
+            <template #default>
+              <div class="grid grid-cols-12">
+                <div class="col-span-12 sm:col-span-6 lg:col-span-3">
+                  <form-input
+                    id="latitude"
+                    type="text"
+                    label="Latitude"
+                    hint="Decimal degrees"
+                    @input="handleDegreesChange"
+                    v-model.number="degrees.latitude"
+                    :errors="errors['latitude']"
+                    :loaded="fieldsLoaded['latitude']"
+                  ></form-input>
+                </div>
+                <div class="col-span-12 sm:col-span-6 lg:col-span-3 lg:col-start-3">
+                  <form-input
+                    id="longitude"
+                    type="text"
+                    @input="handleDegreesChange"
+                    label="Longitude"
+                    hint="Decimal degrees"
+                    v-model.number="degrees.longitude"
+                    :errors="errors['longitude']"
+                    :loaded="fieldsLoaded['longitude']"
+                  ></form-input>
+                </div>
+              </div>
+            </template>
+          </Card>
           <b-row><b-col><p class="p-4 m-0">OR</p></b-col></b-row>
           <b-card no-body class="p-4 mx-1 mx-md-1">
             <b-row>

--- a/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
@@ -161,22 +161,22 @@ Licensed under the Apache License, Version 2.0 (the "License");
           <coords-map :latitude="mapLatitude" :longitude="mapLongitude" v-on:coordinate="handleMapCoordinate" :drinking_water="this.drinking_water"/>
         </div>
       </div>
-      <b-card>
-        <b-modal
-          v-model="confirmRemoveModalInput"
+      <Card>
+        <Dialog
+          v-model:visible="confirmRemoveModalInput"
+          modal
           no-close-on-esc
           no-close-on-backdrop
           hide-header-close
-          centered
-          title="Confirm Coordinates Change"
-          @shown="focusRemoveModal">
+          header="Confirm Coordinates Change"
+          @show="focusRemoveModal">
           WARNING, a well capture zone has been delineated based on the existing coordinates. Are you sure you want to update the coordinates? Note: If you select 'Yes, Update' a notification email will be sent to the data managers of the Capture Zones dataset.
-          <div slot="modal-footer">
+          <template #footer>
             <Button label="No, Cancel" severity="secondary" @click="confirmRemoveModalInput=false;revertCoords()" ref="cancelRemoveBtn"/>
             <Button label="Yes, Update" severity="danger" @click="confirmRemoveModalInput=false;confirmCoords()"/>
-          </div>
-        </b-modal>
-      </b-card>
+          </template>
+        </Dialog>
+      </Card>
       <!-- Error message when coordinates not entered in at least one of the 3 input groups -->
       <b-alert class="mt-4" variant="danger" :show="errorCoordsNotProvided">
         Must enter geographic coordinates in either decimal degrees, degrees/minutes/seconds, or UTM format.

--- a/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
@@ -18,7 +18,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <p class="bg-yellow-400 p-2">The map pin can be placed manually, by clicking, or by dragging on the map. The GPS coordinates will be updated automatically.</p>
       <div class="grid grid-cols-12">
         <div class="sm:col-span-12 md:col-span-6">
-          <Card class="p-4 m-1 md:m-1">
+          <div class="container p-4 m-1 md:m-1">
             <template #default>
               <responsive-grid :cols="12" :sm="6" :lg="3">
                 <form-input
@@ -41,9 +41,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   :loaded="fieldsLoaded['longitude']"/>
               </responsive-grid>
             </template>
-          </Card>
+          </div>
           <div class="flex"><p class="p-4 m-0">OR</p></div>
-          <div class="container p-4 mx-1 mx-md-1">
+          <div class="container p-4 mx-1 md:mx-1">
             <div class="grid grid-cols-12">
               <div class="col-span-12 md:col-span-6 lg:col-span-6">
                 <div class="mb-2">Latitude</div>
@@ -106,7 +106,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             </div>
           </div>
           <div class="flex"><p class="p-4 m-0">OR</p></div>
-          <div class="container p-4 mx-1 mx-md-1">
+          <div class="container p-4 mx-1 md:mx-1">
             <responsive-grid :cols="12" :sm="4" :lg="4">
               <form-input
                 id="utmZone"
@@ -149,11 +149,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 :loaded="fieldsLoaded['coordinateAcquisitionCode']"/>
             </div>
           </div>
-          <div class="flex">
-            <div class="mt-4">
-              <div v-if="validCoordinate === false">
-                <div class="alert alert-danger" role="alert">You have entered an invalid coordinate</div>
-              </div>
+          <div class="flex mt-4">
+            <div v-if="validCoordinate === false">
+              <div class="alert alert-danger" role="alert">You have entered an invalid coordinate</div>
             </div>
           </div>
         </div>
@@ -165,9 +163,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <Dialog
           v-model:visible="confirmRemoveModalInput"
           modal
-          no-close-on-esc
-          no-close-on-backdrop
-          hide-header-close
+          :closeOnEscape="false"
+          :closeable="false"
           header="Confirm Coordinates Change"
           @show="focusRemoveModal">
           WARNING, a well capture zone has been delineated based on the existing coordinates. Are you sure you want to update the coordinates? Note: If you select 'Yes, Update' a notification email will be sent to the data managers of the Capture Zones dataset.

--- a/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
@@ -16,187 +16,151 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <form-subsection title="Geographic Coordinates" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
       <p>To determine coordinates using a Global Positioning System (GPS), set the datum to North America Datum of 1983 (NAD 83), the current ministry standard for mapping.</p>
       <p class="bg-yellow-400 p-2">The map pin can be placed manually, by clicking, or by dragging on the map. The GPS coordinates will be updated automatically.</p>
-      <b-row>
-        <b-col sm="12" md="6">
+      <div class="grid grid-cols-12">
+        <div class="sm:col-span-12 md:col-span-6">
           <Card class="p-4 m-1 md:m-1">
             <template #default>
-              <div class="grid grid-cols-12">
-                <div class="col-span-12 sm:col-span-6 lg:col-span-3">
-                  <form-input
-                    id="latitude"
-                    type="text"
-                    label="Latitude"
-                    hint="Decimal degrees"
-                    @input="handleDegreesChange"
-                    v-model.number="degrees.latitude"
-                    :errors="errors['latitude']"
-                    :loaded="fieldsLoaded['latitude']"
-                  ></form-input>
-                </div>
-                <div class="col-span-12 sm:col-span-6 lg:col-span-3 lg:col-start-3">
-                  <form-input
-                    id="longitude"
-                    type="text"
-                    @input="handleDegreesChange"
-                    label="Longitude"
-                    hint="Decimal degrees"
-                    v-model.number="degrees.longitude"
-                    :errors="errors['longitude']"
-                    :loaded="fieldsLoaded['longitude']"
-                  ></form-input>
-                </div>
-              </div>
+              <responsive-grid :cols="12" :sm="6" :lg="3">
+                <form-input
+                  id="latitude"
+                  type="text"
+                  label="Latitude"
+                  hint="Decimal degrees"
+                  @input="handleDegreesChange"
+                  v-model.number="degrees.latitude"
+                  :errors="errors['latitude']"
+                  :loaded="fieldsLoaded['latitude']"></form-input>
+                <form-input
+                  id="longitude"
+                  type="text"
+                  @input="handleDegreesChange"
+                  label="Longitude"
+                  hint="Decimal degrees"
+                  v-model.number="degrees.longitude"
+                  :errors="errors['longitude']"
+                  :loaded="fieldsLoaded['longitude']"></form-input>
+              </responsive-grid>
             </template>
           </Card>
-          <b-row><b-col><p class="p-4 m-0">OR</p></b-col></b-row>
-          <b-card no-body class="p-4 mx-1 mx-md-1">
+          <div class="flex"><p class="p-4 m-0">OR</p></div>
+          <div class="container p-4 mx-1 mx-md-1">
             <b-row>
               <b-col cols="12" md="6" lg="6">
-                <b-row class="mb-2"><b-col>Latitude</b-col></b-row>
-                <b-row>
-                  <b-col cols="12" sm="4" class="px-2">
-                    <form-input
-                      id="latitudeDeg"
-                      @input="handleDMSChange"
-                      hint="Degrees"
-                      type="text"
-                      v-model.number="dms.lat.deg"
-                      :errors="errors['latitude']"
-                      :loaded="fieldsLoaded['latitude']"
-                    ></form-input>
-                  </b-col>
-                  <b-col cols="12" sm="4" class="px-2">
-                    <form-input
-                      id="latitudeMin"
-                      hint="Minutes"
-                      @input="handleDMSChange"
-                      type="text"
-                      v-model.number="dms.lat.min"
-                      :errors="errors['latitude']"
-                      :loaded="fieldsLoaded['latitude']"
-                    ></form-input>
-                  </b-col>
-                  <b-col cols="12" sm="4" class="px-1">
-                    <form-input
-                      id="latitudeSec"
-                      type="text"
-                      @input="handleDMSChange"
-                      hint="Seconds"
-                      v-model.number="dms.lat.sec"
-                      :errors="errors['latitude']"
-                      :loaded="fieldsLoaded['latitude']"
-                    ></form-input>
-                  </b-col>
-                </b-row>
+                <div class="mb-2">Latitude</div>
+                <responsive-grid :cols="12" :sm="4" :innerDivClass="['px-2', 'px-2', 'px-1']">
+                  <form-input
+                    id="latitudeDeg"
+                    @input="handleDMSChange"
+                    hint="Degrees"
+                    type="text"
+                    v-model.number="dms.lat.deg"
+                    :errors="errors['latitude']"
+                    :loaded="fieldsLoaded['latitude']"></form-input>
+                  <form-input
+                    id="latitudeMin"
+                    hint="Minutes"
+                    @input="handleDMSChange"
+                    type="text"
+                    v-model.number="dms.lat.min"
+                    :errors="errors['latitude']"
+                    :loaded="fieldsLoaded['latitude']"></form-input>
+                  <form-input
+                    id="latitudeSec"
+                    type="text"
+                    @input="handleDMSChange"
+                    hint="Seconds"
+                    v-model.number="dms.lat.sec"
+                    :errors="errors['latitude']"
+                    :loaded="fieldsLoaded['latitude']"></form-input>
+                </responsive-grid>
               </b-col>
               <b-col cols="12" md="6" lg="6" offset-lg="0">
-                <b-row class="mb-2"><b-col>Longitude</b-col></b-row>
-                <b-row>
-                  <b-col cols="12" sm="4" class="px-2">
-                    <form-input
-                      id="longitudeDeg"
-                      type="text"
-                      @input="handleDMSChange"
-                      hint="Degrees"
-                      v-model.number="dms.long.deg"
-                      :errors="errors['longitude']"
-                      :loaded="fieldsLoaded['longitude']"
-                    ></form-input>
-                  </b-col>
-                  <b-col cols="12" sm="4" class="px-2">
-                    <form-input
-                      id="longitudeMin"
-                      type="text"
-                      @input="handleDMSChange"
-                      hint="Minutes"
-                      v-model.number="dms.long.min"
-                      :errors="errors['longitude']"
-                      :loaded="fieldsLoaded['longitude']"
-                    ></form-input>
-                  </b-col>
-                  <b-col cols="12" sm="4" class="px-1">
-                    <form-input
-                      id="longitudeSec"
-                      type="text"
-                      @input="handleDMSChange"
-                      hint="Seconds"
-                      v-model.number="dms.long.sec"
-                      :errors="errors['longitude']"
-                      :loaded="fieldsLoaded['longitude']"
-                    ></form-input>
-                  </b-col>
-                </b-row>
+                <div class="flex mb-2">Longitude</div>
+                <responsive-grid :cols="12" :sm="4" :innerDivClass="['px-2', 'px-2', 'px-1']">
+                  <form-input
+                    id="longitudeDeg"
+                    type="text"
+                    @input="handleDMSChange"
+                    hint="Degrees"
+                    v-model.number="dms.long.deg"
+                    :errors="errors['longitude']"
+                    :loaded="fieldsLoaded['longitude']"></form-input>
+                  <form-input
+                    id="longitudeMin"
+                    type="text"
+                    @input="handleDMSChange"
+                    hint="Minutes"
+                    v-model.number="dms.long.min"
+                    :errors="errors['longitude']"
+                    :loaded="fieldsLoaded['longitude']"></form-input>
+                  <form-input
+                    id="longitudeSec"
+                    type="text"
+                    @input="handleDMSChange"
+                    hint="Seconds"
+                    v-model.number="dms.long.sec"
+                    :errors="errors['longitude']"
+                    :loaded="fieldsLoaded['longitude']"></form-input>
+                </responsive-grid>
               </b-col>
             </b-row>
-          </b-card>
-          <b-row><b-col><p class="p-4 m-0">OR</p></b-col></b-row>
-          <b-card no-body class="p-4 mx-1 mx-md-1">
-            <b-row>
-              <b-col cols="12" sm="4" lg="4">
-                <form-input
-                  id="utmZone"
-                  select
-                  :options="utmZones"
-                  label="Zone"
-                  @input="handleUTMChange"
-                  v-model="utm.zone"
-                  text-field="name"
-                  value-field="value"
-                  :loaded="fieldsLoaded['utmZone']"
-                ></form-input>
-              </b-col>
-              <b-col cols="12" sm="4" lg="4">
-                <!-- UTM Easting should only allow 6 digits to be entered. -->
-                <form-input
-                  id="utmEasting"
-                  type="text"
-                  label="UTM Easting"
-                  v-model.number="utm.easting"
-                  @input="handleUTMChange"
-                  :loaded="fieldsLoaded['utmEasting']"
-                  :max="999999"
-                ></form-input>
-              </b-col>
-              <b-col cols="12" sm="4" lg="4">
-                <!-- UTM Northing should only allow 7 digits to be entered. -->
-                <form-input
-                  id="utmNorthing"
-                  type="text"
-                  label="UTM Northing"
-                  @input="handleUTMChange"
-                  v-model.number="utm.northing"
-                  :max="9999999"
-                  :loaded="fieldsLoaded['utmNorthing']"
-                ></form-input>
-              </b-col>
-            </b-row>
-            <b-row v-if="isStaffEdit">
-              <b-col>
-                <form-input
-                  id="coordinateAcquisitionCode"
-                  select
-                  :options="codes?.coordinate_acquisition_codes"
-                  label="Coordinate Acquisition"
-                  v-model="coordinateAcquisitionCodeInput"
-                  text-field="description"
-                  value-field="code"
-                  :loaded="fieldsLoaded['coordinateAcquisitionCode']"
-                ></form-input>
-              </b-col>
-            </b-row>
-          </b-card>
-          <b-row>
-            <b-col class="mt-4">
+          </div>
+          <div class="flex"><p class="p-4 m-0">OR</p></div>
+          <div class="container p-4 mx-1 mx-md-1">
+            <responsive-grid :cols="12" :sm="4" :lg="4">
+              <form-input
+                id="utmZone"
+                select
+                :options="utmZones"
+                label="Zone"
+                @input="handleUTMChange"
+                v-model="utm.zone"
+                text-field="name"
+                value-field="value"
+                :loaded="fieldsLoaded['utmZone']"></form-input>
+              <!-- UTM Easting should only allow 6 digits to be entered. -->
+              <form-input
+                id="utmEasting"
+                type="text"
+                label="UTM Easting"
+                v-model.number="utm.easting"
+                @input="handleUTMChange"
+                :loaded="fieldsLoaded['utmEasting']"
+                :max="999999"></form-input>
+              <!-- UTM Northing should only allow 7 digits to be entered. -->
+              <form-input
+                id="utmNorthing"
+                type="text"
+                label="UTM Northing"
+                @input="handleUTMChange"
+                v-model.number="utm.northing"
+                :max="9999999"
+                :loaded="fieldsLoaded['utmNorthing']"></form-input>
+            </responsive-grid>
+            <div class="flex" v-if="isStaffEdit">
+              <form-input
+                id="coordinateAcquisitionCode"
+                select
+                :options="codes?.coordinate_acquisition_codes"
+                label="Coordinate Acquisition"
+                v-model="coordinateAcquisitionCodeInput"
+                text-field="description"
+                value-field="code"
+                :loaded="fieldsLoaded['coordinateAcquisitionCode']"></form-input>
+            </div>
+          </div>
+          <div class="flex">
+            <div class="mt-4">
               <div v-if="validCoordinate === false">
                 <div class="alert alert-danger" role="alert">You have entered an invalid coordinate</div>
               </div>
-            </b-col>
-          </b-row>
-        </b-col>
-        <b-col sm="12" md="6">
+            </div>
+          </div>
+        </div>
+        <div class="sm:col-span-12 md:col-span-6">
           <coords-map :latitude="mapLatitude" :longitude="mapLongitude" v-on:coordinate="handleMapCoordinate" :drinking_water="this.drinking_water"/>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
       <b-card>
         <b-modal
           v-model="confirmRemoveModalInput"
@@ -208,12 +172,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           @shown="focusRemoveModal">
           WARNING, a well capture zone has been delineated based on the existing coordinates. Are you sure you want to update the coordinates? Note: If you select 'Yes, Update' a notification email will be sent to the data managers of the Capture Zones dataset.
           <div slot="modal-footer">
-            <b-btn variant="secondary" @click="confirmRemoveModalInput=false;revertCoords()" ref="cancelRemoveBtn">
-              No, Cancel
-            </b-btn>
-            <b-btn variant="danger" @click="confirmRemoveModalInput=false;confirmCoords()">
-              Yes, Update
-            </b-btn>
+            <Button label="No, Cancel" severity="secondary" @click="confirmRemoveModalInput=false;revertCoords()" ref="cancelRemoveBtn"/>
+            <Button label="Yes, Update" severity="danger" @click="confirmRemoveModalInput=false;confirmCoords()"/>
           </div>
         </b-modal>
       </b-card>
@@ -231,11 +191,13 @@ import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import convertCoordinatesMixin from '@/common/convertCoordinatesMixin.js'
 
 import CoordsMap from '@/submissions/components/SubmissionForm/CoordsMap.vue'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import { fetchInsideBCCheck } from '../../../common/mapbox/geometry'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   components: {
+    ResponsiveGrid,
     'coords-map': CoordsMap
   },
   name: 'Coords',

--- a/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
@@ -19,28 +19,26 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <div class="grid grid-cols-12">
         <div class="sm:col-span-12 md:col-span-6">
           <div class="container p-4 m-1 md:m-1">
-            <template #default>
-              <responsive-grid :cols="12" :sm="6" :lg="3">
-                <form-input
-                  id="latitude"
-                  type="text"
-                  label="Latitude"
-                  hint="Decimal degrees"
-                  @input="handleDegreesChange"
-                  v-model.number="degrees.latitude"
-                  :errors="errors['latitude']"
-                  :loaded="fieldsLoaded['latitude']"/>
-                <form-input
-                  id="longitude"
-                  type="text"
-                  @input="handleDegreesChange"
-                  label="Longitude"
-                  hint="Decimal degrees"
-                  v-model.number="degrees.longitude"
-                  :errors="errors['longitude']"
-                  :loaded="fieldsLoaded['longitude']"/>
-              </responsive-grid>
-            </template>
+            <responsive-grid :cols="12" :sm="6" :lg="3">
+              <form-input
+                id="latitude"
+                type="text"
+                label="Latitude"
+                hint="Decimal degrees"
+                @input="handleDegreesChange"
+                v-model.number="degrees.latitude"
+                :errors="errors['latitude']"
+                :loaded="fieldsLoaded['latitude']"/>
+              <form-input
+                id="longitude"
+                type="text"
+                @input="handleDegreesChange"
+                label="Longitude"
+                hint="Decimal degrees"
+                v-model.number="degrees.longitude"
+                :errors="errors['longitude']"
+                :loaded="fieldsLoaded['longitude']"/>
+            </responsive-grid>
           </div>
           <div class="flex"><p class="p-4 m-0">OR</p></div>
           <div class="container p-4 mx-1 md:mx-1">

--- a/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
@@ -13,18 +13,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <div>
-    <fieldset>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-6">
-          <legend :id="id">Geographic Coordinates</legend>
-        </div>
-        <div class="col-span-12 lg:col-span-6">
-          <div class="float-right">
-            <Button label="Save" v-if="isStaffEdit" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
-            <back-to-top-link v-if="isStaffEdit"/>
-          </div>
-        </div>
-      </div>
+    <form-subsection title="Geographic Coordinates" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
       <p>To determine coordinates using a Global Positioning System (GPS), set the datum to North America Datum of 1983 (NAD 83), the current ministry standard for mapping.</p>
       <p class="bg-yellow-400 p-2">The map pin can be placed manually, by clicking, or by dragging on the map. The GPS coordinates will be updated automatically.</p>
       <b-row>
@@ -209,30 +198,30 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </b-col>
       </b-row>
       <b-card>
-      <b-modal
-        v-model="confirmRemoveModalInput"
-        no-close-on-esc
-        no-close-on-backdrop
-        hide-header-close
-        centered
-        title="Confirm Coordinates Change"
-        @shown="focusRemoveModal">
-        WARNING, a well capture zone has been delineated based on the existing coordinates. Are you sure you want to update the coordinates? Note: If you select 'Yes, Update' a notification email will be sent to the data managers of the Capture Zones dataset.
-        <div slot="modal-footer">
-          <b-btn variant="secondary" @click="confirmRemoveModalInput=false;revertCoords()" ref="cancelRemoveBtn">
-            No, Cancel
-          </b-btn>
-          <b-btn variant="danger" @click="confirmRemoveModalInput=false;confirmCoords()">
-            Yes, Update
-          </b-btn>
-        </div>
-      </b-modal>
-    </b-card>
+        <b-modal
+          v-model="confirmRemoveModalInput"
+          no-close-on-esc
+          no-close-on-backdrop
+          hide-header-close
+          centered
+          title="Confirm Coordinates Change"
+          @shown="focusRemoveModal">
+          WARNING, a well capture zone has been delineated based on the existing coordinates. Are you sure you want to update the coordinates? Note: If you select 'Yes, Update' a notification email will be sent to the data managers of the Capture Zones dataset.
+          <div slot="modal-footer">
+            <b-btn variant="secondary" @click="confirmRemoveModalInput=false;revertCoords()" ref="cancelRemoveBtn">
+              No, Cancel
+            </b-btn>
+            <b-btn variant="danger" @click="confirmRemoveModalInput=false;confirmCoords()">
+              Yes, Update
+            </b-btn>
+          </div>
+        </b-modal>
+      </b-card>
       <!-- Error message when coordinates not entered in at least one of the 3 input groups -->
       <b-alert class="mt-4" variant="danger" :show="errorCoordsNotProvided">
         Must enter geographic coordinates in either decimal degrees, degrees/minutes/seconds, or UTM format.
       </b-alert>
-    </fieldset>
+    </form-subsection>
   </div>
 </template>
 <script>
@@ -243,6 +232,7 @@ import convertCoordinatesMixin from '@/common/convertCoordinatesMixin.js'
 
 import CoordsMap from '@/submissions/components/SubmissionForm/CoordsMap.vue'
 import { fetchInsideBCCheck } from '../../../common/mapbox/geometry'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   components: {
@@ -279,6 +269,9 @@ export default {
       type: Boolean,
       default: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Coords.vue
@@ -29,7 +29,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   @input="handleDegreesChange"
                   v-model.number="degrees.latitude"
                   :errors="errors['latitude']"
-                  :loaded="fieldsLoaded['latitude']"></form-input>
+                  :loaded="fieldsLoaded['latitude']"/>
                 <form-input
                   id="longitude"
                   type="text"
@@ -38,7 +38,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   hint="Decimal degrees"
                   v-model.number="degrees.longitude"
                   :errors="errors['longitude']"
-                  :loaded="fieldsLoaded['longitude']"></form-input>
+                  :loaded="fieldsLoaded['longitude']"/>
               </responsive-grid>
             </template>
           </Card>
@@ -55,7 +55,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     type="text"
                     v-model.number="dms.lat.deg"
                     :errors="errors['latitude']"
-                    :loaded="fieldsLoaded['latitude']"></form-input>
+                    :loaded="fieldsLoaded['latitude']"/>
                   <form-input
                     id="latitudeMin"
                     hint="Minutes"
@@ -63,7 +63,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     type="text"
                     v-model.number="dms.lat.min"
                     :errors="errors['latitude']"
-                    :loaded="fieldsLoaded['latitude']"></form-input>
+                    :loaded="fieldsLoaded['latitude']"/>
                   <form-input
                     id="latitudeSec"
                     type="text"
@@ -71,7 +71,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     hint="Seconds"
                     v-model.number="dms.lat.sec"
                     :errors="errors['latitude']"
-                    :loaded="fieldsLoaded['latitude']"></form-input>
+                    :loaded="fieldsLoaded['latitude']"/>
                 </responsive-grid>
               </div>
               <div class="col-span-12 md:col-span-6 lg:col-span-6 lg:col-start-1">
@@ -84,7 +84,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     hint="Degrees"
                     v-model.number="dms.long.deg"
                     :errors="errors['longitude']"
-                    :loaded="fieldsLoaded['longitude']"></form-input>
+                    :loaded="fieldsLoaded['longitude']"/>
                   <form-input
                     id="longitudeMin"
                     type="text"
@@ -92,7 +92,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     hint="Minutes"
                     v-model.number="dms.long.min"
                     :errors="errors['longitude']"
-                    :loaded="fieldsLoaded['longitude']"></form-input>
+                    :loaded="fieldsLoaded['longitude']"/>
                   <form-input
                     id="longitudeSec"
                     type="text"
@@ -100,7 +100,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     hint="Seconds"
                     v-model.number="dms.long.sec"
                     :errors="errors['longitude']"
-                    :loaded="fieldsLoaded['longitude']"></form-input>
+                    :loaded="fieldsLoaded['longitude']"/>
                 </responsive-grid>
               </div>
             </div>
@@ -117,7 +117,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 v-model="utm.zone"
                 text-field="name"
                 value-field="value"
-                :loaded="fieldsLoaded['utmZone']"></form-input>
+                :loaded="fieldsLoaded['utmZone']"/>
               <!-- UTM Easting should only allow 6 digits to be entered. -->
               <form-input
                 id="utmEasting"
@@ -126,7 +126,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 v-model.number="utm.easting"
                 @input="handleUTMChange"
                 :loaded="fieldsLoaded['utmEasting']"
-                :max="999999"></form-input>
+                :max="999999"/>
               <!-- UTM Northing should only allow 7 digits to be entered. -->
               <form-input
                 id="utmNorthing"
@@ -135,7 +135,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 @input="handleUTMChange"
                 v-model.number="utm.northing"
                 :max="9999999"
-                :loaded="fieldsLoaded['utmNorthing']"></form-input>
+                :loaded="fieldsLoaded['utmNorthing']"/>
             </responsive-grid>
             <div class="flex" v-if="isStaffEdit">
               <form-input
@@ -146,7 +146,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 v-model="coordinateAcquisitionCodeInput"
                 text-field="description"
                 value-field="code"
-                :loaded="fieldsLoaded['coordinateAcquisitionCode']"></form-input>
+                :loaded="fieldsLoaded['coordinateAcquisitionCode']"/>
             </div>
           </div>
           <div class="flex">

--- a/app/frontend/src/submissions/components/SubmissionForm/DecommissionInformation.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/DecommissionInformation.vue
@@ -30,14 +30,15 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="decommissionReasonInput"
         :errors="errors['decommission_reason']"
         :loaded="fieldsLoaded['decommission_reason']"/>
-      <b-form-group label="Decommission Method">
-        <b-form-radio-group id="decommissionMethodRadio" class="mt-1" v-model="decommissionMethodInput">
-          <b-form-radio
-            v-for="(method, index) in codes.decommission_methods"
-            :key="`decommissionMethodOption${index}`"
-            :value="method.decommission_method_code">{{method.description}}</b-form-radio>
-        </b-form-radio-group>
-      </b-form-group>
+      <div class="flex flex-col gap-2">
+        <label>Decommission Method</label>
+        <RadioButtonGroup id="decommissionMethodRadio" class="mt-1" v-model="decommissionMethodInput">
+          <div v-for="(method, index) in codes.decommission_methods" class="flex align-items-center" :key="`decommissionMethodOption${index}`">
+            <RadioButton :inputId="`decommissionMethodInput.${method.decommission_method_code}`" :value="method.decommission_method_code"/>
+            <label :for="`decommissionMethodInput.${method.decommission_method_code}`" class="ml-2">{{method.description}}</label>
+          </div>
+        </RadioButtonGroup>
+      </div>
     </responsive-grid>
     <responsive-grid :cols="12" :md="6" :lg="4">
       <form-input

--- a/app/frontend/src/submissions/components/SubmissionForm/DecommissionInformation.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/DecommissionInformation.vue
@@ -13,66 +13,54 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Well Decommission Information" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <div class="grid grid-cols-12">
-      <b-col cols="12" md="3" lg="2">
-        <form-input
-            id="finishedWellDepth"
-            label="Finished Well Depth"
-            type="number"
-            v-model="finishedWellDepthInput"
-            hint="feet (below ground level)"
-            :errors="errors['finished_well_depth']"
-            :loaded="fieldsLoaded['finished_well_depth']"></form-input>
-      </b-col>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-            id="decommissionReason"
-            label="Reason for Well Decommission"
-            v-model="decommissionReasonInput"
-            :errors="errors['decommission_reason']"
-            :loaded="fieldsLoaded['decommission_reason']"></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <b-form-group label="Decommission Method">
-          <b-form-radio-group id="decommissionMethodRadio" class="mt-1" v-model="decommissionMethodInput">
-            <b-form-radio
-                v-for="(method, index) in codes.decommission_methods"
-                :key="`decommissionMethodOption${index}`"
-                :value="method.decommission_method_code">{{method.description}}</b-form-radio>
-          </b-form-radio-group>
-        </b-form-group>
-      </div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-            id="sealantMaterial"
-            label="Sealant Material"
-            v-model="sealantMaterialInput"
-            :errors="errors['decommission_sealant_material']"
-            :loaded="fieldsLoaded['decommission_sealant_material']"></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-4">
-        <form-input
-            id="backfillMaterial"
-            label="Backfill Material"
-            v-model="backfillMaterialInput"
-            :errors="errors['decommission_backfill_material']"
-            :loaded="fieldsLoaded['decommission_backfill_material']"></form-input>
-      </div>
-    </div>
-    <b-row>
-      <b-col cols="12" lg="8">
-        <form-input
-          id="decommissionDetails"
-          label="Decommission Details"
-          v-model="decommissionDetailsInput"
-          :errors="errors['decommission_details']"
-          :loaded="fieldsLoaded['decommission_details']"></form-input>
-      </b-col>
-    </b-row>
+    <responsive-grid :cols="12" :md="3" :lg="2">
+      <form-input
+        id="finishedWellDepth"
+        label="Finished Well Depth"
+        type="number"
+        v-model="finishedWellDepthInput"
+        hint="feet (below ground level)"
+        :errors="errors['finished_well_depth']"
+        :loaded="fieldsLoaded['finished_well_depth']"></form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="6" :lg="4">
+      <form-input
+        id="decommissionReason"
+        label="Reason for Well Decommission"
+        v-model="decommissionReasonInput"
+        :errors="errors['decommission_reason']"
+        :loaded="fieldsLoaded['decommission_reason']"></form-input>
+      <b-form-group label="Decommission Method">
+        <b-form-radio-group id="decommissionMethodRadio" class="mt-1" v-model="decommissionMethodInput">
+          <b-form-radio
+            v-for="(method, index) in codes.decommission_methods"
+            :key="`decommissionMethodOption${index}`"
+            :value="method.decommission_method_code">{{method.description}}</b-form-radio>
+        </b-form-radio-group>
+      </b-form-group>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="6" :lg="4">
+      <form-input
+        id="sealantMaterial"
+        label="Sealant Material"
+        v-model="sealantMaterialInput"
+        :errors="errors['decommission_sealant_material']"
+        :loaded="fieldsLoaded['decommission_sealant_material']"></form-input>
+      <form-input
+        id="backfillMaterial"
+        label="Backfill Material"
+        v-model="backfillMaterialInput"
+        :errors="errors['decommission_backfill_material']"
+        :loaded="fieldsLoaded['decommission_backfill_material']"></form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :lg="8">
+      <form-input
+        id="decommissionDetails"
+        label="Decommission Details"
+        v-model="decommissionDetailsInput"
+        :errors="errors['decommission_details']"
+        :loaded="fieldsLoaded['decommission_details']"></form-input>
+    </responsive-grid>
   </form-subsection>
 </template>
 
@@ -80,6 +68,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
@@ -113,7 +102,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/DecommissionInformation.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/DecommissionInformation.vue
@@ -12,19 +12,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Well Decommission Information</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
-    <b-row>
+  <form-subsection title="Well Decommission Information" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
+    <div class="grid grid-cols-12">
       <b-col cols="12" md="3" lg="2">
         <form-input
             id="finishedWellDepth"
@@ -35,17 +24,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :errors="errors['finished_well_depth']"
             :loaded="fieldsLoaded['finished_well_depth']"></form-input>
       </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="6" lg="4">
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
             id="decommissionReason"
             label="Reason for Well Decommission"
             v-model="decommissionReasonInput"
             :errors="errors['decommission_reason']"
             :loaded="fieldsLoaded['decommission_reason']"></form-input>
-      </b-col>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <b-form-group label="Decommission Method">
           <b-form-radio-group id="decommissionMethodRadio" class="mt-1" v-model="decommissionMethodInput">
             <b-form-radio
@@ -54,43 +43,44 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 :value="method.decommission_method_code">{{method.description}}</b-form-radio>
           </b-form-radio-group>
         </b-form-group>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
             id="sealantMaterial"
             label="Sealant Material"
             v-model="sealantMaterialInput"
             :errors="errors['decommission_sealant_material']"
             :loaded="fieldsLoaded['decommission_sealant_material']"></form-input>
-      </b-col>
-      <b-col cols="12" md="6" lg="4">
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-4">
         <form-input
             id="backfillMaterial"
             label="Backfill Material"
             v-model="backfillMaterialInput"
             :errors="errors['decommission_backfill_material']"
             :loaded="fieldsLoaded['decommission_backfill_material']"></form-input>
-      </b-col>
-    </b-row>
+      </div>
+    </div>
     <b-row>
       <b-col cols="12" lg="8">
         <form-input
-            id="decommissionDetails"
-            label="Decommission Details"
-            v-model="decommissionDetailsInput"
-            :errors="errors['decommission_details']"
-            :loaded="fieldsLoaded['decommission_details']"></form-input>
+          id="decommissionDetails"
+          label="Decommission Details"
+          v-model="decommissionDetailsInput"
+          :errors="errors['decommission_details']"
+          :loaded="fieldsLoaded['decommission_details']"></form-input>
       </b-col>
     </b-row>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -121,6 +111,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/DecommissionInformation.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/DecommissionInformation.vue
@@ -21,7 +21,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="finishedWellDepthInput"
         hint="feet (below ground level)"
         :errors="errors['finished_well_depth']"
-        :loaded="fieldsLoaded['finished_well_depth']"></form-input>
+        :loaded="fieldsLoaded['finished_well_depth']"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="6" :lg="4">
       <form-input
@@ -29,7 +29,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         label="Reason for Well Decommission"
         v-model="decommissionReasonInput"
         :errors="errors['decommission_reason']"
-        :loaded="fieldsLoaded['decommission_reason']"></form-input>
+        :loaded="fieldsLoaded['decommission_reason']"/>
       <b-form-group label="Decommission Method">
         <b-form-radio-group id="decommissionMethodRadio" class="mt-1" v-model="decommissionMethodInput">
           <b-form-radio
@@ -45,13 +45,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
         label="Sealant Material"
         v-model="sealantMaterialInput"
         :errors="errors['decommission_sealant_material']"
-        :loaded="fieldsLoaded['decommission_sealant_material']"></form-input>
+        :loaded="fieldsLoaded['decommission_sealant_material']"/>
       <form-input
         id="backfillMaterial"
         label="Backfill Material"
         v-model="backfillMaterialInput"
         :errors="errors['decommission_backfill_material']"
-        :loaded="fieldsLoaded['decommission_backfill_material']"></form-input>
+        :loaded="fieldsLoaded['decommission_backfill_material']"/>
     </responsive-grid>
     <responsive-grid :cols="12" :lg="8">
       <form-input
@@ -59,7 +59,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         label="Decommission Details"
         v-model="decommissionDetailsInput"
         :errors="errors['decommission_details']"
-        :loaded="fieldsLoaded['decommission_details']"></form-input>
+        :loaded="fieldsLoaded['decommission_details']"/>
     </responsive-grid>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/Development.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Development.vue
@@ -13,42 +13,36 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Well Development" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <b-row>
-      <b-col cols="12" md="4" lg="3">
-        <form-input
-            id="developmentMethod"
-            label="Development Method"
-            select
-            :options="codes?.development_methods"
-            hint="Select one or more methods. Hold the Ctrl (PC) or Command (Mac) key to select more than one option."
-            text-field="description"
-            value-field="development_method_code"
-            v-model="developmentMethodInput"
-            :errors="errors['development_method']"
-            :loaded="fieldsLoaded['development_method']"></form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="4" lg="2">
-        <form-input
-            id="developmentHours"
-            label="Development Hours"
-            type="number"
-            v-model="developmentHoursInput"
-            :errors="errors['development_hours']"
-            :loaded="fieldsLoaded['development_hours']"></form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="10" lg="6">
-        <form-input
-            id="developmentNotes"
-            label="Development Notes"
-            v-model="developmentNotesInput"
-            :errors="errors['development_notes']"
-            :loaded="fieldsLoaded['development_notes']"></form-input>
-      </b-col>
-    </b-row>
+    <responsive-grid :cols="12" :md="4" :lg="3">
+      <form-input
+        id="developmentMethod"
+        label="Development Method"
+        select
+        :options="codes?.development_methods"
+        hint="Select one or more methods. Hold the Ctrl (PC) or Command (Mac) key to select more than one option."
+        text-field="description"
+        value-field="development_method_code"
+        v-model="developmentMethodInput"
+        :errors="errors['development_method']"
+        :loaded="fieldsLoaded['development_method']"></form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="4" :lg="2">
+      <form-input
+        id="developmentHours"
+        label="Development Hours"
+        type="number"
+        v-model="developmentHoursInput"
+        :errors="errors['development_hours']"
+        :loaded="fieldsLoaded['development_hours']"></form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="10" :lg="6">
+      <form-input
+        id="developmentNotes"
+        label="Development Notes"
+        v-model="developmentNotesInput"
+        :errors="errors['development_notes']"
+        :loaded="fieldsLoaded['development_notes']"></form-input>
+    </responsive-grid>
   </form-subsection>
 </template>
 
@@ -56,6 +50,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
@@ -86,7 +81,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   fields: {
     developmentMethodInput: 'developmentMethod',

--- a/app/frontend/src/submissions/components/SubmissionForm/Development.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Development.vue
@@ -12,18 +12,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Well Development</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
+  <form-subsection title="Well Development" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <b-row>
       <b-col cols="12" md="4" lg="3">
         <form-input
@@ -60,13 +49,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :loaded="fieldsLoaded['development_notes']"></form-input>
       </b-col>
     </b-row>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -94,6 +84,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   fields: {
     developmentMethodInput: 'developmentMethod',

--- a/app/frontend/src/submissions/components/SubmissionForm/Development.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Development.vue
@@ -24,7 +24,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         value-field="development_method_code"
         v-model="developmentMethodInput"
         :errors="errors['development_method']"
-        :loaded="fieldsLoaded['development_method']"></form-input>
+        :loaded="fieldsLoaded['development_method']"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="4" :lg="2">
       <form-input
@@ -33,7 +33,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         type="number"
         v-model="developmentHoursInput"
         :errors="errors['development_hours']"
-        :loaded="fieldsLoaded['development_hours']"></form-input>
+        :loaded="fieldsLoaded['development_hours']"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="10" :lg="6">
       <form-input
@@ -41,7 +41,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         label="Development Notes"
         v-model="developmentNotesInput"
         :errors="errors['development_notes']"
-        :loaded="fieldsLoaded['development_notes']"></form-input>
+        :loaded="fieldsLoaded['development_notes']"/>
     </responsive-grid>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
@@ -16,32 +16,31 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <form-subsection title="Attachments" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
       <div v-if="uploadedFiles && uploadedFiles.private && uploadedFiles.public" class="table-responsive">
         <b-table
-            hover
-            :fields="['well_number', 'document_type', 'date_of_upload', 'document_status', 'uploaded_document', 'delete']"
-            striped
-            :items="[...uploadedFiles.public, ...uploadedFiles.private]"
-          >
-            <template v-slot:cell(document_type)="data">
-              {{ callLongFormLabel(data.item.document_type) }}
-            </template>
-            <template v-slot:cell(date_of_upload)="data">
-              {{ data.item.date_of_upload !== -1 ? new Date(data.item.date_of_upload).toLocaleDateString() : "Date Unknown" }}
-            </template>
-            <template v-slot:cell(uploaded_document)="data">
-              <a :href="data.item.url" :download="data.item.name" target="_blank">{{ data.item.name }}</a>
-            </template>
-            <template v-slot:cell(document_status)="data">
-              <p v-if="data.item.document_status">Private Document</p>
-              <p v-else>Public Document</p>
-            </template>
-            <template v-slot:cell(delete)="data">
-              <a
-                class="fa fa-trash fa-lg"
-                variant="primary"
-                style="margin-left: .5em"
-                href="#"
-                @click="handleFileDelete(data.item.name, data.item.document_status, $event)"></a>
-            </template>
+          hover
+          :fields="['well_number', 'document_type', 'date_of_upload', 'document_status', 'uploaded_document', 'delete']"
+          striped
+          :items="[...uploadedFiles.public, ...uploadedFiles.private]">
+          <template v-slot:cell(document_type)="data">
+            {{ callLongFormLabel(data.item.document_type) }}
+          </template>
+          <template v-slot:cell(date_of_upload)="data">
+            {{ data.item.date_of_upload !== -1 ? new Date(data.item.date_of_upload).toLocaleDateString() : "Date Unknown" }}
+          </template>
+          <template v-slot:cell(uploaded_document)="data">
+            <a :href="data.item.url" :download="data.item.name" target="_blank">{{ data.item.name }}</a>
+          </template>
+          <template v-slot:cell(document_status)="data">
+            <p v-if="data.item.document_status">Private Document</p>
+            <p v-else>Public Document</p>
+          </template>
+          <template v-slot:cell(delete)="data">
+            <a
+              class="fa fa-trash fa-lg"
+              variant="primary"
+              style="margin-left: .5em"
+              href="#"
+              @click="handleFileDelete(data.item.name, data.item.document_status, $event)"></a>
+          </template>
         </b-table>
       </div>
       <div v-else>
@@ -72,11 +71,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   class="mt-1 mb-0"
                   :aria-describedby="`attachmentLabelInvalidFeedback${index}`">
                   <b-form-select
-                      @change="setFileName(index)"
-                      v-model="attachment.document_code"
-                      :options="WELL_TAGS"
-                      :state="getAttachmentError(index).document_code ? false : null"
-                      size="med"
+                    @change="setFileName(index)"
+                    v-model="attachment.document_code"
+                    :options="WELL_TAGS"
+                    :state="getAttachmentError(index).document_code ? false : null"
+                    size="med"
                   >
                   </b-form-select>
                   <b-form-invalid-feedback :id="`attachmentCodeInvalidFeedback${index}`">
@@ -128,16 +127,12 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </table>
       </div>
       <b-btn size="sm" id="addAttachmentRowBtn" variant="primary" @click="addRow"><i class="fa fa-plus-square-o"></i>&nbsp;Add file</b-btn>
-      <Dialog
-        v-model:visible="confirmRemoveModal"
-        modal
-        header="Confirm remove"
-        @shown="focusRemoveModal">
+      <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
         Are you sure you want to remove this row?
-        <div slot="modal-footer">
+        <template #footer>
           <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
           <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
-        </div>
+        </template>
       </Dialog>
     </form-subsection>
   </div>

--- a/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
@@ -15,33 +15,40 @@ Licensed under the Apache License, Version 2.0 (the "License");
   <div>
     <form-subsection title="Attachments" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
       <div v-if="uploadedFiles && uploadedFiles.private && uploadedFiles.public" class="table-responsive">
-        <b-table
-          hover
-          :fields="['well_number', 'document_type', 'date_of_upload', 'document_status', 'uploaded_document', 'delete']"
-          striped
-          :items="[...uploadedFiles.public, ...uploadedFiles.private]">
-          <template v-slot:cell(document_type)="data">
-            {{ callLongFormLabel(data.item.document_type) }}
-          </template>
-          <template v-slot:cell(date_of_upload)="data">
-            {{ data.item.date_of_upload !== -1 ? new Date(data.item.date_of_upload).toLocaleDateString() : "Date Unknown" }}
-          </template>
-          <template v-slot:cell(uploaded_document)="data">
-            <a :href="data.item.url" :download="data.item.name" target="_blank">{{ data.item.name }}</a>
-          </template>
-          <template v-slot:cell(document_status)="data">
-            <p v-if="data.item.document_status">Private Document</p>
-            <p v-else>Public Document</p>
-          </template>
-          <template v-slot:cell(delete)="data">
-            <a
-              class="fa fa-trash fa-lg"
-              variant="primary"
-              style="margin-left: .5em"
-              href="#"
-              @click="handleFileDelete(data.item.name, data.item.document_status, $event)"></a>
-          </template>
-        </b-table>
+        <DataTable rowHover stripedRows :value="[...uploadedFiles.public, ...uploadedFiles.private]">
+          <Column field="well_number"/>
+          <Column field="document_type">
+            <template #body="slotProps">
+              {{ callLongFormLabel(slotProps.data.document_type) }}
+            </template>
+          </Column>
+          <Column field="date_of_upload">
+            <template #body="slotProps">
+              {{ slotProps.data.date_of_upload !== -1 ? new Date(slotProps.data.date_of_upload).toLocaleDateString() : "Date Unknown" }}
+            </template>
+          </Column>
+          <Column field="uploaded_document">
+            <template #body="slotProps">
+              <a :href="slotProps.data.url" :download="slotProps.data.name" target="_blank">{{ slotProps.data.name }}</a>
+            </template>
+          </Column>
+          <Column field="document_status">
+            <template #body="slotProps">
+              <p v-if="slotProps.data.document_status">Private Document</p>
+              <p v-else>Public Document</p>
+            </template>
+          </Column>
+          <Column>
+            <template #body="slotProps">
+              <a
+                class="fa fa-trash fa-lg"
+                variant="primary"
+                style="margin-left: .5em"
+                href="#"
+                @click="handleFileDelete(slotProps.data.name, slotProps.data.document_status, $event)"/>
+            </template>
+          </Column>
+        </DataTable>
       </div>
       <div v-else>
         No documents available
@@ -120,13 +127,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 {{ new Date().toLocaleDateString() }}
               </td>
               <td class="pt-1 py-0">
-                <b-btn size="sm" variant="primary" :id="`removeAttachmentRowBtn${index}`" @click="removeRowIfOk(attachment)" class="mt-2 float-right"><i class="fa fa-minus-square-o"></i>&nbsp;Remove</b-btn>
+                <Button label="Remove" icon="fa fa-minus-square-o" size="small" :id="`removeAttachmentRowBtn${index}`" @click="removeRowIfOk(attachment)" class="mt-2 float-right"/>
               </td>
             </tr>
           </tbody>
         </table>
       </div>
-      <b-btn size="sm" id="addAttachmentRowBtn" variant="primary" @click="addRow"><i class="fa fa-plus-square-o"></i>&nbsp;Add file</b-btn>
+      <Button label="Add row" icon="fa fa-plus-square-o" size="small" id="addAttachmentRowBtn" @click="addRow"/>
       <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
         Are you sure you want to remove this row?
         <template #footer>

--- a/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
@@ -13,132 +13,121 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <div>
-    <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Attachments</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
-    <div v-if="uploadedFiles && uploadedFiles.private && uploadedFiles.public" class="table-responsive">
-      <b-table
-          hover
-          :fields="['well_number', 'document_type', 'date_of_upload', 'document_status', 'uploaded_document', 'delete']"
-          striped
-          :items="[...uploadedFiles.public, ...uploadedFiles.private]"
-        >
-          <template v-slot:cell(document_type)="data">
-            {{ callLongFormLabel(data.item.document_type) }}
-          </template>
-          <template v-slot:cell(date_of_upload)="data">
-            {{ data.item.date_of_upload !== -1 ? new Date(data.item.date_of_upload).toLocaleDateString() : "Date Unknown" }}
-          </template>
-          <template v-slot:cell(uploaded_document)="data">
-            <a :href="data.item.url" :download="data.item.name" target="_blank">{{ data.item.name }}</a>
-          </template>
-          <template v-slot:cell(document_status)="data">
-            <p v-if="data.item.document_status">Private Document</p>
-            <p v-else>Public Document</p>
-          </template>
-          <template v-slot:cell(delete)="data">
-            <a
-              class="fa fa-trash fa-lg"
-              variant="primary"
-              style="margin-left: .5em"
-              href="#"
-              @click="handleFileDelete(data.item.name, data.item.document_status, $event)"></a>
-          </template>
-      </b-table>
-    </div>
-    <div v-else>
-      No documents available
-    </div>
-    <div class="table-responsive" id="attachmentsTable" v-if="attachmentsData">
-      <table class="table table-sm" aria-describedby="attachmentsDetails">
-        <thead>
-          <tr>
-            <th class="font-weight-normal">Well Number</th>
-            <th class="font-weight-normal">Document Type</th>
-            <th class="font-weight-normal">File</th>
-            <th class="font-weight-normal">Private Document?</th>
-            <th class="font-weight-normal">New File Name</th>
-            <th class="font-weight-normal">Date of Upload</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="(attachment, index) in attachmentsData" :key="index">
-            <td class="p-4">
-                {{ attachment.well_tag_number = wellTagNumber }}
-            </td>
+    <form-subsection title="Attachments" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
+      <div v-if="uploadedFiles && uploadedFiles.private && uploadedFiles.public" class="table-responsive">
+        <b-table
+            hover
+            :fields="['well_number', 'document_type', 'date_of_upload', 'document_status', 'uploaded_document', 'delete']"
+            striped
+            :items="[...uploadedFiles.public, ...uploadedFiles.private]"
+          >
+            <template v-slot:cell(document_type)="data">
+              {{ callLongFormLabel(data.item.document_type) }}
+            </template>
+            <template v-slot:cell(date_of_upload)="data">
+              {{ data.item.date_of_upload !== -1 ? new Date(data.item.date_of_upload).toLocaleDateString() : "Date Unknown" }}
+            </template>
+            <template v-slot:cell(uploaded_document)="data">
+              <a :href="data.item.url" :download="data.item.name" target="_blank">{{ data.item.name }}</a>
+            </template>
+            <template v-slot:cell(document_status)="data">
+              <p v-if="data.item.document_status">Private Document</p>
+              <p v-else>Public Document</p>
+            </template>
+            <template v-slot:cell(delete)="data">
+              <a
+                class="fa fa-trash fa-lg"
+                variant="primary"
+                style="margin-left: .5em"
+                href="#"
+                @click="handleFileDelete(data.item.name, data.item.document_status, $event)"></a>
+            </template>
+        </b-table>
+      </div>
+      <div v-else>
+        No documents available
+      </div>
+      <div class="table-responsive" id="attachmentsTable" v-if="attachmentsData">
+        <table class="table table-sm" aria-describedby="attachmentsDetails">
+          <thead>
+            <tr>
+              <th class="font-weight-normal">Well Number</th>
+              <th class="font-weight-normal">Document Type</th>
+              <th class="font-weight-normal">File</th>
+              <th class="font-weight-normal">Private Document?</th>
+              <th class="font-weight-normal">New File Name</th>
+              <th class="font-weight-normal">Date of Upload</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(attachment, index) in attachmentsData" :key="index">
+              <td class="p-4">
+                  {{ attachment.well_tag_number = wellTagNumber }}
+              </td>
+              <td>
+                <!-- Document Selector -->
+                <b-form-group
+                  :id="'attachmentLabel_' + index"
+                  class="mt-1 mb-0"
+                  :aria-describedby="`attachmentLabelInvalidFeedback${index}`">
+                  <b-form-select
+                      @change="setFileName(index)"
+                      v-model="attachment.document_code"
+                      :options="WELL_TAGS"
+                      :state="getAttachmentError(index).document_code ? false : null"
+                      size="med"
+                  >
+                  </b-form-select>
+                  <b-form-invalid-feedback :id="`attachmentCodeInvalidFeedback${index}`">
+                    <div v-for="(error, error_index) in getAttachmentError(index).document_code" :key="`Document Type input error ${error_index}`">
+                      {{ error }}
+                    </div>
+                  </b-form-invalid-feedback>
+                </b-form-group>
+              </td>
+              <td>
+                <!-- File Upload -->
+                <b-form-file
+                  @input="setFileName(index)"
+                  accept=".jpg, .png, .jpeg, .pdf, .docx, .csv"
+                  class="mt-1 mb-0"
+                  v-model="attachment.file"
+                  :errors="getAttachmentError(index).file"
+                  :loaded="getFieldsLoaded(index).file"
+                />
+              </td>
+            <!-- Privacy Flag  -->
             <td>
-              <!-- Document Selector -->
-              <b-form-group
-                :id="'attachmentLabel_' + index"
-                class="mt-1 mb-0"
-                :aria-describedby="`attachmentLabelInvalidFeedback${index}`">
-                <b-form-select
-                    @change="setFileName(index)"
-                    v-model="attachment.document_code"
-                    :options="WELL_TAGS"
-                    :state="getAttachmentError(index).document_code ? false : null"
-                    size="med"
-                >
-                </b-form-select>
-                <b-form-invalid-feedback :id="`attachmentCodeInvalidFeedback${index}`">
-                  <div v-for="(error, error_index) in getAttachmentError(index).document_code" :key="`Document Type input error ${error_index}`">
-                    {{ error }}
-                  </div>
-                </b-form-invalid-feedback>
-              </b-form-group>
-            </td>
-            <td>
-              <!-- File Upload -->
-              <b-form-file
-                @input="setFileName(index)"
-                accept=".jpg, .png, .jpeg, .pdf, .docx, .csv"
-                class="mt-1 mb-0"
-                v-model="attachment.file"
-                :errors="getAttachmentError(index).file"
-                :loaded="getFieldsLoaded(index).file"
-              />
-            </td>
-           <!-- Privacy Flag  -->
-           <td>
-              <b-form-checkbox
-                class="mt-2 ml-4"
-                v-model="attachment.private"
-                :loaded="getFieldsLoaded(index).private"
-              />
-            </td>
-            <td>
-              <!-- File Name -->
-              <b-form-input
-                class="mt-1 mb-0"
-                v-model="attachment.file_name"
-                placeholder="File_Name"
-                :errors="getAttachmentError(index).file_name"
-                :loaded="getFieldsLoaded(index).file_name"
-                disabled
-              />
-            </td>
-            <!-- Date -->
-            <td class="p-2">
-              {{ new Date().toLocaleDateString() }}
-            </td>
-            <td class="pt-1 py-0">
-              <b-btn size="sm" variant="primary" :id="`removeAttachmentRowBtn${index}`" @click="removeRowIfOk(attachment)" class="mt-2 float-right"><i class="fa fa-minus-square-o"></i>&nbsp;Remove</b-btn>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <b-btn size="sm" id="addAttachmentRowBtn" variant="primary" @click="addRow"><i class="fa fa-plus-square-o"></i>&nbsp;Add file</b-btn>
+                <b-form-checkbox
+                  class="mt-2 ml-4"
+                  v-model="attachment.private"
+                  :loaded="getFieldsLoaded(index).private"
+                />
+              </td>
+              <td>
+                <!-- File Name -->
+                <b-form-input
+                  class="mt-1 mb-0"
+                  v-model="attachment.file_name"
+                  placeholder="File_Name"
+                  :errors="getAttachmentError(index).file_name"
+                  :loaded="getFieldsLoaded(index).file_name"
+                  disabled
+                />
+              </td>
+              <!-- Date -->
+              <td class="p-2">
+                {{ new Date().toLocaleDateString() }}
+              </td>
+              <td class="pt-1 py-0">
+                <b-btn size="sm" variant="primary" :id="`removeAttachmentRowBtn${index}`" @click="removeRowIfOk(attachment)" class="mt-2 float-right"><i class="fa fa-minus-square-o"></i>&nbsp;Remove</b-btn>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <b-btn size="sm" id="addAttachmentRowBtn" variant="primary" @click="addRow"><i class="fa fa-plus-square-o"></i>&nbsp;Add file</b-btn>
       <b-modal
           v-model="confirmRemoveModal"
           centered
@@ -154,7 +143,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </b-btn>
         </div>
       </b-modal>
-    </fieldset>
+    </form-subsection>
   </div>
 </template>
 
@@ -167,6 +156,7 @@ import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import ApiService from '@/common/services/ApiService.js'
 import { WELL_TAGS } from '@/common/constants.js'
 import getLongFormLabel from '@/common/helpers/getLongFormLabel.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -205,6 +195,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
@@ -323,6 +323,11 @@ export default {
       instance.length_required = !instance.length_required
       this.attachmentsData[index] = instance
     },
+    getAttachmentError (index) {
+      return this.errors && 'attachment_set' in this.errors && index in this.errors['attachment_set']
+        ? this.errors['attachment_set'][index]
+        : {}
+    },
     getFieldsLoaded (index) {
       return this.fieldsLoaded && 'attachment_set' in this.fieldsLoaded && index in this.fieldsLoaded['attachment_set']
         ? this.fieldsLoaded['attachment_set'][index]

--- a/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
@@ -128,21 +128,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </table>
       </div>
       <b-btn size="sm" id="addAttachmentRowBtn" variant="primary" @click="addRow"><i class="fa fa-plus-square-o"></i>&nbsp;Add file</b-btn>
-      <b-modal
-          v-model="confirmRemoveModal"
-          centered
-          title="Confirm remove"
-          @shown="focusRemoveModal">
+      <Dialog
+        v-model:visible="confirmRemoveModal"
+        modal
+        header="Confirm remove"
+        @shown="focusRemoveModal">
         Are you sure you want to remove this row?
         <div slot="modal-footer">
-          <b-btn variant="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn">
-            Cancel
-          </b-btn>
-          <b-btn variant="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)">
-            Remove
-          </b-btn>
+          <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
+          <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
         </div>
-      </b-modal>
+      </Dialog>
     </form-subsection>
   </div>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
@@ -80,11 +80,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     v-model="attachment.document_code"
                     :options="WELL_TAGS"
                     :invalid="getAttachmentError(index).document_code ? true : false"/>
-                  <b-form-invalid-feedback :id="`attachmentCodeInvalidFeedback${index}`">
-                    <div v-for="(error, error_index) in getAttachmentError(index).document_code" :key="`Document Type input error ${error_index}`">
+                  <div :id="`attachmentCodeInvalidFeedback${index}`">
+                    <div v-for="(error, e_index) in getAttachmentError(index).document_code" class="mt-1 text-sm text-red-600" :key="`Document Type input error ${e_index}`">
                       {{ error }}
                     </div>
-                  </b-form-invalid-feedback>
+                  </div>
                 </div>
               </td>
               <td>

--- a/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
@@ -82,9 +82,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     v-model="attachment.document_code"
                     :options="WELL_TAGS"
                     :state="getAttachmentError(index).document_code ? false : null"
-                    size="med"
-                  >
-                  </b-form-select>
+                    size="med"/>
                   <b-form-invalid-feedback :id="`attachmentCodeInvalidFeedback${index}`">
                     <div v-for="(error, error_index) in getAttachmentError(index).document_code" :key="`Document Type input error ${error_index}`">
                       {{ error }}
@@ -94,33 +92,26 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </td>
               <td>
                 <!-- File Upload -->
-                <b-form-file
-                  @input="setFileName(index)"
+                 <!-- The accept prop will need to be changed but the documentation is super unhelpful -->
+                <FileUpload
+                  @select="setFileName(index)"
                   accept=".jpg, .png, .jpeg, .pdf, .docx, .csv"
                   class="mt-1 mb-0"
                   v-model="attachment.file"
-                  :errors="getAttachmentError(index).file"
-                  :loaded="getFieldsLoaded(index).file"
-                />
+                  mode="basic"
+                  auto/>
               </td>
-            <!-- Privacy Flag  -->
-            <td>
-                <b-form-checkbox
-                  class="mt-2 ml-4"
-                  v-model="attachment.private"
-                  :loaded="getFieldsLoaded(index).private"
-                />
+              <!-- Privacy Flag  -->
+              <td>
+                <Checkbox class="mt-2 ml-4" v-model="attachment.private" binary :disabled="!getFieldsLoaded(index).private"/>
               </td>
               <td>
                 <!-- File Name -->
-                <b-form-input
+                <InputText
                   class="mt-1 mb-0"
                   v-model="attachment.file_name"
                   placeholder="File_Name"
-                  :errors="getAttachmentError(index).file_name"
-                  :loaded="getFieldsLoaded(index).file_name"
-                  disabled
-                />
+                  disabled/>
               </td>
               <!-- Date -->
               <td class="p-2">
@@ -338,11 +329,6 @@ export default {
       const instance = this.attachmentsData[index]
       instance.length_required = !instance.length_required
       this.attachmentsData[index] = instance
-    },
-    getAttachmentError (index) {
-      return this.errors && 'attachment_set' in this.errors && index in this.errors['attachment_set']
-        ? this.errors['attachment_set'][index]
-        : {}
     },
     getFieldsLoaded (index) {
       return this.fieldsLoaded && 'attachment_set' in this.fieldsLoaded && index in this.fieldsLoaded['attachment_set']

--- a/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Documents.vue
@@ -73,22 +73,19 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </td>
               <td>
                 <!-- Document Selector -->
-                <b-form-group
-                  :id="'attachmentLabel_' + index"
-                  class="mt-1 mb-0"
-                  :aria-describedby="`attachmentLabelInvalidFeedback${index}`">
-                  <b-form-select
-                    @change="setFileName(index)"
+                <div class="flex flex-col gap-2 mt-1 mb-0" :aria-describedby="`attachmentLabelInvalidFeedback${index}`">
+                  <Select
+                    :id="'attachmentLabel_' + index"
+                    @update:modelValue="setFileName(index)"
                     v-model="attachment.document_code"
                     :options="WELL_TAGS"
-                    :state="getAttachmentError(index).document_code ? false : null"
-                    size="med"/>
+                    :invalid="getAttachmentError(index).document_code ? true : false"/>
                   <b-form-invalid-feedback :id="`attachmentCodeInvalidFeedback${index}`">
                     <div v-for="(error, error_index) in getAttachmentError(index).document_code" :key="`Document Type input error ${error_index}`">
                       {{ error }}
                     </div>
                   </b-form-invalid-feedback>
-                </b-form-group>
+                </div>
               </td>
               <td>
                 <!-- File Upload -->
@@ -103,15 +100,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </td>
               <!-- Privacy Flag  -->
               <td>
-                <Checkbox class="mt-2 ml-4" v-model="attachment.private" binary :disabled="!getFieldsLoaded(index).private"/>
+                <Checkbox class="mt-2 ml-4" v-model="attachment.private" binary/>
               </td>
               <td>
                 <!-- File Name -->
-                <InputText
-                  class="mt-1 mb-0"
-                  v-model="attachment.file_name"
-                  placeholder="File_Name"
-                  disabled/>
+                <InputText class="mt-1 mb-0" v-model="attachment.file_name" placeholder="File_Name" disabled/>
               </td>
               <!-- Date -->
               <td class="p-2">

--- a/app/frontend/src/submissions/components/SubmissionForm/EditHistory.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/EditHistory.vue
@@ -13,11 +13,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <fieldset :id="id" class="mt-12">
-    <b-row>
-      <b-col cols="12" lg="6">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 lg:col-span-6">
         <legend>Change History</legend>
-      </b-col>
-    </b-row>
+      </div>
+    </div>
     <b-row>
       <b-col cols="12">
         <well-history :well-tag-number="wellTagNumber" resource="wells" :events="events" ref="wellHistory"/>

--- a/app/frontend/src/submissions/components/SubmissionForm/EditHistory.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/EditHistory.vue
@@ -12,23 +12,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset :id="id" class="mt-12">
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 lg:col-span-6">
-        <legend>Change History</legend>
-      </div>
+  <form-subsection title="Change History" :id="id" class="mt-12" :hideSave="true">
+    <div class="flex">
+      <well-history :well-tag-number="wellTagNumber" resource="wells" :events="events" ref="wellHistory"/>
     </div>
-    <b-row>
-      <b-col cols="12">
-        <well-history :well-tag-number="wellTagNumber" resource="wells" :events="events" ref="wellHistory"/>
-      </b-col>
-    </b-row>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 import WellHistory from './WellHistory.vue'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   name: 'StaffEditHistory',
@@ -48,7 +42,8 @@ export default {
     // }
   },
   components: {
-    WellHistory
+    WellHistory,
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/FilterPack.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/FilterPack.vue
@@ -19,19 +19,19 @@ Licensed under the Apache License, Version 2.0 (the "License");
         label="Filter Pack From"
         hint="ft"
         type="number"
-        v-model="filterPackFromInput"></form-input>
+        v-model="filterPackFromInput"/>
       <form-input
         id="filterPackTo"
         label="Filter Pack To"
         hint="ft"
         type="number"
-        v-model="filterPackToInput"></form-input>
+        v-model="filterPackToInput"/>
       <form-input
         id="filterPackThickness"
         label="Filter Pack Thickness"
         hint="inches"
         type="number"
-        v-model="filterPackThicknessInput"></form-input>
+        v-model="filterPackThicknessInput"/>
       <form-input
         id="filterPackMaterial"
         label="Filter Pack Material"
@@ -42,7 +42,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="filterPackMaterialInput"
         placeholder="Select material"
         :errors="errors['filter_pack_material']"
-        :loaded="fieldsLoaded['filter_pack_material']"></form-input>
+        :loaded="fieldsLoaded['filter_pack_material']"/>
       <form-input
         id="filterPackMaterialSize"
         label="Filter Pack Material Size"
@@ -53,7 +53,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="filterPackMaterialSizeInput"
         placeholder="Select size"
         :errors="errors['filter_pack_material_size']"
-        :loaded="fieldsLoaded['filter_pack_material_size']"></form-input>
+        :loaded="fieldsLoaded['filter_pack_material_size']"/>
     </responsive-grid>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/FilterPack.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/FilterPack.vue
@@ -12,20 +12,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-      <b-row>
-        <b-col cols="12" lg="6">
-          <legend :id="id">Filter Pack</legend>
-        </b-col>
-        <b-col cols="12" lg="6">
-          <div class="float-right">
-            <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-            <back-to-top-link v-if="isStaffEdit"/>
-          </div>
-        </b-col>
-      </b-row>
-    <b-row>
-      <b-col cols="12" md="6" lg="3">
+  <form-subsection title="Filter Pack" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
           id="filterPackFrom"
           label="Filter Pack From"
@@ -33,8 +22,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           type="number"
           v-model="filterPackFromInput"
         ></form-input>
-      </b-col>
-      <b-col cols="12" md="6" lg="3">
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
           id="filterPackTo"
           label="Filter Pack To"
@@ -42,8 +31,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           type="number"
           v-model="filterPackToInput"
         ></form-input>
-      </b-col>
-      <b-col cols="12" md="6" lg="3">
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
           id="filterPackThickness"
           label="Filter Pack Thickness"
@@ -51,10 +40,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
           type="number"
           v-model="filterPackThicknessInput"
         ></form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="6" lg="3">
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
           id="filterPackMaterial"
           label="Filter Pack Material"
@@ -67,8 +56,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           :errors="errors['filter_pack_material']"
           :loaded="fieldsLoaded['filter_pack_material']"
         ></form-input>
-      </b-col>
-      <b-col cols="12" md="6" lg="3">
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
           id="filterPackMaterialSize"
           label="Filter Pack Material Size"
@@ -81,15 +70,16 @@ Licensed under the Apache License, Version 2.0 (the "License");
           :errors="errors['filter_pack_material_size']"
           :loaded="fieldsLoaded['filter_pack_material_size']"
         ></form-input>
-      </b-col>
-    </b-row>
-  </fieldset>
+      </div>
+    </div>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   name: 'FilterPack',
@@ -120,6 +110,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   fields: {
     filterPackFromInput: 'filterPackFrom',

--- a/app/frontend/src/submissions/components/SubmissionForm/FilterPack.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/FilterPack.vue
@@ -13,65 +13,48 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Filter Pack" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="filterPackFrom"
-          label="Filter Pack From"
-          hint="ft"
-          type="number"
-          v-model="filterPackFromInput"
-        ></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="filterPackTo"
-          label="Filter Pack To"
-          hint="ft"
-          type="number"
-          v-model="filterPackToInput"
-        ></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="filterPackThickness"
-          label="Filter Pack Thickness"
-          hint="inches"
-          type="number"
-          v-model="filterPackThicknessInput"
-        ></form-input>
-      </div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="filterPackMaterial"
-          label="Filter Pack Material"
-          select
-          :options="codes?.filter_pack_material"
-          text-field="description"
-          value-field="filter_pack_material_code"
-          v-model="filterPackMaterialInput"
-          placeholder="Select material"
-          :errors="errors['filter_pack_material']"
-          :loaded="fieldsLoaded['filter_pack_material']"
-        ></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="filterPackMaterialSize"
-          label="Filter Pack Material Size"
-          select
-          :options="codes?.filter_pack_material_size"
-          text-field="description"
-          value-field="filter_pack_material_size_code"
-          v-model="filterPackMaterialSizeInput"
-          placeholder="Select size"
-          :errors="errors['filter_pack_material_size']"
-          :loaded="fieldsLoaded['filter_pack_material_size']"
-        ></form-input>
-      </div>
-    </div>
+    <responsive-grid :cols="12" :md="6" :lg="3">
+      <form-input
+        id="filterPackFrom"
+        label="Filter Pack From"
+        hint="ft"
+        type="number"
+        v-model="filterPackFromInput"></form-input>
+      <form-input
+        id="filterPackTo"
+        label="Filter Pack To"
+        hint="ft"
+        type="number"
+        v-model="filterPackToInput"></form-input>
+      <form-input
+        id="filterPackThickness"
+        label="Filter Pack Thickness"
+        hint="inches"
+        type="number"
+        v-model="filterPackThicknessInput"></form-input>
+      <form-input
+        id="filterPackMaterial"
+        label="Filter Pack Material"
+        select
+        :options="codes?.filter_pack_material"
+        text-field="description"
+        value-field="filter_pack_material_code"
+        v-model="filterPackMaterialInput"
+        placeholder="Select material"
+        :errors="errors['filter_pack_material']"
+        :loaded="fieldsLoaded['filter_pack_material']"></form-input>
+      <form-input
+        id="filterPackMaterialSize"
+        label="Filter Pack Material Size"
+        select
+        :options="codes?.filter_pack_material_size"
+        text-field="description"
+        value-field="filter_pack_material_size_code"
+        v-model="filterPackMaterialSizeInput"
+        placeholder="Select size"
+        :errors="errors['filter_pack_material_size']"
+        :loaded="fieldsLoaded['filter_pack_material_size']"></form-input>
+    </responsive-grid>
   </form-subsection>
 </template>
 
@@ -79,6 +62,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
@@ -112,7 +96,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   fields: {
     filterPackFromInput: 'filterPackFrom',

--- a/app/frontend/src/submissions/components/SubmissionForm/Liner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Liner.vue
@@ -12,145 +12,135 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
+  <form-subsection title="Liner Information" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6">
+        <form-input
+          id="linerMaterial"
+          label="Liner Material"
+          select
+          :options="codes?.liner_material_codes"
+          v-model="linerMaterialInput"
+          text-field="description"
+          value-field="code"
+          placeholder="Select material"
+          :errors="errors['liner_material']"
+          :loaded="fieldsLoaded['liner_material']"/>
+      </div>
+    </div>
     <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Liner Information</legend>
+      <b-col cols="6" md="6">
+        <form-input
+          id="linerDiameter"
+          label="Liner Diameter"
+          hint="inches"
+          type="number"
+          v-model.number="linerDiameterInput"
+          :errors="errors['liner_diameter']"
+          :loaded="fieldsLoaded['liner_diameter']"
+          />
       </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
+      <b-col cols="6" md="6">
+        <form-input
+          id="linerThickness"
+          label="Liner Thickness"
+          hint="inches"
+          type="number"
+          v-model.number="linerThicknessInput"
+          :errors="errors['liner_thickness']"
+          :loaded="fieldsLoaded['liner_thickness']"
+          />
       </b-col>
     </b-row>
     <b-row>
-        <b-col cols="12" md="6">
-          <form-input
-            id="linerMaterial"
-            label="Liner Material"
-            select
-            :options="codes?.liner_material_codes"
-            v-model="linerMaterialInput"
-            text-field="description"
-            value-field="code"
-            placeholder="Select material"
-            :errors="errors['liner_material']"
-            :loaded="fieldsLoaded['liner_material']"/>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="6" md="6">
-          <form-input
-            id="linerDiameter"
-            label="Liner Diameter"
-            hint="inches"
-            type="number"
-            v-model.number="linerDiameterInput"
-            :errors="errors['liner_diameter']"
-            :loaded="fieldsLoaded['liner_diameter']"
-            />
-        </b-col>
-        <b-col cols="6" md="6">
-          <form-input
-            id="linerThickness"
-            label="Liner Thickness"
-            hint="inches"
-            type="number"
-            v-model.number="linerThicknessInput"
-            :errors="errors['liner_thickness']"
-            :loaded="fieldsLoaded['liner_thickness']"
-            />
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="6" md="6">
-          <form-input
-            id="linerFrom"
-            label="Liner From"
-            hint="ft (bgl)"
-            type="number"
-            v-model.number="linerFromInput"
-            :errors="errors['liner_from']"
-            :loaded="fieldsLoaded['liner_from']"
-            />
-        </b-col>
-        <b-col cols="6" md="6">
-          <form-input
-            id="linerTo"
-            label="Liner To"
-            hint="ft (bgl)"
-            type="number"
-            v-model.number="linerToInput"
-            :errors="errors['liner_to']"
-            :loaded="fieldsLoaded['liner_to']"
-            />
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col>Liner Perforations</b-col>
-      </b-row>
-      <b-row>
-        <b-col md="6">
-          <table class="table table-sm no-border">
-            <thead>
-              <tr>
-                <th class="font-weight-normal no-border">Perforated From ft (bgl)</th>
-                <th class="font-weight-normal">Perforated To ft (bgl)</th>
-                <th></th>
-              </tr>
-              <tr v-for="(liner, index) in linerPerforationsData" :key="index">
-                <td class="pb-0 pt-1">
-                  <form-input
-                    :id="`liner_perforated_from_${index}`"
-                    type="number"
-                    class="mb-0"
-                    v-model="liner.start"
-                    :errors="getLinerPerforationError(index).start"
-                    :loaded="getFieldsLoaded(index).start"/>
-                </td>
-                <td class="pb-0 pt-1">
-                  <form-input
-                    :id="`liner_perforated_to_${index}`"
-                    type="number"
-                    class="mb-0"
-                    v-model="liner.end"
-                    :errors="getLinerPerforationError(index).end"
-                    :loaded="getFieldsLoaded(index).end"/>
-                </td>
-                <td class="py-0">
-                  <b-btn size="sm" :id="`removeLinerPerfRowBtn${index}`" variant="primary" @click="removeRowIfOk(index)" class="mt-2"><i class="fa fa-minus-square-o"></i> Remove</b-btn>
-                </td>
-              </tr>
-            </thead>
-            <tbody>
-            </tbody>
-          </table>
-          <b-btn size="sm" variant="primary" id="addlinerPerforationRowBtn" @click="addRow"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
-          <b-modal
-            v-model="confirmRemoveModal"
-            centered
-            title="Confirm remove"
-            @shown="focusRemoveModal">
-            Are you sure you want to remove this row?
-            <div slot="modal-footer">
-              <b-btn variant="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn">
-                Cancel
-              </b-btn>
-              <b-btn variant="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)">
-                Remove
-              </b-btn>
-            </div>
-          </b-modal>
-        </b-col>
-      </b-row>
-  </fieldset>
+      <b-col cols="6" md="6">
+        <form-input
+          id="linerFrom"
+          label="Liner From"
+          hint="ft (bgl)"
+          type="number"
+          v-model.number="linerFromInput"
+          :errors="errors['liner_from']"
+          :loaded="fieldsLoaded['liner_from']"
+          />
+      </b-col>
+      <b-col cols="6" md="6">
+        <form-input
+          id="linerTo"
+          label="Liner To"
+          hint="ft (bgl)"
+          type="number"
+          v-model.number="linerToInput"
+          :errors="errors['liner_to']"
+          :loaded="fieldsLoaded['liner_to']"
+          />
+      </b-col>
+    </b-row>
+    <b-row>
+      <b-col>Liner Perforations</b-col>
+    </b-row>
+    <b-row>
+      <b-col md="6">
+        <table class="table table-sm no-border">
+          <thead>
+            <tr>
+              <th class="font-weight-normal no-border">Perforated From ft (bgl)</th>
+              <th class="font-weight-normal">Perforated To ft (bgl)</th>
+              <th></th>
+            </tr>
+            <tr v-for="(liner, index) in linerPerforationsData" :key="index">
+              <td class="pb-0 pt-1">
+                <form-input
+                  :id="`liner_perforated_from_${index}`"
+                  type="number"
+                  class="mb-0"
+                  v-model="liner.start"
+                  :errors="getLinerPerforationError(index).start"
+                  :loaded="getFieldsLoaded(index).start"/>
+              </td>
+              <td class="pb-0 pt-1">
+                <form-input
+                  :id="`liner_perforated_to_${index}`"
+                  type="number"
+                  class="mb-0"
+                  v-model="liner.end"
+                  :errors="getLinerPerforationError(index).end"
+                  :loaded="getFieldsLoaded(index).end"/>
+              </td>
+              <td class="py-0">
+                <b-btn size="sm" :id="`removeLinerPerfRowBtn${index}`" variant="primary" @click="removeRowIfOk(index)" class="mt-2"><i class="fa fa-minus-square-o"></i> Remove</b-btn>
+              </td>
+            </tr>
+          </thead>
+          <tbody>
+          </tbody>
+        </table>
+        <b-btn size="sm" variant="primary" id="addlinerPerforationRowBtn" @click="addRow"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
+        <b-modal
+          v-model="confirmRemoveModal"
+          centered
+          title="Confirm remove"
+          @shown="focusRemoveModal">
+          Are you sure you want to remove this row?
+          <div slot="modal-footer">
+            <b-btn variant="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn">
+              Cancel
+            </b-btn>
+            <b-btn variant="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)">
+              Remove
+            </b-btn>
+          </div>
+        </b-modal>
+      </b-col>
+    </b-row>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   name: 'LinerInformation',
@@ -184,6 +174,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/Liner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Liner.vue
@@ -61,8 +61,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
         :loaded="fieldsLoaded['liner_to']"/>
     </responsive-grid>
     <div class="flex">>Liner Perforations</div>
-    <b-row>
-      <b-col md="6">
+    <div class="grid grid-cols-2">
+      <div class="md:col-span-1">
         <table class="table table-sm no-border">
           <thead>
             <tr>
@@ -90,14 +90,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   :loaded="getFieldsLoaded(index).end"/>
               </td>
               <td class="py-0">
-                <b-btn size="sm" :id="`removeLinerPerfRowBtn${index}`" variant="primary" @click="removeRowIfOk(index)" class="mt-2"><i class="fa fa-minus-square-o"></i> Remove</b-btn>
+                <Button label="Remove" icon="fa fa-minus-square-o" size="small" :id="`removeLinerPerfRowBtn${index}`" @click="removeRowIfOk(index)" class="mt-2"/>
               </td>
             </tr>
           </thead>
           <tbody>
           </tbody>
         </table>
-        <b-btn size="sm" variant="primary" id="addlinerPerforationRowBtn" @click="addRow"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
+        <Button label="Add row" icon="fa fa-plus-square-o" size="small" id="addlinerPerforationRowBtn" @click="addRow"/>
         <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
           Are you sure you want to remove this row?
           <template #footer>
@@ -105,8 +105,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
             <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
           </template>
         </Dialog>
-      </b-col>
-    </b-row>
+      </div>
+    </div>
   </form-subsection>
 </template>
 

--- a/app/frontend/src/submissions/components/SubmissionForm/Liner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Liner.vue
@@ -116,21 +116,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </tbody>
         </table>
         <b-btn size="sm" variant="primary" id="addlinerPerforationRowBtn" @click="addRow"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
-        <b-modal
-          v-model="confirmRemoveModal"
-          centered
-          title="Confirm remove"
+        <Dialog
+          v-model:visible="confirmRemoveModal"
+          modal
+          header="Confirm remove"
           @shown="focusRemoveModal">
           Are you sure you want to remove this row?
           <div slot="modal-footer">
-            <b-btn variant="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn">
-              Cancel
-            </b-btn>
-            <b-btn variant="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)">
-              Remove
-            </b-btn>
+            <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
+            <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
           </div>
-        </b-modal>
+        </Dialog>
       </b-col>
     </b-row>
   </form-subsection>

--- a/app/frontend/src/submissions/components/SubmissionForm/Liner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Liner.vue
@@ -13,72 +13,54 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Liner Information" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6">
-        <form-input
-          id="linerMaterial"
-          label="Liner Material"
-          select
-          :options="codes?.liner_material_codes"
-          v-model="linerMaterialInput"
-          text-field="description"
-          value-field="code"
-          placeholder="Select material"
-          :errors="errors['liner_material']"
-          :loaded="fieldsLoaded['liner_material']"/>
-      </div>
-    </div>
-    <b-row>
-      <b-col cols="6" md="6">
-        <form-input
-          id="linerDiameter"
-          label="Liner Diameter"
-          hint="inches"
-          type="number"
-          v-model.number="linerDiameterInput"
-          :errors="errors['liner_diameter']"
-          :loaded="fieldsLoaded['liner_diameter']"
-          />
-      </b-col>
-      <b-col cols="6" md="6">
-        <form-input
-          id="linerThickness"
-          label="Liner Thickness"
-          hint="inches"
-          type="number"
-          v-model.number="linerThicknessInput"
-          :errors="errors['liner_thickness']"
-          :loaded="fieldsLoaded['liner_thickness']"
-          />
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="6" md="6">
-        <form-input
-          id="linerFrom"
-          label="Liner From"
-          hint="ft (bgl)"
-          type="number"
-          v-model.number="linerFromInput"
-          :errors="errors['liner_from']"
-          :loaded="fieldsLoaded['liner_from']"
-          />
-      </b-col>
-      <b-col cols="6" md="6">
-        <form-input
-          id="linerTo"
-          label="Liner To"
-          hint="ft (bgl)"
-          type="number"
-          v-model.number="linerToInput"
-          :errors="errors['liner_to']"
-          :loaded="fieldsLoaded['liner_to']"
-          />
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col>Liner Perforations</b-col>
-    </b-row>
+    <responsive-grid :cols="12" :md="6">
+      <form-input
+        id="linerMaterial"
+        label="Liner Material"
+        select
+        :options="codes?.liner_material_codes"
+        v-model="linerMaterialInput"
+        text-field="description"
+        value-field="code"
+        placeholder="Select material"
+        :errors="errors['liner_material']"
+        :loaded="fieldsLoaded['liner_material']"/>
+    </responsive-grid>
+    <responsive-grid :cols="6" :md="6">
+      <form-input
+        id="linerDiameter"
+        label="Liner Diameter"
+        hint="inches"
+        type="number"
+        v-model.number="linerDiameterInput"
+        :errors="errors['liner_diameter']"
+        :loaded="fieldsLoaded['liner_diameter']"/>
+      <form-input
+        id="linerThickness"
+        label="Liner Thickness"
+        hint="inches"
+        type="number"
+        v-model.number="linerThicknessInput"
+        :errors="errors['liner_thickness']"
+        :loaded="fieldsLoaded['liner_thickness']"/>
+      <form-input
+        id="linerFrom"
+        label="Liner From"
+        hint="ft (bgl)"
+        type="number"
+        v-model.number="linerFromInput"
+        :errors="errors['liner_from']"
+        :loaded="fieldsLoaded['liner_from']"/>
+      <form-input
+        id="linerTo"
+        label="Liner To"
+        hint="ft (bgl)"
+        type="number"
+        v-model.number="linerToInput"
+        :errors="errors['liner_to']"
+        :loaded="fieldsLoaded['liner_to']"/>
+    </responsive-grid>
+    <div class="flex">>Liner Perforations</div>
     <b-row>
       <b-col md="6">
         <table class="table table-sm no-border">
@@ -116,16 +98,12 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </tbody>
         </table>
         <b-btn size="sm" variant="primary" id="addlinerPerforationRowBtn" @click="addRow"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
-        <Dialog
-          v-model:visible="confirmRemoveModal"
-          modal
-          header="Confirm remove"
-          @shown="focusRemoveModal">
+        <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
           Are you sure you want to remove this row?
-          <div slot="modal-footer">
+          <template #footer>
             <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
             <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
-          </div>
+          </template>
         </Dialog>
       </b-col>
     </b-row>
@@ -136,6 +114,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
@@ -172,7 +151,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
@@ -87,52 +87,51 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </td>
               <td class="input-width-medium">
                 <form-input
-                    :id="`lithologyDescriptor${index}`"
-                    aria-label="Descriptor"
-                    select
-                    :options="codes?.lithology_descriptors"
-                    text-field="description"
-                    value-field="lithology_description_code"
-                    placeholder="Select descriptor"
-                    v-model="lithologyData[index].lithology_description"
-                    group-class="mt-1 mb-0"
-                />
+                  :id="`lithologyDescriptor${index}`"
+                  aria-label="Descriptor"
+                  select
+                  :options="codes?.lithology_descriptors"
+                  text-field="description"
+                  value-field="lithology_description_code"
+                  placeholder="Select descriptor"
+                  v-model="lithologyData[index].lithology_description"
+                  group-class="mt-1 mb-0"/>
               </td>
               <td class="input-width-medium">
                 <form-input
-                    :id="`lithologyMoisture${index}`"
-                    aria-label="Moisture"
-                    select
-                    :options="codes?.lithology_moisture_codes"
-                    text-field="description"
-                    value-field="lithology_moisture_code"
-                    placeholder="Select moisture"
-                    v-model="lithologyData[index].lithology_moisture"
-                    group-class="mt-1 mb-0"></form-input>
+                  :id="`lithologyMoisture${index}`"
+                  aria-label="Moisture"
+                  select
+                  :options="codes?.lithology_moisture_codes"
+                  text-field="description"
+                  value-field="lithology_moisture_code"
+                  placeholder="Select moisture"
+                  v-model="lithologyData[index].lithology_moisture"
+                  group-class="mt-1 mb-0"></form-input>
               </td>
               <td class="input-width-medium">
                 <form-input
-                    :id="`lithologyColour${index}`"
-                    aria-label="Colour"
-                    select
-                    :options="codes?.lithology_colours"
-                    text-field="description"
-                    placeholder="Select colour"
-                    value-field="lithology_colour_code"
-                    v-model="lithologyData[index].lithology_colour"
-                    group-class="mt-1 mb-0"></form-input>
+                  :id="`lithologyColour${index}`"
+                  aria-label="Colour"
+                  select
+                  :options="codes?.lithology_colours"
+                  text-field="description"
+                  placeholder="Select colour"
+                  value-field="lithology_colour_code"
+                  v-model="lithologyData[index].lithology_colour"
+                  group-class="mt-1 mb-0"></form-input>
               </td>
               <td class="input-width-medium">
                 <form-input
-                    :id="`lithologyHardness${index}`"
-                    aria-label="Hardness"
-                    select
-                    :options="codes?.lithology_hardness_codes"
-                    text-field="description"
-                    placeholder="Select hardness"
-                    value-field="lithology_hardness_code"
-                    v-model="lithologyData[index].lithology_hardness"
-                    group-class="mt-1 mb-0"></form-input>
+                  :id="`lithologyHardness${index}`"
+                  aria-label="Hardness"
+                  select
+                  :options="codes?.lithology_hardness_codes"
+                  text-field="description"
+                  placeholder="Select hardness"
+                  value-field="lithology_hardness_code"
+                  v-model="lithologyData[index].lithology_hardness"
+                  group-class="mt-1 mb-0"></form-input>
               </td>
               <td class="input-width-medium">
                 <form-input
@@ -145,10 +144,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </td>
               <td class="input-width-medium">
                 <form-input
-                    :id="`lithologyObservations${index}`"
-                    aria-label="Observations"
-                    v-model="lithologyData[index].lithology_observation"
-                    group-class="mt-1 mb-0"></form-input>
+                  :id="`lithologyObservations${index}`"
+                  aria-label="Observations"
+                  v-model="lithologyData[index].lithology_observation"
+                  group-class="mt-1 mb-0"></form-input>
               </td>
               <td class="pt-1">
                 <b-btn size="sm" variant="primary" @click="removeRowIfOk(index)" :id="`removeRowButton${index}`" class="mt-2 float-right"><i class="fa fa-minus-square-o"></i> Remove</b-btn>
@@ -159,16 +158,12 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </table>
     </div>
     <b-btn size="sm" variant="primary" @click="addLithologyRow" id="addLithologyRowButton"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
-    <Dialog
-      v-model:visible="confirmRemoveModal"
-      modal
-      header="Confirm remove"
-      @shown="focusRemoveModal">
+    <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
       Are you sure you want to remove this row?
-      <div slot="modal-footer">
+      <template #footer>
         <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
         <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
-      </div>
+      </template>
     </Dialog>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
@@ -76,7 +76,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                     v-model="lithologyData[index].lithology_raw_data"
                     group-class="mt-1 mb-0"
                     @input="parseDescription(index, $event)"
-                ></form-input>
+                />
               </td>
               <td class="input-width-medium">
                 <div class="material-badges">
@@ -107,7 +107,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   value-field="lithology_moisture_code"
                   placeholder="Select moisture"
                   v-model="lithologyData[index].lithology_moisture"
-                  group-class="mt-1 mb-0"></form-input>
+                  group-class="mt-1 mb-0"/>
               </td>
               <td class="input-width-medium">
                 <form-input
@@ -119,7 +119,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   placeholder="Select colour"
                   value-field="lithology_colour_code"
                   v-model="lithologyData[index].lithology_colour"
-                  group-class="mt-1 mb-0"></form-input>
+                  group-class="mt-1 mb-0"/>
               </td>
               <td class="input-width-medium">
                 <form-input
@@ -131,7 +131,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   placeholder="Select hardness"
                   value-field="lithology_hardness_code"
                   v-model="lithologyData[index].lithology_hardness"
-                  group-class="mt-1 mb-0"></form-input>
+                  group-class="mt-1 mb-0"/>
               </td>
               <td class="input-width-medium">
                 <form-input
@@ -140,14 +140,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   type="number"
                   v-model="lithologyData[index].water_bearing_estimated_flow"
                   group-class="mt-1 mb-0"
-                ></form-input>
+                />
               </td>
               <td class="input-width-medium">
                 <form-input
                   :id="`lithologyObservations${index}`"
                   aria-label="Observations"
                   v-model="lithologyData[index].lithology_observation"
-                  group-class="mt-1 mb-0"></form-input>
+                  group-class="mt-1 mb-0"/>
               </td>
               <td class="pt-1">
                 <Button label="Remove" icon="fa fa-minus-square-o" size="small" @click="removeRowIfOk(index)" :id="`removeRowButton${index}`" class="mt-2 float-right"/>

--- a/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
@@ -150,14 +150,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   group-class="mt-1 mb-0"></form-input>
               </td>
               <td class="pt-1">
-                <b-btn size="sm" variant="primary" @click="removeRowIfOk(index)" :id="`removeRowButton${index}`" class="mt-2 float-right"><i class="fa fa-minus-square-o"></i> Remove</b-btn>
+                <Button label="Remove" icon="fa fa-minus-square-o" size="small" @click="removeRowIfOk(index)" :id="`removeRowButton${index}`" class="mt-2 float-right"/>
               </td>
             </tr>
           </template>
         </tbody>
       </table>
     </div>
-    <b-btn size="sm" variant="primary" @click="addLithologyRow" id="addLithologyRowButton"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
+    <Button label="Add row" icon="fa fa-plus-square-o" size="small" @click="addLithologyRow" id="addLithologyRowButton"/>
     <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
       Are you sure you want to remove this row?
       <template #footer>

--- a/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
@@ -159,21 +159,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </table>
     </div>
     <b-btn size="sm" variant="primary" @click="addLithologyRow" id="addLithologyRowButton"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
-    <b-modal
-        v-model="confirmRemoveModal"
-        centered
-        title="Confirm remove"
-        @shown="focusRemoveModal">
+    <Dialog
+      v-model:visible="confirmRemoveModal"
+      modal
+      header="Confirm remove"
+      @shown="focusRemoveModal">
       Are you sure you want to remove this row?
       <div slot="modal-footer">
-        <b-btn variant="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn">
-          Cancel
-        </b-btn>
-        <b-btn variant="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)">
-          Remove
-        </b-btn>
+        <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
+        <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
       </div>
-    </b-modal>
+    </Dialog>
   </form-subsection>
 </template>
 

--- a/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
@@ -71,12 +71,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </td>
               <td>
                 <form-input
-                    :id="`lithologyDescription${index}`"
-                    aria-label="Soil or Bedrock Description"
-                    v-model="lithologyData[index].lithology_raw_data"
-                    group-class="mt-1 mb-0"
-                    @input="parseDescription(index, $event)"
-                />
+                  :id="`lithologyDescription${index}`"
+                  aria-label="Soil or Bedrock Description"
+                  v-model="lithologyData[index].lithology_raw_data"
+                  group-class="mt-1 mb-0"
+                  @input="parseDescription(index, $event)"/>
               </td>
               <td class="input-width-medium">
                 <div class="material-badges">
@@ -139,8 +138,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   aria-label="Water bearing flow"
                   type="number"
                   v-model="lithologyData[index].water_bearing_estimated_flow"
-                  group-class="mt-1 mb-0"
-                />
+                  group-class="mt-1 mb-0"/>
               </td>
               <td class="input-width-medium">
                 <form-input

--- a/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
@@ -167,6 +167,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 </template>
 
 <script>
+import { Badge } from 'primevue'
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
@@ -204,7 +205,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    Badge
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
@@ -79,9 +79,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </td>
               <td class="input-width-medium">
                 <div class="material-badges">
-                  <b-badge v-for="(soil, j) in lithSoils[index]" variant="light" class="font-weight-normal" :key="`soilTerm-${index}-${j}`">
+                  <Badge v-for="(soil, j) in lithSoils[index]" severity="secondary" class="font-weight-normal" :key="`soilTerm-${index}-${j}`">
                     {{ soil }}
-                  </b-badge>
+                  </Badge>
                 </div>
               </td>
               <td class="input-width-medium">

--- a/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Lithology.vue
@@ -12,18 +12,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Lithology</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
+  <form-subsection title="Lithology" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <div class="table-responsive">
       <table class="table table-sm" aria-describedby="lithologyDetails">
         <thead>
@@ -185,13 +174,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </b-btn>
       </div>
     </b-modal>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 import Lithology from '@/submissions/components/lithology.js'
 
@@ -223,6 +213,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -161,6 +161,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
   </form-subsection>
 </template>
 <script>
+import querystring from 'querystring'
 import { useSubmissionStore } from '@/stores/submission'
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import ApiService from '../../../common/services/ApiService'
@@ -283,7 +284,6 @@ export default {
         addressString: this.streetAddressInput
       }
 
-      const querystring = require('querystring')
       const searchParams = querystring.stringify(params)
       try {
         ApiService.getAddresses(searchParams).then((response) => {

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -26,7 +26,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </b-row>
       <b-row>
         <b-col>
-          <p>Please provide as much information as possible.</p> <p class="bg-warning p-2">A minimum of one type of well location information is required below:</p>
+          <p>Please provide as much information as possible.</p> <p class="bg-yellow-400 p-2">A minimum of one type of well location information is required below:</p>
           <p class="d-inline font-weight-bold">1) Well Location Address</p>
           <div class="d-inline pl-2"><b-form-checkbox v-model="sameAsOwnerAddress">Same as owner address</b-form-checkbox></div>
         </b-col>

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -12,40 +12,29 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-    <fieldset>
-      <b-row>
-        <b-col cols="12" lg="6">
-          <legend :id="id">Well Location</legend>
-        </b-col>
-        <b-col cols="12" lg="6">
-          <div class="float-right">
-            <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-            <back-to-top-link v-if="isStaffEdit"/>
-          </div>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col>
-          <p>Please provide as much information as possible.</p> <p class="bg-yellow-400 p-2">A minimum of one type of well location information is required below:</p>
-          <p class="d-inline font-weight-bold">1) Well Location Address</p>
-          <div class="d-inline pl-2"><b-form-checkbox v-model="sameAsOwnerAddress">Same as owner address</b-form-checkbox></div>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" md="6">
-          <form-input
-            v-model="streetAddressInput"
-            id="wellStreetAddress"
-            type="text"
-            label="Street address"
-            @input="fetchAddressSuggestions"
-            v-on:focus="showList(true)"
-            v-on:blur="showList(false)"
-            :errors="errors['street_address']"
-            :loaded="fieldsLoaded['street_address']"
-            :disabled="sameAsOwnerAddress"
-          ></form-input>
-           <!-- Display the address suggestions -->
+  <form-subsection title="Well Location" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
+    <div class="flex">
+      <div>
+        <p>Please provide as much information as possible.</p> <p class="bg-yellow-400 p-2">A minimum of one type of well location information is required below:</p>
+        <p class="d-inline font-weight-bold">1) Well Location Address</p>
+        <div class="d-inline pl-2"><b-form-checkbox v-model="sameAsOwnerAddress">Same as owner address</b-form-checkbox></div>
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6">
+        <form-input
+          v-model="streetAddressInput"
+          id="wellStreetAddress"
+          type="text"
+          label="Street address"
+          @input="fetchAddressSuggestions"
+          v-on:focus="showList(true)"
+          v-on:blur="showList(false)"
+          :errors="errors['street_address']"
+          :loaded="fieldsLoaded['street_address']"
+          :disabled="sameAsOwnerAddress"
+        ></form-input>
+          <!-- Display the address suggestions -->
         <div v-if="addressSuggestions.length > 0" class="address-suggestions list-group list-group-flush border" id="location-address-suggestions-list">
           <div v-for="(suggestion, index) in addressSuggestions" :key="index">
             <button @mousedown="selectAddressSuggestion(suggestion)" class="list-group-item list-group-item-action border-0">{{ suggestion }}</button>
@@ -55,177 +44,177 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <div v-if="isLoadingSuggestions" class="loading-indicator">
           Loading...
         </div>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" md="5">
-          <form-input
-              id="wellCity"
-              label="City"
-              type="text"
-              v-model="cityInput"
-              :errors="errors['city']"
-              :loaded="fieldsLoaded['city']"
-              :disabled="sameAsOwnerAddress"
-              >
-          </form-input>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col>
-          <p class="mb-1">OR</p>
-          <p class="font-weight-bold">
-            2) Legal Description
-            <i id="legal_description_fields" tabindex="0" class="fa fa-question-circle color-info fa-xs pt-0 mt-0 d-print-none"></i>
-            <b-popover
-              target="legal_description_fields"
-              triggers="hover focus"
-              :content="TOOLTIP_TEXT.location_vue.legal_description_fields"
-            />
-          </p>
-        </b-col>
-      </b-row>
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-5">
+        <form-input
+            id="wellCity"
+            label="City"
+            type="text"
+            v-model="cityInput"
+            :errors="errors['city']"
+            :loaded="fieldsLoaded['city']"
+            :disabled="sameAsOwnerAddress"
+            >
+        </form-input>
+      </div>
+    </div>
+    <div class="flex">
+      <div>
+        <p class="mb-1">OR</p>
+        <p class="font-weight-bold">
+          2) Legal Description
+          <i id="legal_description_fields" tabindex="0" class="fa fa-question-circle color-info fa-xs pt-0 mt-0 d-print-none"></i>
+          <b-popover
+            target="legal_description_fields"
+            triggers="hover focus"
+            :content="TOOLTIP_TEXT.location_vue.legal_description_fields"
+          />
+        </p>
+      </div>
+    </div>
 
-      <b-row>
-        <b-col cols="12" md="6" lg="3">
-          <form-input
-              id="legalLot"
-              label="Lot"
-              type="text"
-              v-model="legalLotInput"
-              :errors="errors['legal_lot']"
-              :loaded="fieldsLoaded['legal_lot']"
-              >
-          </form-input>
-        </b-col>
-        <b-col cols="12" md="6" lg="3">
-          <form-input
-              id="legalPlan"
-              label="Plan"
-              type="text"
-              v-model="legalPlanInput"
-              :errors="errors['legal_plan']"
-              :loaded="fieldsLoaded['legal_plan']"
-              >
-          </form-input>
-        </b-col>
-        <b-col cols="12" md="6" lg="3">
-          <form-input
-              id="legalDistrictLot"
-              label="District Lot"
-              type="text"
-              v-model="legalDistrictLotInput"
-              :errors="errors['legal_district_lot']"
-              :loaded="fieldsLoaded['legal_district_lot']"
-              >
-          </form-input>
-        </b-col>
-        <b-col cols="12" md="6" lg="3">
-          <form-input
-              id="legalBlock"
-              label="Block"
-              type="text"
-              v-model="legalBlockInput"
-              :errors="errors['legal_block']"
-              :loaded="fieldsLoaded['legal_block']"
-              >
-          </form-input>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" md="6" lg="3">
-          <form-input
-              id="legalSection"
-              label="Section"
-              type="text"
-              v-model="legalSectionInput"
-              :errors="errors['legal_section']"
-              :loaded="fieldsLoaded['legal_section']"
-              >
-          </form-input>
-        </b-col>
-        <b-col cols="12" md="6" lg="3">
-          <form-input
-              id="legalTownship"
-              label="Township"
-              type="text"
-              v-model="legalTownshipInput"
-              :errors="errors['legal_township']"
-              :loaded="fieldsLoaded['legal_township']"
-              >
-          </form-input>
-        </b-col>
-        <b-col cols="12" md="6" lg="3">
-          <form-input
-              id="legalRange"
-              label="Range"
-              type="text"
-              v-model="legalRangeInput"
-              :errors="errors['legal_range']"
-              :loaded="fieldsLoaded['legal_range']"
-              >
-          </form-input>
-        </b-col>
-        <b-col cols="12" md="6" lg="3">
-          <form-input
-              id="landDistrict"
-              label="Land District"
-              select
-              :options="districtCodes"
-              text-field="name"
-              value-field="land_district_code"
-              v-model="landDistrictInput"
-              :errors="errors['land_district']"
-              :loaded="fieldsLoaded['land_district']"
-              >
-          </form-input>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col>
-          <p class="mb-1">OR</p>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" md="6" lg="3">
-          <p class="font-weight-bold">3) Parcel Identifier (PID)</p>
-          <form-input
-              id="legalPID"
-              type="text"
-              hint="*Input a 9 digit number (including leading zeroes, if necessary)"
-              v-model="legalPIDInput"
-              :errors="errors['legal_pid']"
-              :loaded="fieldsLoaded['legal_pid']"
-              >
-          </form-input>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" md="8">
-          <form-input
-              id="wellLocationDescription"
-              label="Description of Well Location"
-              type="text"
-              v-model="wellLocationDescriptionInput"
-              :errors="errors['well_location_description']"
-              :loaded="fieldsLoaded['well_location_description']"
-              >
-          </form-input>
-        </b-col>
-      </b-row>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
+        <form-input
+            id="legalLot"
+            label="Lot"
+            type="text"
+            v-model="legalLotInput"
+            :errors="errors['legal_lot']"
+            :loaded="fieldsLoaded['legal_lot']"
+            >
+        </form-input>
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
+        <form-input
+            id="legalPlan"
+            label="Plan"
+            type="text"
+            v-model="legalPlanInput"
+            :errors="errors['legal_plan']"
+            :loaded="fieldsLoaded['legal_plan']"
+            >
+        </form-input>
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
+        <form-input
+            id="legalDistrictLot"
+            label="District Lot"
+            type="text"
+            v-model="legalDistrictLotInput"
+            :errors="errors['legal_district_lot']"
+            :loaded="fieldsLoaded['legal_district_lot']"
+            >
+        </form-input>
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
+        <form-input
+            id="legalBlock"
+            label="Block"
+            type="text"
+            v-model="legalBlockInput"
+            :errors="errors['legal_block']"
+            :loaded="fieldsLoaded['legal_block']"
+            >
+        </form-input>
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
+        <form-input
+            id="legalSection"
+            label="Section"
+            type="text"
+            v-model="legalSectionInput"
+            :errors="errors['legal_section']"
+            :loaded="fieldsLoaded['legal_section']"
+            >
+        </form-input>
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
+        <form-input
+            id="legalTownship"
+            label="Township"
+            type="text"
+            v-model="legalTownshipInput"
+            :errors="errors['legal_township']"
+            :loaded="fieldsLoaded['legal_township']"
+            >
+        </form-input>
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
+        <form-input
+            id="legalRange"
+            label="Range"
+            type="text"
+            v-model="legalRangeInput"
+            :errors="errors['legal_range']"
+            :loaded="fieldsLoaded['legal_range']"
+            >
+        </form-input>
+      </div>
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
+        <form-input
+            id="landDistrict"
+            label="Land District"
+            select
+            :options="districtCodes"
+            text-field="name"
+            value-field="land_district_code"
+            v-model="landDistrictInput"
+            :errors="errors['land_district']"
+            :loaded="fieldsLoaded['land_district']"
+            >
+        </form-input>
+      </div>
+    </div>
+    <div class="flex">
+      <div>
+        <p class="mb-1">OR</p>
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6 lg:col-span-3">
+        <p class="font-weight-bold">3) Parcel Identifier (PID)</p>
+        <form-input
+            id="legalPID"
+            type="text"
+            hint="*Input a 9 digit number (including leading zeroes, if necessary)"
+            v-model="legalPIDInput"
+            :errors="errors['legal_pid']"
+            :loaded="fieldsLoaded['legal_pid']"
+            >
+        </form-input>
+      </div>
+    </div>
+    <b-row>
+      <b-col cols="12" md="8">
+        <form-input
+            id="wellLocationDescription"
+            label="Description of Well Location"
+            type="text"
+            v-model="wellLocationDescriptionInput"
+            :errors="errors['well_location_description']"
+            :loaded="fieldsLoaded['well_location_description']"
+            >
+        </form-input>
+      </b-col>
+    </b-row>
 
-      <!-- Error message when location not given -->
-      <b-alert class="mt-4" variant="danger" :show="errors.well_location_section && errors.well_location_section.length > 0">
-        Must provide well location as either an address, legal description, or parcel identifier.
-      </b-alert>
-
-    </fieldset>
+    <!-- Error message when location not given -->
+    <b-alert class="mt-4" variant="danger" :show="errors.well_location_section && errors.well_location_section.length > 0">
+      Must provide well location as either an address, legal description, or parcel identifier.
+    </b-alert>
+  </form-subsection>
 </template>
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import ApiService from '../../../common/services/ApiService'
 import { TOOLTIP_TEXT } from '@/common/constants'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   name: 'Location',
@@ -268,6 +257,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -17,7 +17,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <div>
         <p>Please provide as much information as possible.</p> <p class="bg-yellow-400 p-2">A minimum of one type of well location information is required below:</p>
         <p class="d-inline font-weight-bold">1) Well Location Address</p>
-        <div class="d-inline pl-2"><b-form-checkbox v-model="sameAsOwnerAddress">Same as owner address</b-form-checkbox></div>
+        <div class="d-inline pl-2"><Checkbox v-model="sameAsOwnerAddress" binary>Same as owner address</Checkbox></div>
       </div>
     </div>
     <div class="grid grid-cols-12">
@@ -32,7 +32,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           v-on:blur="showList(false)"
           :errors="errors['street_address']"
           :loaded="fieldsLoaded['street_address']"
-          :disabled="sameAsOwnerAddress"></form-input>
+          :disabled="sameAsOwnerAddress"/>
           <!-- Display the address suggestions -->
         <div v-if="addressSuggestions.length > 0" class="address-suggestions list-group list-group-flush border" id="location-address-suggestions-list">
           <div v-for="(suggestion, index) in addressSuggestions" :key="index">
@@ -53,7 +53,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="cityInput"
         :errors="errors['city']"
         :loaded="fieldsLoaded['city']"
-        :disabled="sameAsOwnerAddress"></form-input>
+        :disabled="sameAsOwnerAddress"/>
     </responsive-grid>
     <div class="flex">
       <div>
@@ -77,49 +77,49 @@ Licensed under the Apache License, Version 2.0 (the "License");
         type="text"
         v-model="legalLotInput"
         :errors="errors['legal_lot']"
-        :loaded="fieldsLoaded['legal_lot']"></form-input>
+        :loaded="fieldsLoaded['legal_lot']"/>
       <form-input
         id="legalPlan"
         label="Plan"
         type="text"
         v-model="legalPlanInput"
         :errors="errors['legal_plan']"
-        :loaded="fieldsLoaded['legal_plan']"></form-input>
+        :loaded="fieldsLoaded['legal_plan']"/>
       <form-input
         id="legalDistrictLot"
         label="District Lot"
         type="text"
         v-model="legalDistrictLotInput"
         :errors="errors['legal_district_lot']"
-        :loaded="fieldsLoaded['legal_district_lot']"></form-input>
+        :loaded="fieldsLoaded['legal_district_lot']"/>
       <form-input
         id="legalBlock"
         label="Block"
         type="text"
         v-model="legalBlockInput"
         :errors="errors['legal_block']"
-        :loaded="fieldsLoaded['legal_block']"></form-input>
+        :loaded="fieldsLoaded['legal_block']"/>
       <form-input
         id="legalSection"
         label="Section"
         type="text"
         v-model="legalSectionInput"
         :errors="errors['legal_section']"
-        :loaded="fieldsLoaded['legal_section']"></form-input>
+        :loaded="fieldsLoaded['legal_section']"/>
       <form-input
         id="legalTownship"
         label="Township"
         type="text"
         v-model="legalTownshipInput"
         :errors="errors['legal_township']"
-        :loaded="fieldsLoaded['legal_township']"></form-input>
+        :loaded="fieldsLoaded['legal_township']"/>
       <form-input
         id="legalRange"
         label="Range"
         type="text"
         v-model="legalRangeInput"
         :errors="errors['legal_range']"
-        :loaded="fieldsLoaded['legal_range']"></form-input>
+        :loaded="fieldsLoaded['legal_range']"/>
       <form-input
         id="landDistrict"
         label="Land District"
@@ -129,7 +129,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         value-field="land_district_code"
         v-model="landDistrictInput"
         :errors="errors['land_district']"
-        :loaded="fieldsLoaded['land_district']"></form-input>
+        :loaded="fieldsLoaded['land_district']"/>
     </responsive-grid>
     <div class="flex">
       <p class="mb-1">OR</p>
@@ -143,7 +143,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           hint="*Input a 9 digit number (including leading zeroes, if necessary)"
           v-model="legalPIDInput"
           :errors="errors['legal_pid']"
-          :loaded="fieldsLoaded['legal_pid']"></form-input>
+          :loaded="fieldsLoaded['legal_pid']"/>
       </div>
     </div>
     <responsive-grid :cols="12" :md="8">
@@ -153,7 +153,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         type="text"
         v-model="wellLocationDescriptionInput"
         :errors="errors['well_location_description']"
-        :loaded="fieldsLoaded['well_location_description']"></form-input>
+        :loaded="fieldsLoaded['well_location_description']"/>
     </responsive-grid>
 
     <!-- Error message when location not given -->

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -14,11 +14,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
 <template>
   <form-subsection title="Well Location" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <div class="flex">
-      <div>
-        <p>Please provide as much information as possible.</p> <p class="bg-yellow-400 p-2">A minimum of one type of well location information is required below:</p>
-        <p class="d-inline font-weight-bold">1) Well Location Address</p>
-        <div class="d-inline pl-2"><Checkbox v-model="sameAsOwnerAddress" binary>Same as owner address</Checkbox></div>
-      </div>
+      <p>Please provide as much information as possible.</p> <p class="bg-yellow-400 p-2">A minimum of one type of well location information is required below:</p>
+      <p class="d-inline font-weight-bold">1) Well Location Address</p>
+      <div class="d-inline pl-2"><Checkbox v-model="sameAsOwnerAddress" binary>Same as owner address</Checkbox></div>
     </div>
     <div class="grid grid-cols-12">
       <div class="col-span-12 md:col-span-6">
@@ -33,7 +31,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           :errors="errors['street_address']"
           :loaded="fieldsLoaded['street_address']"
           :disabled="sameAsOwnerAddress"/>
-          <!-- Display the address suggestions -->
+        <!-- Display the address suggestions -->
         <div v-if="addressSuggestions.length > 0" class="address-suggestions list-group list-group-flush border" id="location-address-suggestions-list">
           <div v-for="(suggestion, index) in addressSuggestions" :key="index">
             <button @mousedown="selectAddressSuggestion(suggestion)" class="list-group-item list-group-item-action border-0">{{ suggestion }}</button>
@@ -56,18 +54,16 @@ Licensed under the Apache License, Version 2.0 (the "License");
         :disabled="sameAsOwnerAddress"/>
     </responsive-grid>
     <div class="flex">
-      <div>
-        <p class="mb-1">OR</p>
-        <p class="font-weight-bold">
-          2) Legal Description
-          <i id="legal_description_fields" tabindex="0" class="fa fa-question-circle color-info fa-xs pt-0 mt-0 d-print-none"></i>
-          <b-popover
-            target="legal_description_fields"
-            triggers="hover focus"
-            :content="TOOLTIP_TEXT.location_vue.legal_description_fields"
-          />
-        </p>
-      </div>
+      <p class="mb-1">OR</p>
+      <p class="font-weight-bold">
+        2) Legal Description
+        <i id="legal_description_fields" tabindex="0" class="fa fa-question-circle color-info fa-xs pt-0 mt-0 d-print-none"></i>
+        <b-popover
+          target="legal_description_fields"
+          triggers="hover focus"
+          :content="TOOLTIP_TEXT.location_vue.legal_description_fields"
+        />
+      </p>
     </div>
 
     <responsive-grid :cols="12" :md="6" :lg="3">

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -57,12 +57,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <p class="mb-1">OR</p>
       <p class="font-weight-bold">
         2) Legal Description
-        <i id="legal_description_fields" tabindex="0" class="fa fa-question-circle color-info fa-xs pt-0 mt-0 d-print-none"></i>
-        <b-popover
-          target="legal_description_fields"
-          triggers="hover focus"
-          :content="TOOLTIP_TEXT.location_vue.legal_description_fields"
-        />
+        <i 
+          tabindex="0"
+          class="fa fa-question-circle color-info fa-xs pt-0 mt-0 d-print-none"
+          @mouseenter="showPopover"
+          @mouseleave="hidePopover"
+          @focus="showPopover"
+          @blur="hidePopover"/>
+        <Popover ref="op">{{ TOOLTIP_TEXT.location_vue.legal_description_fields }}</Popover>
       </p>
     </div>
 
@@ -330,6 +332,14 @@ export default {
       if (document.getElementById('location-address-suggestions-list')) {
         document.getElementById('location-address-suggestions-list').style.display = show ? 'block' : 'none'
       }
+    },
+
+    // Show and hide popover
+    showPopover() {
+      this.$refs.op.show()
+    },
+    hidePopover() {
+      this.$refs.op.hide()
     }
   }
 }

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -45,18 +45,16 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </div>
       </div>
     </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-5">
-        <form-input
-          id="wellCity"
-          label="City"
-          type="text"
-          v-model="cityInput"
-          :errors="errors['city']"
-          :loaded="fieldsLoaded['city']"
-          :disabled="sameAsOwnerAddress"></form-input>
-      </div>
-    </div>
+    <responsive-grid :cols="12" :md="5">
+      <form-input
+        id="wellCity"
+        label="City"
+        type="text"
+        v-model="cityInput"
+        :errors="errors['city']"
+        :loaded="fieldsLoaded['city']"
+        :disabled="sameAsOwnerAddress"></form-input>
+    </responsive-grid>
     <div class="flex">
       <div>
         <p class="mb-1">OR</p>
@@ -72,85 +70,67 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </div>
     </div>
 
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="legalLot"
-          label="Lot"
-          type="text"
-          v-model="legalLotInput"
-          :errors="errors['legal_lot']"
-          :loaded="fieldsLoaded['legal_lot']"></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="legalPlan"
-          label="Plan"
-          type="text"
-          v-model="legalPlanInput"
-          :errors="errors['legal_plan']"
-          :loaded="fieldsLoaded['legal_plan']"></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="legalDistrictLot"
-          label="District Lot"
-          type="text"
-          v-model="legalDistrictLotInput"
-          :errors="errors['legal_district_lot']"
-          :loaded="fieldsLoaded['legal_district_lot']"></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="legalBlock"
-          label="Block"
-          type="text"
-          v-model="legalBlockInput"
-          :errors="errors['legal_block']"
-          :loaded="fieldsLoaded['legal_block']"></form-input>
-      </div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="legalSection"
-          label="Section"
-          type="text"
-          v-model="legalSectionInput"
-          :errors="errors['legal_section']"
-          :loaded="fieldsLoaded['legal_section']"></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="legalTownship"
-          label="Township"
-          type="text"
-          v-model="legalTownshipInput"
-          :errors="errors['legal_township']"
-          :loaded="fieldsLoaded['legal_township']"></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="legalRange"
-          label="Range"
-          type="text"
-          v-model="legalRangeInput"
-          :errors="errors['legal_range']"
-          :loaded="fieldsLoaded['legal_range']"></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-6 lg:col-span-3">
-        <form-input
-          id="landDistrict"
-          label="Land District"
-          select
-          :options="districtCodes"
-          text-field="name"
-          value-field="land_district_code"
-          v-model="landDistrictInput"
-          :errors="errors['land_district']"
-          :loaded="fieldsLoaded['land_district']"></form-input>
-      </div>
-    </div>
+    <responsive-grid :cols="12" :md="6" :lg="3">
+      <form-input
+        id="legalLot"
+        label="Lot"
+        type="text"
+        v-model="legalLotInput"
+        :errors="errors['legal_lot']"
+        :loaded="fieldsLoaded['legal_lot']"></form-input>
+      <form-input
+        id="legalPlan"
+        label="Plan"
+        type="text"
+        v-model="legalPlanInput"
+        :errors="errors['legal_plan']"
+        :loaded="fieldsLoaded['legal_plan']"></form-input>
+      <form-input
+        id="legalDistrictLot"
+        label="District Lot"
+        type="text"
+        v-model="legalDistrictLotInput"
+        :errors="errors['legal_district_lot']"
+        :loaded="fieldsLoaded['legal_district_lot']"></form-input>
+      <form-input
+        id="legalBlock"
+        label="Block"
+        type="text"
+        v-model="legalBlockInput"
+        :errors="errors['legal_block']"
+        :loaded="fieldsLoaded['legal_block']"></form-input>
+      <form-input
+        id="legalSection"
+        label="Section"
+        type="text"
+        v-model="legalSectionInput"
+        :errors="errors['legal_section']"
+        :loaded="fieldsLoaded['legal_section']"></form-input>
+      <form-input
+        id="legalTownship"
+        label="Township"
+        type="text"
+        v-model="legalTownshipInput"
+        :errors="errors['legal_township']"
+        :loaded="fieldsLoaded['legal_township']"></form-input>
+      <form-input
+        id="legalRange"
+        label="Range"
+        type="text"
+        v-model="legalRangeInput"
+        :errors="errors['legal_range']"
+        :loaded="fieldsLoaded['legal_range']"></form-input>
+      <form-input
+        id="landDistrict"
+        label="Land District"
+        select
+        :options="districtCodes"
+        text-field="name"
+        value-field="land_district_code"
+        v-model="landDistrictInput"
+        :errors="errors['land_district']"
+        :loaded="fieldsLoaded['land_district']"></form-input>
+    </responsive-grid>
     <div class="flex">
       <p class="mb-1">OR</p>
     </div>
@@ -166,22 +146,20 @@ Licensed under the Apache License, Version 2.0 (the "License");
           :loaded="fieldsLoaded['legal_pid']"></form-input>
       </div>
     </div>
-    <b-row>
-      <b-col cols="12" md="8">
-        <form-input
-          id="wellLocationDescription"
-          label="Description of Well Location"
-          type="text"
-          v-model="wellLocationDescriptionInput"
-          :errors="errors['well_location_description']"
-          :loaded="fieldsLoaded['well_location_description']"></form-input>
-      </b-col>
-    </b-row>
+    <responsive-grid :cols="12" :md="8">
+      <form-input
+        id="wellLocationDescription"
+        label="Description of Well Location"
+        type="text"
+        v-model="wellLocationDescriptionInput"
+        :errors="errors['well_location_description']"
+        :loaded="fieldsLoaded['well_location_description']"></form-input>
+    </responsive-grid>
 
     <!-- Error message when location not given -->
-    <b-alert class="mt-4" variant="danger" :show="errors.well_location_section && errors.well_location_section.length > 0">
+    <Message class="mt-4" severity="error" v-if="errors.well_location_section && errors.well_location_section.length > 0">
       Must provide well location as either an address, legal description, or parcel identifier.
-    </b-alert>
+    </Message>
   </form-subsection>
 </template>
 <script>
@@ -189,6 +167,7 @@ import { useSubmissionStore } from '@/stores/submission'
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import ApiService from '../../../common/services/ApiService'
 import { TOOLTIP_TEXT } from '@/common/constants'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
@@ -234,7 +213,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/Location.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Location.vue
@@ -32,8 +32,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           v-on:blur="showList(false)"
           :errors="errors['street_address']"
           :loaded="fieldsLoaded['street_address']"
-          :disabled="sameAsOwnerAddress"
-        ></form-input>
+          :disabled="sameAsOwnerAddress"></form-input>
           <!-- Display the address suggestions -->
         <div v-if="addressSuggestions.length > 0" class="address-suggestions list-group list-group-flush border" id="location-address-suggestions-list">
           <div v-for="(suggestion, index) in addressSuggestions" :key="index">
@@ -49,15 +48,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <div class="grid grid-cols-12">
       <div class="col-span-12 md:col-span-5">
         <form-input
-            id="wellCity"
-            label="City"
-            type="text"
-            v-model="cityInput"
-            :errors="errors['city']"
-            :loaded="fieldsLoaded['city']"
-            :disabled="sameAsOwnerAddress"
-            >
-        </form-input>
+          id="wellCity"
+          label="City"
+          type="text"
+          v-model="cityInput"
+          :errors="errors['city']"
+          :loaded="fieldsLoaded['city']"
+          :disabled="sameAsOwnerAddress"></form-input>
       </div>
     </div>
     <div class="flex">
@@ -78,128 +75,106 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <div class="grid grid-cols-12">
       <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
-            id="legalLot"
-            label="Lot"
-            type="text"
-            v-model="legalLotInput"
-            :errors="errors['legal_lot']"
-            :loaded="fieldsLoaded['legal_lot']"
-            >
-        </form-input>
+          id="legalLot"
+          label="Lot"
+          type="text"
+          v-model="legalLotInput"
+          :errors="errors['legal_lot']"
+          :loaded="fieldsLoaded['legal_lot']"></form-input>
       </div>
       <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
-            id="legalPlan"
-            label="Plan"
-            type="text"
-            v-model="legalPlanInput"
-            :errors="errors['legal_plan']"
-            :loaded="fieldsLoaded['legal_plan']"
-            >
-        </form-input>
+          id="legalPlan"
+          label="Plan"
+          type="text"
+          v-model="legalPlanInput"
+          :errors="errors['legal_plan']"
+          :loaded="fieldsLoaded['legal_plan']"></form-input>
       </div>
       <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
-            id="legalDistrictLot"
-            label="District Lot"
-            type="text"
-            v-model="legalDistrictLotInput"
-            :errors="errors['legal_district_lot']"
-            :loaded="fieldsLoaded['legal_district_lot']"
-            >
-        </form-input>
+          id="legalDistrictLot"
+          label="District Lot"
+          type="text"
+          v-model="legalDistrictLotInput"
+          :errors="errors['legal_district_lot']"
+          :loaded="fieldsLoaded['legal_district_lot']"></form-input>
       </div>
       <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
-            id="legalBlock"
-            label="Block"
-            type="text"
-            v-model="legalBlockInput"
-            :errors="errors['legal_block']"
-            :loaded="fieldsLoaded['legal_block']"
-            >
-        </form-input>
+          id="legalBlock"
+          label="Block"
+          type="text"
+          v-model="legalBlockInput"
+          :errors="errors['legal_block']"
+          :loaded="fieldsLoaded['legal_block']"></form-input>
       </div>
     </div>
     <div class="grid grid-cols-12">
       <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
-            id="legalSection"
-            label="Section"
-            type="text"
-            v-model="legalSectionInput"
-            :errors="errors['legal_section']"
-            :loaded="fieldsLoaded['legal_section']"
-            >
-        </form-input>
+          id="legalSection"
+          label="Section"
+          type="text"
+          v-model="legalSectionInput"
+          :errors="errors['legal_section']"
+          :loaded="fieldsLoaded['legal_section']"></form-input>
       </div>
       <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
-            id="legalTownship"
-            label="Township"
-            type="text"
-            v-model="legalTownshipInput"
-            :errors="errors['legal_township']"
-            :loaded="fieldsLoaded['legal_township']"
-            >
-        </form-input>
+          id="legalTownship"
+          label="Township"
+          type="text"
+          v-model="legalTownshipInput"
+          :errors="errors['legal_township']"
+          :loaded="fieldsLoaded['legal_township']"></form-input>
       </div>
       <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
-            id="legalRange"
-            label="Range"
-            type="text"
-            v-model="legalRangeInput"
-            :errors="errors['legal_range']"
-            :loaded="fieldsLoaded['legal_range']"
-            >
-        </form-input>
+          id="legalRange"
+          label="Range"
+          type="text"
+          v-model="legalRangeInput"
+          :errors="errors['legal_range']"
+          :loaded="fieldsLoaded['legal_range']"></form-input>
       </div>
       <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <form-input
-            id="landDistrict"
-            label="Land District"
-            select
-            :options="districtCodes"
-            text-field="name"
-            value-field="land_district_code"
-            v-model="landDistrictInput"
-            :errors="errors['land_district']"
-            :loaded="fieldsLoaded['land_district']"
-            >
-        </form-input>
+          id="landDistrict"
+          label="Land District"
+          select
+          :options="districtCodes"
+          text-field="name"
+          value-field="land_district_code"
+          v-model="landDistrictInput"
+          :errors="errors['land_district']"
+          :loaded="fieldsLoaded['land_district']"></form-input>
       </div>
     </div>
     <div class="flex">
-      <div>
-        <p class="mb-1">OR</p>
-      </div>
+      <p class="mb-1">OR</p>
     </div>
     <div class="grid grid-cols-12">
       <div class="col-span-12 md:col-span-6 lg:col-span-3">
         <p class="font-weight-bold">3) Parcel Identifier (PID)</p>
         <form-input
-            id="legalPID"
-            type="text"
-            hint="*Input a 9 digit number (including leading zeroes, if necessary)"
-            v-model="legalPIDInput"
-            :errors="errors['legal_pid']"
-            :loaded="fieldsLoaded['legal_pid']"
-            >
-        </form-input>
+          id="legalPID"
+          type="text"
+          hint="*Input a 9 digit number (including leading zeroes, if necessary)"
+          v-model="legalPIDInput"
+          :errors="errors['legal_pid']"
+          :loaded="fieldsLoaded['legal_pid']"></form-input>
       </div>
     </div>
     <b-row>
       <b-col cols="12" md="8">
         <form-input
-            id="wellLocationDescription"
-            label="Description of Well Location"
-            type="text"
-            v-model="wellLocationDescriptionInput"
-            :errors="errors['well_location_description']"
-            :loaded="fieldsLoaded['well_location_description']"
-            >
-        </form-input>
+          id="wellLocationDescription"
+          label="Description of Well Location"
+          type="text"
+          v-model="wellLocationDescriptionInput"
+          :errors="errors['well_location_description']"
+          :loaded="fieldsLoaded['well_location_description']"></form-input>
       </b-col>
     </b-row>
 

--- a/app/frontend/src/submissions/components/SubmissionForm/MethodOfDrilling.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/MethodOfDrilling.vue
@@ -12,83 +12,73 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-    <fieldset>
-      <b-row>
-        <b-col cols="12" lg="6">
-          <legend :id="id">Method of Drilling</legend>
-        </b-col>
-        <b-col cols="12" lg="6">
-          <div class="float-right">
-            <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-            <back-to-top-link v-if="isStaffEdit"/>
-          </div>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" md="6">
+  <form-subsection title="Method of Drilling" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6">
+        <form-input
+          id="groundElevation"
+          label="Ground Elevation"
+          hint="ft (asl)"
+          v-model.number="groundElevationInput"
+          type="number"
+          :errors="errors['ground_elevation']"
+          :loaded="fieldsLoaded['ground_elevation']"></form-input>
+      </div>
+      <div class="col-span-12 md:col-span-6">
+        <b-form-group label="Method for Determining Ground Elevation">
           <form-input
-            id="groundElevation"
-            label="Ground Elevation"
-            hint="ft (asl)"
-            v-model.number="groundElevationInput"
-            type="number"
-            :errors="errors['ground_elevation']"
-            :loaded="fieldsLoaded['ground_elevation']"></form-input>
-        </b-col>
-        <b-col cols="12" md="6">
-          <b-form-group label="Method for Determining Ground Elevation">
-            <form-input
-              select
-              id="groundElevationMethod"
-              v-model="groundElevationMethodInput"
-              value-field="ground_elevation_method_code"
-              text-field="description"
-              placeholder="Select Method"
-              :options="method_codes()"
-              :errors="errors['ground_elevation_method']"
-              :loaded="fieldsLoaded['ground_elevation_method']">
-            </form-input>
-          </b-form-group>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" md="6">
+            select
+            id="groundElevationMethod"
+            v-model="groundElevationMethodInput"
+            value-field="ground_elevation_method_code"
+            text-field="description"
+            placeholder="Select Method"
+            :options="method_codes()"
+            :errors="errors['ground_elevation_method']"
+            :loaded="fieldsLoaded['ground_elevation_method']">
+          </form-input>
+        </b-form-group>
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6">
+        <form-input
+            id="drillingMethod"
+            :label="drillingMethodsLabel"
+            select
+            :options="codes?.drilling_methods"
+            value-field="drilling_method_code"
+            text-field="description"
+            hint="Select one or more drilling methods. Hold the Ctrl (PC) or Command (Mac) key to select more than one option."
+            v-model="drillingMethodInput"
+            :errors="errors['drilling_methods']"
+            :loaded="fieldsLoaded['drilling_methods']"
+        ></form-input>
+      </div>
+      <div>
+        <b-form-group label="Orientation of Well">
           <form-input
-              id="drillingMethod"
-              :label="drillingMethodsLabel"
-              select
-              :options="codes?.drilling_methods"
-              value-field="drilling_method_code"
-              text-field="description"
-              hint="Select one or more drilling methods. Hold the Ctrl (PC) or Command (Mac) key to select more than one option."
-              v-model="drillingMethodInput"
-              :errors="errors['drilling_methods']"
-              :loaded="fieldsLoaded['drilling_methods']"
-          ></form-input>
-        </b-col>
-        <b-col>
-          <b-form-group label="Orientation of Well">
-            <form-input
-              select
-              id="wellOrientationStatus"
-              v-model="wellOrientationStatusInput"
-              value-field="well_orientation_code"
-              text-field="description"
-              placeholder="Select Orientation"
-              :options="codes?.well_orientation_codes"
-              :errors="errors['well_orientation_status']"
-              :loaded="fieldsLoaded['well_orientation_status']">
-            </form-input>
-          </b-form-group>
-        </b-col>
-      </b-row>
-    </fieldset>
+            select
+            id="wellOrientationStatus"
+            v-model="wellOrientationStatusInput"
+            value-field="well_orientation_code"
+            text-field="description"
+            placeholder="Select Orientation"
+            :options="codes?.well_orientation_codes"
+            :errors="errors['well_orientation_status']"
+            :loaded="fieldsLoaded['well_orientation_status']">
+          </form-input>
+        </b-form-group>
+      </div>
+    </div>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   name: 'MethodOfDrilling',
@@ -120,6 +110,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/MethodOfDrilling.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/MethodOfDrilling.vue
@@ -13,59 +13,49 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Method of Drilling" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6">
-        <form-input
-          id="groundElevation"
-          label="Ground Elevation"
-          hint="ft (asl)"
-          v-model.number="groundElevationInput"
-          type="number"
-          :errors="errors['ground_elevation']"
-          :loaded="fieldsLoaded['ground_elevation']"/>
-      </div>
-      <div class="col-span-12 md:col-span-6">
-        <form-input
-          select
-          id="groundElevationMethod"
-          label="Method for Determining Ground Elevation"
-          v-model="groundElevationMethodInput"
-          value-field="ground_elevation_method_code"
-          text-field="description"
-          placeholder="Select Method"
-          :options="method_codes()"
-          :errors="errors['ground_elevation_method']"
-          :loaded="fieldsLoaded['ground_elevation_method']"/>
-      </div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6">
-        <form-input
-          id="drillingMethod"
-          :label="drillingMethodsLabel"
-          select
-          :options="codes?.drilling_methods"
-          value-field="drilling_method_code"
-          text-field="description"
-          hint="Select one or more drilling methods. Hold the Ctrl (PC) or Command (Mac) key to select more than one option."
-          v-model="drillingMethodInput"
-          :errors="errors['drilling_methods']"
-          :loaded="fieldsLoaded['drilling_methods']"/>
-      </div>
-      <div>
-        <form-input
-          select
-          id="wellOrientationStatus"
-          label="Orientation of Well"
-          v-model="wellOrientationStatusInput"
-          value-field="well_orientation_code"
-          text-field="description"
-          placeholder="Select Orientation"
-          :options="codes?.well_orientation_codes"
-          :errors="errors['well_orientation_status']"
-          :loaded="fieldsLoaded['well_orientation_status']"/>
-      </div>
-    </div>
+    <responsive-grid :cols="12" :md="6">
+      <form-input
+        id="groundElevation"
+        label="Ground Elevation"
+        hint="ft (asl)"
+        v-model.number="groundElevationInput"
+        type="number"
+        :errors="errors['ground_elevation']"
+        :loaded="fieldsLoaded['ground_elevation']"/>
+      <form-input
+        select
+        id="groundElevationMethod"
+        label="Method for Determining Ground Elevation"
+        v-model="groundElevationMethodInput"
+        value-field="ground_elevation_method_code"
+        text-field="description"
+        placeholder="Select Method"
+        :options="method_codes()"
+        :errors="errors['ground_elevation_method']"
+        :loaded="fieldsLoaded['ground_elevation_method']"/>
+      <form-input
+        id="drillingMethod"
+        :label="drillingMethodsLabel"
+        select
+        :options="codes?.drilling_methods"
+        value-field="drilling_method_code"
+        text-field="description"
+        hint="Select one or more drilling methods. Hold the Ctrl (PC) or Command (Mac) key to select more than one option."
+        v-model="drillingMethodInput"
+        :errors="errors['drilling_methods']"
+        :loaded="fieldsLoaded['drilling_methods']"/>
+      <form-input
+        select
+        id="wellOrientationStatus"
+        label="Orientation of Well"
+        v-model="wellOrientationStatusInput"
+        value-field="well_orientation_code"
+        text-field="description"
+        placeholder="Select Orientation"
+        :options="codes?.well_orientation_codes"
+        :errors="errors['well_orientation_status']"
+        :loaded="fieldsLoaded['well_orientation_status']"/>
+    </responsive-grid>
   </form-subsection>
 </template>
 
@@ -73,6 +63,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
@@ -107,7 +98,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/MethodOfDrilling.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/MethodOfDrilling.vue
@@ -22,7 +22,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           v-model.number="groundElevationInput"
           type="number"
           :errors="errors['ground_elevation']"
-          :loaded="fieldsLoaded['ground_elevation']"></form-input>
+          :loaded="fieldsLoaded['ground_elevation']"/>
       </div>
       <div class="col-span-12 md:col-span-6">
         <form-input
@@ -35,7 +35,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           placeholder="Select Method"
           :options="method_codes()"
           :errors="errors['ground_elevation_method']"
-          :loaded="fieldsLoaded['ground_elevation_method']"></form-input>
+          :loaded="fieldsLoaded['ground_elevation_method']"/>
       </div>
     </div>
     <div class="grid grid-cols-12">
@@ -50,7 +50,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           hint="Select one or more drilling methods. Hold the Ctrl (PC) or Command (Mac) key to select more than one option."
           v-model="drillingMethodInput"
           :errors="errors['drilling_methods']"
-          :loaded="fieldsLoaded['drilling_methods']"></form-input>
+          :loaded="fieldsLoaded['drilling_methods']"/>
       </div>
       <div>
         <form-input
@@ -63,7 +63,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           placeholder="Select Orientation"
           :options="codes?.well_orientation_codes"
           :errors="errors['well_orientation_status']"
-          :loaded="fieldsLoaded['well_orientation_status']"></form-input>
+          :loaded="fieldsLoaded['well_orientation_status']"/>
       </div>
     </div>
   </form-subsection>

--- a/app/frontend/src/submissions/components/SubmissionForm/MethodOfDrilling.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/MethodOfDrilling.vue
@@ -25,50 +25,45 @@ Licensed under the Apache License, Version 2.0 (the "License");
           :loaded="fieldsLoaded['ground_elevation']"></form-input>
       </div>
       <div class="col-span-12 md:col-span-6">
-        <b-form-group label="Method for Determining Ground Elevation">
-          <form-input
-            select
-            id="groundElevationMethod"
-            v-model="groundElevationMethodInput"
-            value-field="ground_elevation_method_code"
-            text-field="description"
-            placeholder="Select Method"
-            :options="method_codes()"
-            :errors="errors['ground_elevation_method']"
-            :loaded="fieldsLoaded['ground_elevation_method']">
-          </form-input>
-        </b-form-group>
+        <form-input
+          select
+          id="groundElevationMethod"
+          label="Method for Determining Ground Elevation"
+          v-model="groundElevationMethodInput"
+          value-field="ground_elevation_method_code"
+          text-field="description"
+          placeholder="Select Method"
+          :options="method_codes()"
+          :errors="errors['ground_elevation_method']"
+          :loaded="fieldsLoaded['ground_elevation_method']"></form-input>
       </div>
     </div>
     <div class="grid grid-cols-12">
       <div class="col-span-12 md:col-span-6">
         <form-input
-            id="drillingMethod"
-            :label="drillingMethodsLabel"
-            select
-            :options="codes?.drilling_methods"
-            value-field="drilling_method_code"
-            text-field="description"
-            hint="Select one or more drilling methods. Hold the Ctrl (PC) or Command (Mac) key to select more than one option."
-            v-model="drillingMethodInput"
-            :errors="errors['drilling_methods']"
-            :loaded="fieldsLoaded['drilling_methods']"
-        ></form-input>
+          id="drillingMethod"
+          :label="drillingMethodsLabel"
+          select
+          :options="codes?.drilling_methods"
+          value-field="drilling_method_code"
+          text-field="description"
+          hint="Select one or more drilling methods. Hold the Ctrl (PC) or Command (Mac) key to select more than one option."
+          v-model="drillingMethodInput"
+          :errors="errors['drilling_methods']"
+          :loaded="fieldsLoaded['drilling_methods']"></form-input>
       </div>
       <div>
-        <b-form-group label="Orientation of Well">
-          <form-input
-            select
-            id="wellOrientationStatus"
-            v-model="wellOrientationStatusInput"
-            value-field="well_orientation_code"
-            text-field="description"
-            placeholder="Select Orientation"
-            :options="codes?.well_orientation_codes"
-            :errors="errors['well_orientation_status']"
-            :loaded="fieldsLoaded['well_orientation_status']">
-          </form-input>
-        </b-form-group>
+        <form-input
+          select
+          id="wellOrientationStatus"
+          label="Orientation of Well"
+          v-model="wellOrientationStatusInput"
+          value-field="well_orientation_code"
+          text-field="description"
+          placeholder="Select Orientation"
+          :options="codes?.well_orientation_codes"
+          :errors="errors['well_orientation_status']"
+          :loaded="fieldsLoaded['well_orientation_status']"></form-input>
       </div>
     </div>
   </form-subsection>

--- a/app/frontend/src/submissions/components/SubmissionForm/ObservationWellInfo.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ObservationWellInfo.vue
@@ -19,7 +19,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         label="Observation Well Number"
         v-model="obsWellNumberInput"
         :errors="errors['observation_well_number']"
-        :loaded="fieldsLoaded['observation_well_number']"></form-input>
+        :loaded="fieldsLoaded['observation_well_number']"/>
       <form-input
         id="obsWellStatus"
         label="Observation Well Status"
@@ -30,7 +30,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         text-field="obs_well_status_code"
         value-field="obs_well_status_code"
         placeholder="Select status"
-        v-model="obsWellStatusInput"></form-input>
+        v-model="obsWellStatusInput"/>
     </responsive-grid>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/ObservationWellInfo.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ObservationWellInfo.vue
@@ -12,18 +12,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Observation Well Information</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
+  <form-subsection title="Observation Well Information" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <b-row>
       <b-col cols="12" md="3" xl="2">
         <form-input
@@ -49,13 +38,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
         ></form-input>
       </b-col>
     </b-row>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -84,6 +74,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   fields: {
     commentsInput: 'comments',

--- a/app/frontend/src/submissions/components/SubmissionForm/ObservationWellInfo.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/ObservationWellInfo.vue
@@ -13,31 +13,25 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Observation Well Information" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <b-row>
-      <b-col cols="12" md="3" xl="2">
-        <form-input
-          id="obsWellNumber"
-          label="Observation Well Number"
-          v-model="obsWellNumberInput"
-          :errors="errors['observation_well_number']"
-          :loaded="fieldsLoaded['observation_well_number']"
-        ></form-input>
-      </b-col>
-      <b-col cols="12" md="3" xl="2">
-        <form-input
-          id="obsWellStatus"
-          label="Observation Well Status"
-          select
-          :options="codes?.observation_well_status"
-          :errors="errors['observation_well_status']"
-          :loaded="fieldsLoaded['observation_well_status']"
-          text-field="obs_well_status_code"
-          value-field="obs_well_status_code"
-          placeholder="Select status"
-          v-model="obsWellStatusInput"
-        ></form-input>
-      </b-col>
-    </b-row>
+    <responsive-grid :cols="12" :md="3" :xl="2">
+      <form-input
+        id="obsWellNumber"
+        label="Observation Well Number"
+        v-model="obsWellNumberInput"
+        :errors="errors['observation_well_number']"
+        :loaded="fieldsLoaded['observation_well_number']"></form-input>
+      <form-input
+        id="obsWellStatus"
+        label="Observation Well Status"
+        select
+        :options="codes?.observation_well_status"
+        :errors="errors['observation_well_status']"
+        :loaded="fieldsLoaded['observation_well_status']"
+        text-field="obs_well_status_code"
+        value-field="obs_well_status_code"
+        placeholder="Select status"
+        v-model="obsWellStatusInput"></form-input>
+    </responsive-grid>
   </form-subsection>
 </template>
 
@@ -45,6 +39,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
@@ -76,7 +71,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   fields: {
     commentsInput: 'comments',

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -20,8 +20,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           label="Well Owner Name *"
           v-model="ownerFullNameInput"
           :errors="errors['owner_full_name']"
-          :loaded="fieldsLoaded['owner_full_name']"
-        ></form-input>
+          :loaded="fieldsLoaded['owner_full_name']"></form-input>
       </div>
       <div class="col-span-12 md:col-span-6">
         <form-input
@@ -32,8 +31,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           v-on:focus="showList(true)"
           v-on:blur="showList(false)"
           :errors="errors['owner_mailing_address']"
-          :loaded="fieldsLoaded['owner_mailing_address']">
-        </form-input>
+          :loaded="fieldsLoaded['owner_mailing_address']"></form-input>
         <!-- Display the address suggestions -->
         <div v-if="addressSuggestions.length > 0" class="address-suggestions list-group list-group-flush border" id="owner-address-suggestions-list">
           <div v-for="(suggestion, index) in addressSuggestions" :key="index">
@@ -46,58 +44,44 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </div>
       </div>
     </div>
-    <b-row>
-      <b-col cols="12" md="4">
-        <form-input id="ownerCity" label="City *" v-model="ownerCityInput" :errors="errors['owner_city']" :loaded="fieldsLoaded['owner_city']" required></form-input>
-      </b-col>
-      <b-col cols="6" md="4">
-        <b-form-group
-            id="ownerProvince"
-            label="Province or State *"
-            aria-describedby="ownerProvinceInvalidFeedback">
-          <b-form-select
-              v-model="ownerProvinceInput"
-              :options="codes?.province_codes"
-              value-field="province_state_code"
-              text-field="description"
-              :state="errors['owner_province_state'] ? false : null">
-            <template v-slot:first>
-              <option :value="null" disabled>Select a province</option>
-            </template>
-          </b-form-select>
-          <b-form-invalid-feedback id="ownerProvinceInvalidFeedback">
-            <div v-for="(error, index) in errors['owner_province_state']" :key="`ProvinceInput error ${index}`">
-              {{ error }}
-            </div>
-          </b-form-invalid-feedback>
-        </b-form-group>
-      </b-col>
-      <b-col cols="6" md="4" xl="3">
-        <form-input id="ownerPostalCode" label="Postal Code *" v-model="ownerPostalCodeInput" :errors="errors['owner_postal_code']" :loaded="fieldsLoaded['owner_postal_code']"></form-input>
-      </b-col>
-    </b-row>
-    <b-row v-if="isStaffEdit">
-      <b-col cols="12" md="6" lg="4" xl="4">
-        <form-input id="ownerEmail" label="Email Address" v-model="ownerEmailInput" :errors="errors['owner_email']" :loaded="fieldsLoaded['owner_email']"></form-input>
-      </b-col>
-      <b-col cols="12" md="6" lg="4" xl="3">
-        <InputMask
-            id="ownerTel"
-            label="Telephone"
-            v-model="ownerTelInput"
-            :errors="errors['owner_tel']"
-            :loaded="fieldsLoaded['owner_tel']"
-            mask="(999) 999-9999"
-            >
-        </InputMask>
-      </b-col>
-    </b-row>
+    <responsive-grid :cols="[12, 6, 6]" :md="4" :xl="[undefined, undefined, 3]">
+      <form-input id="ownerCity" label="City *" v-model="ownerCityInput" :errors="errors['owner_city']" :loaded="fieldsLoaded['owner_city']" required></form-input>
+      <b-form-group
+        id="ownerProvince"
+        label="Province or State *"
+        aria-describedby="ownerProvinceInvalidFeedback">
+        <Dropdown
+          v-model="ownerProvinceInput"
+          :options="codes?.province_codes"
+          optionValue="province_state_code"
+          optionLabel="description"
+          :invalid="errors['owner_province_state'] ? true : false"
+          placeholder="Select a province"/>
+        <b-form-invalid-feedback id="ownerProvinceInvalidFeedback">
+          <div v-for="(error, index) in errors['owner_province_state']" :key="`ProvinceInput error ${index}`">
+            {{ error }}
+          </div>
+        </b-form-invalid-feedback>
+      </b-form-group>
+      <form-input id="ownerPostalCode" label="Postal Code *" v-model="ownerPostalCodeInput" :errors="errors['owner_postal_code']" :loaded="fieldsLoaded['owner_postal_code']"></form-input>
+    </responsive-grid>
+    <responsive-grid v-if="isStaffEdit" :cols="12" :md="6" :lg="4" :xl="[4, 3]">
+      <form-input id="ownerEmail" label="Email Address" v-model="ownerEmailInput" :errors="errors['owner_email']" :loaded="fieldsLoaded['owner_email']"></form-input>
+      <InputMask
+        id="ownerTel"
+        label="Telephone"
+        v-model="ownerTelInput"
+        :errors="errors['owner_tel']"
+        :loaded="fieldsLoaded['owner_tel']"
+        mask="(999) 999-9999"/>
+    </responsive-grid>
   </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import ApiService from '../../../common/services/ApiService'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
@@ -133,7 +117,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   fields: {
     ownerFullNameInput: 'ownerFullName',

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -56,11 +56,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
           optionLabel="description"
           :invalid="errors['owner_province_state'] ? true : false"
           placeholder="Select a province"/>
-        <b-form-invalid-feedback id="ownerProvinceInvalidFeedback">
-          <div v-for="(error, index) in errors['owner_province_state']" :key="`ProvinceInput error ${index}`">
+        <div id="ownerProvinceInvalidFeedback">
+          <div v-for="(error, index) in errors['owner_province_state']" class="mt-1 text-sm text-red-600" :key="`ProvinceInput error ${index}`">
             {{ error }}
           </div>
-        </b-form-invalid-feedback>
+        </div>
       </div>
       <form-input id="ownerPostalCode" label="Postal Code *" v-model="ownerPostalCodeInput" :errors="errors['owner_postal_code']" :loaded="fieldsLoaded['owner_postal_code']"/>
     </responsive-grid>

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -12,21 +12,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Well Owner</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
-
-    <b-row>
-      <b-col cols="12" md="6">
+  <form-subsection title="Well Owner" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6">
         <form-input
           id="ownerFullName"
           label="Well Owner Name *"
@@ -34,8 +22,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           :errors="errors['owner_full_name']"
           :loaded="fieldsLoaded['owner_full_name']"
         ></form-input>
-      </b-col>
-      <b-col cols="12" md="6">
+      </div>
+      <div class="col-span-12 md:col-span-6">
         <form-input
           id="ownerMailingAddress"
           label="Owner Mailing Address *"
@@ -56,8 +44,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <div v-if="isLoadingSuggestions" class="loading-indicator">
           Loading...
         </div>
-      </b-col>
-    </b-row>
+      </div>
+    </div>
     <b-row>
       <b-col cols="12" md="4">
         <form-input id="ownerCity" label="City *" v-model="ownerCityInput" :errors="errors['owner_city']" :loaded="fieldsLoaded['owner_city']" required></form-input>
@@ -104,13 +92,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </InputMask>
       </b-col>
     </b-row>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import ApiService from '../../../common/services/ApiService'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -142,6 +131,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   fields: {
     ownerFullNameInput: 'ownerFullName',

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -46,11 +46,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
     </div>
     <responsive-grid :cols="[12, 6, 6]" :md="4" :xl="[undefined, undefined, 3]">
       <form-input id="ownerCity" label="City *" v-model="ownerCityInput" :errors="errors['owner_city']" :loaded="fieldsLoaded['owner_city']" required/>
-      <b-form-group
-        id="ownerProvince"
-        label="Province or State *"
-        aria-describedby="ownerProvinceInvalidFeedback">
+      <div class="flex flex-col gap-2" aria-describedby="ownerProvinceInvalidFeedback">
+        <label for="ownerProvince">Province or State *</label>
         <Select
+          id="ownerProvince"
           v-model="ownerProvinceInput"
           :options="codes?.province_codes"
           optionValue="province_state_code"
@@ -62,7 +61,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             {{ error }}
           </div>
         </b-form-invalid-feedback>
-      </b-form-group>
+      </div>
       <form-input id="ownerPostalCode" label="Postal Code *" v-model="ownerPostalCodeInput" :errors="errors['owner_postal_code']" :loaded="fieldsLoaded['owner_postal_code']"/>
     </responsive-grid>
     <responsive-grid v-if="isStaffEdit" :cols="12" :md="6" :lg="4" :xl="[4, 3]">

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -20,7 +20,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           label="Well Owner Name *"
           v-model="ownerFullNameInput"
           :errors="errors['owner_full_name']"
-          :loaded="fieldsLoaded['owner_full_name']"></form-input>
+          :loaded="fieldsLoaded['owner_full_name']"/>
       </div>
       <div class="col-span-12 md:col-span-6">
         <form-input
@@ -31,7 +31,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           v-on:focus="showList(true)"
           v-on:blur="showList(false)"
           :errors="errors['owner_mailing_address']"
-          :loaded="fieldsLoaded['owner_mailing_address']"></form-input>
+          :loaded="fieldsLoaded['owner_mailing_address']"/>
         <!-- Display the address suggestions -->
         <div v-if="addressSuggestions.length > 0" class="address-suggestions list-group list-group-flush border" id="owner-address-suggestions-list">
           <div v-for="(suggestion, index) in addressSuggestions" :key="index">
@@ -45,12 +45,12 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </div>
     </div>
     <responsive-grid :cols="[12, 6, 6]" :md="4" :xl="[undefined, undefined, 3]">
-      <form-input id="ownerCity" label="City *" v-model="ownerCityInput" :errors="errors['owner_city']" :loaded="fieldsLoaded['owner_city']" required></form-input>
+      <form-input id="ownerCity" label="City *" v-model="ownerCityInput" :errors="errors['owner_city']" :loaded="fieldsLoaded['owner_city']" required/>
       <b-form-group
         id="ownerProvince"
         label="Province or State *"
         aria-describedby="ownerProvinceInvalidFeedback">
-        <Dropdown
+        <Select
           v-model="ownerProvinceInput"
           :options="codes?.province_codes"
           optionValue="province_state_code"
@@ -63,17 +63,18 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </div>
         </b-form-invalid-feedback>
       </b-form-group>
-      <form-input id="ownerPostalCode" label="Postal Code *" v-model="ownerPostalCodeInput" :errors="errors['owner_postal_code']" :loaded="fieldsLoaded['owner_postal_code']"></form-input>
+      <form-input id="ownerPostalCode" label="Postal Code *" v-model="ownerPostalCodeInput" :errors="errors['owner_postal_code']" :loaded="fieldsLoaded['owner_postal_code']"/>
     </responsive-grid>
     <responsive-grid v-if="isStaffEdit" :cols="12" :md="6" :lg="4" :xl="[4, 3]">
-      <form-input id="ownerEmail" label="Email Address" v-model="ownerEmailInput" :errors="errors['owner_email']" :loaded="fieldsLoaded['owner_email']"></form-input>
-      <InputMask
+      <form-input id="ownerEmail" label="Email Address" v-model="ownerEmailInput" :errors="errors['owner_email']" :loaded="fieldsLoaded['owner_email']"/>
+      <form-input
         id="ownerTel"
         label="Telephone"
         v-model="ownerTelInput"
         :errors="errors['owner_tel']"
         :loaded="fieldsLoaded['owner_tel']"
-        mask="(999) 999-9999"/>
+        :formatter="formatTel"
+        lazy-formatter/>
     </responsive-grid>
   </form-subsection>
 </template>
@@ -229,6 +230,10 @@ export default {
       if (document.getElementById('owner-address-suggestions-list')) {
         document.getElementById('owner-address-suggestions-list').style.display = show ? 'block' : 'none'
       }
+    },
+
+    formatTel (value) {
+      return value.replace(/[^0-9]/g, '').replace(/(\d{3})(\d{3})(\d{4})/, '($1) $2-$3')
     }
   }
 }

--- a/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Owner.vue
@@ -79,6 +79,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 </template>
 
 <script>
+import querystring from 'querystring'
 import { useSubmissionStore } from '@/stores/submission'
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
@@ -169,7 +170,6 @@ export default {
         addressString: this.ownerAddressInput
       }
 
-      const querystring = require('querystring')
       const searchParams = querystring.stringify(params)
       try {
         ApiService.getAddresses(searchParams).then((response) => {

--- a/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
@@ -27,10 +27,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <label for="checkbox1">Person Responsible is the same as the Person Who Completed the Work</label>
       </div>
       <responsive-grid :cols="12" :md="12" :lg="6">
-        <b-form-group
-          label="Person Responsible for Work"
-          aria-describedby="personResponsibleInvalidFeedback"
-          :state="false">
+        <div class="flex flex-col gap-2" aria-describedby="personResponsibleInvalidFeedback">
+          <label>Person Responsible for Work</label>
           <v-select
             :class="errors.person_responsible?'border border-danger dropdown-error-border':''"
             :disabled="persons === null"
@@ -43,17 +41,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
             ref="personResponsible"
             @search:blur="handleSearchBlur(personOptions, $refs.personResponsible, 'personResponsibleInput')">
             <template v-slot:no-options>
-                Type to search registry...
+              Type to search registry...
             </template>
             <template v-slot:cell(selected-option)="option">
-              <div>
-                {{ personNameReg (option) }}
-              </div>
+              <div>{{ personNameReg (option) }}</div>
             </template>
             <template v-slot:cell(option)="option">
-              <div>
-                {{ personNameReg (option) }}
-              </div>
+              <div>{{ personNameReg (option) }}</div>
             </template>
           </v-select>
           <!-- TODO: Copy over the bootstrap form-text class to one of the css files -->
@@ -65,7 +59,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
               {{ error }}
             </div>
           </div>
-        </b-form-group>
+        </div>
         <form-input
           id="drillerName"
           label="Person Who Completed the Work"
@@ -89,7 +83,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             ref="companyOfPersonResponsible"
             @search:blur="handleSearchBlur(companyOfPersonResponsibleOptions, $refs.companyOfPersonResponsible, 'companyOfPersonResponsibleInput')">
             <template v-slot:no-options>
-                Search by company name
+              Search by company name
             </template>
           </v-select>
           <small id="companyOfPersonResponsibleSelectHint" class="form-text text-muted">

--- a/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
@@ -13,19 +13,15 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
     <fieldset>
-      <b-row>
-        <b-col xs="12">
-          <legend :id="id">
-            Person Responsible for Work
-          </legend>
-        </b-col>
-        <b-col xs="12">
-          <div class="float-right">
-            <Button v-if="isStaffEdit" label="Save" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
-            <back-to-top-link v-if="isStaffEdit"/>
-          </div>
-        </b-col>
-      </b-row>
+      <responsive-grid :xs="12">
+        <legend :id="id">
+          Person Responsible for Work
+        </legend>
+        <div class="float-right">
+          <Button v-if="isStaffEdit" label="Save" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
+          <back-to-top-link v-if="isStaffEdit"/>
+        </div>
+      </responsive-grid>
       <b-form-checkbox id="checkbox1"
         v-model="drillerSameAsPersonResponsibleInput"
         :value="true"
@@ -33,112 +29,99 @@ Licensed under the Apache License, Version 2.0 (the "License");
       >
       <p>Person Responsible is the same as the Person Who Completed the Work</p>
       </b-form-checkbox>
-      <b-row>
-        <b-col cols="12" md="12" lg="6">
-          <b-form-group
-              label="Person Responsible for Work"
-              aria-describedby="personResponsibleInvalidFeedback"
-              :state="false">
-            <v-select
-                :class="errors.person_responsible?'border border-danger dropdown-error-border':''"
-                :disabled="persons === null"
-                id="personResponsibleSelect"
-                :filterable="false"
-                :options="personOptions"
-                label="name"
-                v-model="personResponsibleInput"
-                @search="onPersonSearch"
-                ref="personResponsible"
-                @search:blur="handleSearchBlur(personOptions, $refs.personResponsible, 'personResponsibleInput')">
-              <template v-slot:no-options>
-                  Type to search registry...
-              </template>
-              <template v-slot:cell(selected-option)="option">
-                <div>
-                  {{ personNameReg (option) }}
-                </div>
-              </template>
-              <template v-slot:cell(option)="option">
-                <div>
-                  {{ personNameReg (option) }}
-                </div>
-              </template>
-            </v-select>
-            <small id="personResponsibleSelectHint" class="form-text text-muted">
-              *displays a maximum of {{MAX_RESULTS}} results
-            </small>
-            <b-form-text id="personResponsibleInvalidFeedback" v-if="errors.person_responsible">
-              <div v-for="(error, index) in errors.person_responsible" :key="`personResponsible error ${index}`" class="text-danger">
-                {{ error }}
-              </div>
-            </b-form-text>
-          </b-form-group>
-        </b-col>
-        <b-col cols="12" md="12" lg="6">
-          <form-input
-              id="drillerName"
-              label="Person Who Completed the Work"
-              type="text"
-              :disabled="drillerSameAsPersonResponsible"
-              v-model="drillerNameInput"
-              :errors="errors['driller_name']"
-              :loaded="fieldsLoaded['driller_name']"
-          ></form-input>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" md="12" lg="4">
-          <b-form-group
-              aria-describedby="companyOfPersonResponsibleInvalidFeedback"
-              :state="false">
-            <label>Company of Person Responsible for Drilling</label>
-            <v-select
-              :disabled="companies === null"
-              id="companyOfPersonResponsibleSelect"
+      <responsive-grid :cols="12" :md="12" :lg="6">
+        <b-form-group
+            label="Person Responsible for Work"
+            aria-describedby="personResponsibleInvalidFeedback"
+            :state="false">
+          <v-select
+              :class="errors.person_responsible?'border border-danger dropdown-error-border':''"
+              :disabled="persons === null"
+              id="personResponsibleSelect"
               :filterable="false"
-              :options="companyOfPersonResponsibleOptions"
-              label="org_verbose_name"
-              v-model="companyOfPersonResponsibleInput"
-              @search="onCompanyOfPersonResponsibleSearch"
-              ref="companyOfPersonResponsible"
-              @search:blur="handleSearchBlur(companyOfPersonResponsibleOptions, $refs.companyOfPersonResponsible, 'companyOfPersonResponsibleInput')">
-              <template v-slot:no-options>
-                  Search by company name
-              </template>
-            </v-select>
-            <small id="companyOfPersonResponsibleSelectHint" class="form-text text-muted">
-              *displays a maximum of {{MAX_RESULTS}} results
-            </small>
-            <b-form-text id="companyOfPersonResponsibleInvalidFeedback" v-if="errors.person_responsible">
-              <div v-for="(error, index) in errors.driller_company_responsible" :key="`companyOfPersonResponsible error ${index}`" class="text-danger">
-                {{ error }}
+              :options="personOptions"
+              label="name"
+              v-model="personResponsibleInput"
+              @search="onPersonSearch"
+              ref="personResponsible"
+              @search:blur="handleSearchBlur(personOptions, $refs.personResponsible, 'personResponsibleInput')">
+            <template v-slot:no-options>
+                Type to search registry...
+            </template>
+            <template v-slot:cell(selected-option)="option">
+              <div>
+                {{ personNameReg (option) }}
               </div>
-            </b-form-text>
-          </b-form-group>
-        </b-col>
-      </b-row>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 md:col-span-6">
-          <form-input
-              id="consultantName"
-              label="Consultant Name"
-              type="text"
-              v-model="consultantNameInput"
-              :errors="errors['consultant_name']"
-              :loaded="fieldsLoaded['consultant_name']"
-          ></form-input>
-        </div>
-        <div class="col-span-12 md:col-span-6">
-          <form-input
-              id="consultantCompany"
-              label="Consultant Company"
-              type="text"
-              v-model="consultantCompanyInput"
-              :errors="errors['consultant_company']"
-              :loaded="fieldsLoaded['consultant_company']"
-          ></form-input>
-        </div>
-      </div>
+            </template>
+            <template v-slot:cell(option)="option">
+              <div>
+                {{ personNameReg (option) }}
+              </div>
+            </template>
+          </v-select>
+          <small id="personResponsibleSelectHint" class="form-text text-muted">
+            *displays a maximum of {{MAX_RESULTS}} results
+          </small>
+          <b-form-text id="personResponsibleInvalidFeedback" v-if="errors.person_responsible">
+            <div v-for="(error, index) in errors.person_responsible" :key="`personResponsible error ${index}`" class="text-danger">
+              {{ error }}
+            </div>
+          </b-form-text>
+        </b-form-group>
+        <form-input
+          id="drillerName"
+          label="Person Who Completed the Work"
+          type="text"
+          :disabled="drillerSameAsPersonResponsible"
+          v-model="drillerNameInput"
+          :errors="errors['driller_name']"
+          :loaded="fieldsLoaded['driller_name']"></form-input>
+      </responsive-grid>
+      <responsive-grid :cols="12" :md="12" :lg="4">
+        <b-form-group
+          aria-describedby="companyOfPersonResponsibleInvalidFeedback"
+          :state="false">
+          <label>Company of Person Responsible for Drilling</label>
+          <v-select
+            :disabled="companies === null"
+            id="companyOfPersonResponsibleSelect"
+            :filterable="false"
+            :options="companyOfPersonResponsibleOptions"
+            label="org_verbose_name"
+            v-model="companyOfPersonResponsibleInput"
+            @search="onCompanyOfPersonResponsibleSearch"
+            ref="companyOfPersonResponsible"
+            @search:blur="handleSearchBlur(companyOfPersonResponsibleOptions, $refs.companyOfPersonResponsible, 'companyOfPersonResponsibleInput')">
+            <template v-slot:no-options>
+                Search by company name
+            </template>
+          </v-select>
+          <small id="companyOfPersonResponsibleSelectHint" class="form-text text-muted">
+            *displays a maximum of {{MAX_RESULTS}} results
+          </small>
+          <b-form-text id="companyOfPersonResponsibleInvalidFeedback" v-if="errors.person_responsible">
+            <div v-for="(error, index) in errors.driller_company_responsible" :key="`companyOfPersonResponsible error ${index}`" class="text-danger">
+              {{ error }}
+            </div>
+          </b-form-text>
+        </b-form-group>
+      </responsive-grid>
+      <responsive-grid :cols="12" :md="6">
+        <form-input
+          id="consultantName"
+          label="Consultant Name"
+          type="text"
+          v-model="consultantNameInput"
+          :errors="errors['consultant_name']"
+          :loaded="fieldsLoaded['consultant_name']"></form-input>
+        <form-input
+          id="consultantCompany"
+          label="Consultant Company"
+          type="text"
+          v-model="consultantCompanyInput"
+          :errors="errors['consultant_company']"
+          :loaded="fieldsLoaded['consultant_company']"></form-input>
+      </responsive-grid>
     </fieldset>
 </template>
 
@@ -147,6 +130,7 @@ import { useCommonStore } from '@/stores/common.js'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import ApiService from '@/common/services/ApiService.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 
 export default {
   name: 'PersonResponsible',
@@ -180,6 +164,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    ResponsiveGrid
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
@@ -22,13 +22,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
           <back-to-top-link v-if="isStaffEdit"/>
         </div>
       </responsive-grid>
-      <b-form-checkbox id="checkbox1"
-        v-model="drillerSameAsPersonResponsibleInput"
-        :value="true"
-        :unchecked-value="false"
-      >
-        <p>Person Responsible is the same as the Person Who Completed the Work</p>
-      </b-form-checkbox>
+      <div class="flex items-center gap-2">
+        <Checkbox inputId="checkbox1" v-model="drillerSameAsPersonResponsibleInput" binary/>
+        <label for="checkbox1">Person Responsible is the same as the Person Who Completed the Work</label>
+      </div>
       <responsive-grid :cols="12" :md="12" :lg="6">
         <b-form-group
           label="Person Responsible for Work"

--- a/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
@@ -21,7 +21,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </b-col>
         <b-col xs="12">
           <div class="float-right">
-            <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
+            <Button v-if="isStaffEdit" label="Save" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
             <back-to-top-link v-if="isStaffEdit"/>
           </div>
         </b-col>
@@ -117,8 +117,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </b-form-group>
         </b-col>
       </b-row>
-      <b-row>
-        <b-col cols="12" md="6">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 md:col-span-6">
           <form-input
               id="consultantName"
               label="Consultant Name"
@@ -127,8 +127,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
               :errors="errors['consultant_name']"
               :loaded="fieldsLoaded['consultant_name']"
           ></form-input>
-        </b-col>
-        <b-col cols="12" md="6">
+        </div>
+        <div class="col-span-12 md:col-span-6">
           <form-input
               id="consultantCompany"
               label="Consultant Company"
@@ -137,8 +137,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
               :errors="errors['consultant_company']"
               :loaded="fieldsLoaded['consultant_company']"
           ></form-input>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
     </fieldset>
 </template>
 

--- a/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
@@ -59,14 +59,15 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </div>
             </template>
           </v-select>
+          <!-- TODO: Copy over the bootstrap form-text class to one of the css files -->
           <small id="personResponsibleSelectHint" class="form-text text-muted">
             *displays a maximum of {{MAX_RESULTS}} results
           </small>
-          <b-form-text id="personResponsibleInvalidFeedback" v-if="errors.person_responsible">
+          <div id="personResponsibleInvalidFeedback" class="form-text" v-if="errors.person_responsible">
             <div v-for="(error, index) in errors.person_responsible" :key="`personResponsible error ${index}`" class="text-danger">
               {{ error }}
             </div>
-          </b-form-text>
+          </div>
         </b-form-group>
         <form-input
           id="drillerName"
@@ -78,9 +79,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           :loaded="fieldsLoaded['driller_name']"/>
       </responsive-grid>
       <responsive-grid :cols="12" :md="12" :lg="4">
-        <b-form-group
-          aria-describedby="companyOfPersonResponsibleInvalidFeedback"
-          :state="false">
+        <div class="flex flex-col gap-2" aria-describedby="companyOfPersonResponsibleInvalidFeedback">
           <label>Company of Person Responsible for Drilling</label>
           <v-select
             :disabled="companies === null"
@@ -99,12 +98,12 @@ Licensed under the Apache License, Version 2.0 (the "License");
           <small id="companyOfPersonResponsibleSelectHint" class="form-text text-muted">
             *displays a maximum of {{MAX_RESULTS}} results
           </small>
-          <b-form-text id="companyOfPersonResponsibleInvalidFeedback" v-if="errors.person_responsible">
+          <div id="companyOfPersonResponsibleInvalidFeedback" class="form-text" v-if="errors.person_responsible">
             <div v-for="(error, index) in errors.driller_company_responsible" :key="`companyOfPersonResponsible error ${index}`" class="text-danger">
               {{ error }}
             </div>
-          </b-form-text>
-        </b-form-group>
+          </div>
+        </div>
       </responsive-grid>
       <responsive-grid :cols="12" :md="6">
         <form-input

--- a/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
@@ -75,7 +75,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           :disabled="drillerSameAsPersonResponsible"
           v-model="drillerNameInput"
           :errors="errors['driller_name']"
-          :loaded="fieldsLoaded['driller_name']"></form-input>
+          :loaded="fieldsLoaded['driller_name']"/>
       </responsive-grid>
       <responsive-grid :cols="12" :md="12" :lg="4">
         <b-form-group
@@ -113,14 +113,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
           type="text"
           v-model="consultantNameInput"
           :errors="errors['consultant_name']"
-          :loaded="fieldsLoaded['consultant_name']"></form-input>
+          :loaded="fieldsLoaded['consultant_name']"/>
         <form-input
           id="consultantCompany"
           label="Consultant Company"
           type="text"
           v-model="consultantCompanyInput"
           :errors="errors['consultant_company']"
-          :loaded="fieldsLoaded['consultant_company']"></form-input>
+          :loaded="fieldsLoaded['consultant_company']"/>
       </responsive-grid>
     </fieldset>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/PersonResponsible.vue
@@ -27,24 +27,24 @@ Licensed under the Apache License, Version 2.0 (the "License");
         :value="true"
         :unchecked-value="false"
       >
-      <p>Person Responsible is the same as the Person Who Completed the Work</p>
+        <p>Person Responsible is the same as the Person Who Completed the Work</p>
       </b-form-checkbox>
       <responsive-grid :cols="12" :md="12" :lg="6">
         <b-form-group
-            label="Person Responsible for Work"
-            aria-describedby="personResponsibleInvalidFeedback"
-            :state="false">
+          label="Person Responsible for Work"
+          aria-describedby="personResponsibleInvalidFeedback"
+          :state="false">
           <v-select
-              :class="errors.person_responsible?'border border-danger dropdown-error-border':''"
-              :disabled="persons === null"
-              id="personResponsibleSelect"
-              :filterable="false"
-              :options="personOptions"
-              label="name"
-              v-model="personResponsibleInput"
-              @search="onPersonSearch"
-              ref="personResponsible"
-              @search:blur="handleSearchBlur(personOptions, $refs.personResponsible, 'personResponsibleInput')">
+            :class="errors.person_responsible?'border border-danger dropdown-error-border':''"
+            :disabled="persons === null"
+            id="personResponsibleSelect"
+            :filterable="false"
+            :options="personOptions"
+            label="name"
+            v-model="personResponsibleInput"
+            @search="onPersonSearch"
+            ref="personResponsible"
+            @search:blur="handleSearchBlur(personOptions, $refs.personResponsible, 'personResponsibleInput')">
             <template v-slot:no-options>
                 Type to search registry...
             </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/PublicationStatus.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/PublicationStatus.vue
@@ -13,23 +13,21 @@ limitations under the License.
 */
 <template>
   <form-subsection title="Well Publication Status" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <div v-if="isStaffEdit" class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-4">
-        <b-form-group id="wellPublicationStatusCodeInput">
-          <b-form-select
-            v-model="wellPublicationStatusCodeInput"
-            :options="codes?.well_publication_status_codes"
-            value-field="well_publication_status_code"
-            text-field="well_publication_status_code"
-            :errors="errors['well_publication_status']"
-            :loaded="fieldsLoaded['well_publication_status']">
-            <template v-slot:first>
-              <option :value="null" disabled>Select Publication Status</option>
-            </template>
-          </b-form-select>
-        </b-form-group>
-      </div>
-    </div>
+    <responsive-grid v-if="isStaffEdit" :cols="12" :md="4">
+      <b-form-group id="wellPublicationStatusCodeInput">
+        <b-form-select
+          v-model="wellPublicationStatusCodeInput"
+          :options="codes?.well_publication_status_codes"
+          value-field="well_publication_status_code"
+          text-field="well_publication_status_code"
+          :errors="errors['well_publication_status']"
+          :loaded="fieldsLoaded['well_publication_status']">
+          <template v-slot:first>
+            <option :value="null" disabled>Select Publication Status</option>
+          </template>
+        </b-form-select>
+      </b-form-group>
+    </responsive-grid>
   </form-subsection>
 </template>
 
@@ -38,6 +36,7 @@ import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -65,7 +64,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/PublicationStatus.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/PublicationStatus.vue
@@ -14,19 +14,14 @@ limitations under the License.
 <template>
   <form-subsection title="Well Publication Status" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <responsive-grid v-if="isStaffEdit" :cols="12" :md="4">
-      <b-form-group id="wellPublicationStatusCodeInput">
-        <b-form-select
-          v-model="wellPublicationStatusCodeInput"
-          :options="codes?.well_publication_status_codes"
-          value-field="well_publication_status_code"
-          text-field="well_publication_status_code"
-          :errors="errors['well_publication_status']"
-          :loaded="fieldsLoaded['well_publication_status']">
-          <template v-slot:first>
-            <option :value="null" disabled>Select Publication Status</option>
-          </template>
-        </b-form-select>
-      </b-form-group>
+      <Dropdown
+        id="wellPublicationStatusCodeInput"
+        v-model="wellPublicationStatusCodeInput"
+        :options="codes?.well_publication_status_codes"
+        optionValue="well_publication_status_code"
+        optionLabel="well_publication_status_code"
+        :loading="!fieldsLoaded['well_publication_status']"
+        placeholder="Select Publication Status"/>
     </responsive-grid>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/PublicationStatus.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/PublicationStatus.vue
@@ -12,22 +12,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 <template>
-  <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Well Publication Status</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">
-            Save
-          </b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
-    <b-row v-if="isStaffEdit">
-      <b-col cols="12" md="4">
+  <form-subsection title="Well Publication Status" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
+    <div v-if="isStaffEdit" class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-4">
         <b-form-group id="wellPublicationStatusCodeInput">
           <b-form-select
             v-model="wellPublicationStatusCodeInput"
@@ -41,15 +28,16 @@ limitations under the License.
             </template>
           </b-form-select>
         </b-form-group>
-      </b-col>
-    </b-row>
-  </fieldset>
+      </div>
+    </div>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -75,6 +63,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/PublicationStatus.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/PublicationStatus.vue
@@ -14,7 +14,7 @@ limitations under the License.
 <template>
   <form-subsection title="Well Publication Status" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <responsive-grid v-if="isStaffEdit" :cols="12" :md="4">
-      <Dropdown
+      <Select
         id="wellPublicationStatusCodeInput"
         v-model="wellPublicationStatusCodeInput"
         :options="codes?.well_publication_status_codes"

--- a/app/frontend/src/submissions/components/SubmissionForm/Screens.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Screens.vue
@@ -13,51 +13,42 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Screen Information" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <b-row>
-      <b-col cols="12" md="4" lg="3">
-        <form-input
-          id="screenIntake"
-          label="Intake"
-          select
-          :options="codes?.screen_intake_methods"
-          text-field="description"
-          value-field="screen_intake_code"
-          placeholder="Select intake"
-          v-model="screenIntakeMethodInput"></form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="4" lg="3">
-        <form-input
-          id="screenType"
-          label="Screen Type"
-          select
-          :options="codes?.screen_types"
-          text-field="description"
-          value-field="screen_type_code"
-          placeholder="Select type"
-          v-model="screenTypeInput"></form-input>
-      </b-col>
-      <b-col cols="12" md="4" lg="3">
-        <form-input
-          id="screenMaterial"
-          label="Screen Material"
-          select
-          :options="codes?.screen_materials"
-          text-field="description"
-          value-field="screen_material_code"
-          placeholder="Select material"
-          v-model="screenMaterialInput"></form-input>
-      </b-col>
-      <b-col cols="12" md="4" lg="3">
-        <form-input
-          id="otherScreenMaterial"
-          label="Specify Other Screen Material"
-          v-model="otherScreenMaterialInput"></form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="4" lg="3">
+    <responsive-grid :cols="12" :md="4" :lg="3">
+      <form-input
+        id="screenIntake"
+        label="Intake"
+        select
+        :options="codes?.screen_intake_methods"
+        text-field="description"
+        value-field="screen_intake_code"
+        placeholder="Select intake"
+        v-model="screenIntakeMethodInput"></form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="4" :lg="3">
+      <form-input
+        id="screenType"
+        label="Screen Type"
+        select
+        :options="codes?.screen_types"
+        text-field="description"
+        value-field="screen_type_code"
+        placeholder="Select type"
+        v-model="screenTypeInput"></form-input>
+      <form-input
+        id="screenMaterial"
+        label="Screen Material"
+        select
+        :options="codes?.screen_materials"
+        text-field="description"
+        value-field="screen_material_code"
+        placeholder="Select material"
+        v-model="screenMaterialInput"></form-input>
+      <form-input
+        id="otherScreenMaterial"
+        label="Specify Other Screen Material"
+        v-model="otherScreenMaterialInput"></form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="4" :lg="3">
         <form-input
           id="screenOpening"
           label="Screen Opening"
@@ -67,8 +58,6 @@ Licensed under the Apache License, Version 2.0 (the "License");
           value-field="screen_opening_code"
           placeholder="Select opening"
           v-model="screenOpeningInput"></form-input>
-      </b-col>
-      <b-col cols="12" md="4" lg="3">
         <form-input
           id="screenBottom"
           label="Screen Bottom"
@@ -78,18 +67,15 @@ Licensed under the Apache License, Version 2.0 (the "License");
           value-field="screen_bottom_code"
           placeholder="Select bottom"
           v-model="screenBottomInput"></form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="4" lg="3">
-        <form-input
-          id="screenInformation"
-          label="Screen Information"
-          v-model="screenInformationInput"
-          :errors="errors['screen_information']"
-          :loaded="fieldsLoaded['screen_information']"></form-input>
-      </b-col>
-    </b-row>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="4" :lg="3">
+      <form-input
+        id="screenInformation"
+        label="Screen Information"
+        v-model="screenInformationInput"
+        :errors="errors['screen_information']"
+        :loaded="fieldsLoaded['screen_information']"></form-input>
+    </responsive-grid>
     <p class="mt-4 mb-2">Screen Details</p>
     <div class="table-responsive">
       <table class="table table-sm" aria-describedby="screenDetails">
@@ -189,21 +175,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <option v-for="size in screenSlotSizeSuggestions" :key="`screenSlotSizeListOption-${size}`">{{size}}.00</option>
     </datalist>
     <b-btn size="sm" variant="primary" @click="addScreenRow" id="addScreenRowButton"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
-    <b-modal
-      v-model="confirmRemoveModal"
-      centered
-      title="Confirm remove"
+    <Dialog
+      v-model:visible="confirmRemoveModal"
+      modal
+      header="Confirm remove"
       @shown="focusRemoveModal">
       Are you sure you want to remove this row?
       <div slot="modal-footer">
-        <b-btn variant="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn">
-          Cancel
-        </b-btn>
-        <b-btn variant="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)">
-          Remove
-        </b-btn>
+        <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
+        <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
       </div>
-    </b-modal>
+    </Dialog>
   </form-subsection>
 </template>
 
@@ -212,6 +194,7 @@ import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -249,7 +232,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/Screens.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Screens.vue
@@ -49,24 +49,24 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="otherScreenMaterialInput"></form-input>
     </responsive-grid>
     <responsive-grid :cols="12" :md="4" :lg="3">
-        <form-input
-          id="screenOpening"
-          label="Screen Opening"
-          select
-          :options="codes?.screen_openings"
-          text-field="description"
-          value-field="screen_opening_code"
-          placeholder="Select opening"
-          v-model="screenOpeningInput"></form-input>
-        <form-input
-          id="screenBottom"
-          label="Screen Bottom"
-          select
-          :options="codes?.screen_bottoms"
-          text-field="description"
-          value-field="screen_bottom_code"
-          placeholder="Select bottom"
-          v-model="screenBottomInput"></form-input>
+      <form-input
+        id="screenOpening"
+        label="Screen Opening"
+        select
+        :options="codes?.screen_openings"
+        text-field="description"
+        value-field="screen_opening_code"
+        placeholder="Select opening"
+        v-model="screenOpeningInput"></form-input>
+      <form-input
+        id="screenBottom"
+        label="Screen Bottom"
+        select
+        :options="codes?.screen_bottoms"
+        text-field="description"
+        value-field="screen_bottom_code"
+        placeholder="Select bottom"
+        v-model="screenBottomInput"></form-input>
     </responsive-grid>
     <responsive-grid :cols="12" :md="4" :lg="3">
       <form-input
@@ -111,8 +111,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   aria-label="Depth from (feet)"
                   v-model="screensData[index].start"
                   :errors="getScreenError(index).start"
-                  :loaded="getScreenLoaded(index).start"
-                  />
+                  :loaded="getScreenLoaded(index).start"/>
               </td>
               <td class="input-width-small py-0">
                 <form-input
@@ -122,8 +121,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   aria-label="Depth to (feet)"
                   v-model="screensData[index].end"
                   :errors="getScreenError(index).end"
-                  :loaded="getScreenLoaded(index).end"
-                  />
+                  :loaded="getScreenLoaded(index).end"/>
               </td>
               <td class="input-width-small py-0">
                 <form-input
@@ -133,23 +131,21 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   aria-label="Diameter (inches)"
                   v-model="screensData[index].diameter"
                   :errors="getScreenError(index).diameter"
-                  :loaded="getScreenLoaded(index).diameter"
-                  />
+                  :loaded="getScreenLoaded(index).diameter"/>
               </td>
               <td class="input-width-small py-0">
                 <form-input
-                    group-class="my-1"
-                    :id="`screenAssemblyType_${index}`"
-                    aria-label="Screen Assembly Type"
-                    v-model="screensData[index].assembly_type"
-                    select
-                    :options="codes?.screen_assemblies"
-                    text-field="description"
-                    value-field="screen_assembly_type_code"
-                    placeholder="Select type"
-                    :errors="getScreenError(index).assembly_type"
-                    :loaded="getScreenLoaded(index).assembly_type"
-                    />
+                  group-class="my-1"
+                  :id="`screenAssemblyType_${index}`"
+                  aria-label="Screen Assembly Type"
+                  v-model="screensData[index].assembly_type"
+                  select
+                  :options="codes?.screen_assemblies"
+                  text-field="description"
+                  value-field="screen_assembly_type_code"
+                  placeholder="Select type"
+                  :errors="getScreenError(index).assembly_type"
+                  :loaded="getScreenLoaded(index).assembly_type"/>
               </td>
               <td class="input-width-small py-0">
                 <form-input
@@ -160,8 +156,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   type="number"
                   v-model="screensData[index].slot_size"
                   :errors="getScreenError(index).slot_size"
-                  :loaded="getScreenLoaded(index).slot_size"
-                  />
+                  :loaded="getScreenLoaded(index).slot_size"/>
               </td>
               <td class="py-0">
                 <b-btn size="sm" variant="primary" @click="removeRowIfOk(index)" :id="`removeScreenRowButton${index}`" class="mt-2 float-right"><i class="fa fa-minus-square-o"></i> Remove</b-btn>
@@ -175,16 +170,12 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <option v-for="size in screenSlotSizeSuggestions" :key="`screenSlotSizeListOption-${size}`">{{size}}.00</option>
     </datalist>
     <b-btn size="sm" variant="primary" @click="addScreenRow" id="addScreenRowButton"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
-    <Dialog
-      v-model:visible="confirmRemoveModal"
-      modal
-      header="Confirm remove"
-      @shown="focusRemoveModal">
+    <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
       Are you sure you want to remove this row?
-      <div slot="modal-footer">
+      <template #footer>
         <Button label="Cancel" severity="secondary" @click="confirmRemoveModal=false;rowIndexToRemove=null" ref="cancelRemoveBtn"/>
         <Button label="Remove" severity="danger" @click="confirmRemoveModal=false;removeRowByIndex(rowIndexToRemove)"/>
-      </div>
+      </template>
     </Dialog>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/Screens.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Screens.vue
@@ -12,18 +12,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Screen Information</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
+  <form-subsection title="Screen Information" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <b-row>
       <b-col cols="12" md="4" lg="3">
         <form-input
@@ -215,13 +204,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </b-btn>
       </div>
     </b-modal>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -257,6 +247,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/Screens.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Screens.vue
@@ -159,7 +159,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   :loaded="getScreenLoaded(index).slot_size"/>
               </td>
               <td class="py-0">
-                <b-btn size="sm" variant="primary" @click="removeRowIfOk(index)" :id="`removeScreenRowButton${index}`" class="mt-2 float-right"><i class="fa fa-minus-square-o"></i> Remove</b-btn>
+                <Button label="Remove" icon="fa fa-minus-square-o" size="small" @click="removeRowIfOk(index)" :id="`removeScreenRowButton${index}`" class="mt-2 float-right"/>
               </td>
             </tr>
           </template>
@@ -169,7 +169,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <datalist id="screenSlotSizeList">
       <option v-for="size in screenSlotSizeSuggestions" :key="`screenSlotSizeListOption-${size}`">{{size}}.00</option>
     </datalist>
-    <b-btn size="sm" variant="primary" @click="addScreenRow" id="addScreenRowButton"><i class="fa fa-plus-square-o"></i> Add row</b-btn>
+    <Button label="Add row" icon="fa fa-plus-square-o" size="small" @click="addScreenRow" id="addScreenRowButton"/>
     <Dialog v-model:visible="confirmRemoveModal" modal header="Confirm remove" @show="focusRemoveModal">
       Are you sure you want to remove this row?
       <template #footer>

--- a/app/frontend/src/submissions/components/SubmissionForm/Screens.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Screens.vue
@@ -22,7 +22,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         text-field="description"
         value-field="screen_intake_code"
         placeholder="Select intake"
-        v-model="screenIntakeMethodInput"></form-input>
+        v-model="screenIntakeMethodInput"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="4" :lg="3">
       <form-input
@@ -33,7 +33,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         text-field="description"
         value-field="screen_type_code"
         placeholder="Select type"
-        v-model="screenTypeInput"></form-input>
+        v-model="screenTypeInput"/>
       <form-input
         id="screenMaterial"
         label="Screen Material"
@@ -42,11 +42,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
         text-field="description"
         value-field="screen_material_code"
         placeholder="Select material"
-        v-model="screenMaterialInput"></form-input>
+        v-model="screenMaterialInput"/>
       <form-input
         id="otherScreenMaterial"
         label="Specify Other Screen Material"
-        v-model="otherScreenMaterialInput"></form-input>
+        v-model="otherScreenMaterialInput"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="4" :lg="3">
       <form-input
@@ -57,7 +57,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         text-field="description"
         value-field="screen_opening_code"
         placeholder="Select opening"
-        v-model="screenOpeningInput"></form-input>
+        v-model="screenOpeningInput"/>
       <form-input
         id="screenBottom"
         label="Screen Bottom"
@@ -66,7 +66,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         text-field="description"
         value-field="screen_bottom_code"
         placeholder="Select bottom"
-        v-model="screenBottomInput"></form-input>
+        v-model="screenBottomInput"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="4" :lg="3">
       <form-input
@@ -74,7 +74,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         label="Screen Information"
         v-model="screenInformationInput"
         :errors="errors['screen_information']"
-        :loaded="fieldsLoaded['screen_information']"></form-input>
+        :loaded="fieldsLoaded['screen_information']"/>
     </responsive-grid>
     <p class="mt-4 mb-2">Screen Details</p>
     <div class="table-responsive">

--- a/app/frontend/src/submissions/components/SubmissionForm/SubmissionHistory.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/SubmissionHistory.vue
@@ -19,17 +19,16 @@ Licensed under the Apache License, Version 2.0 (the "License");
           There {{ filteredSubmissions.length !== 1 ? 'are' : 'is' }} {{ filteredSubmissions.length }} activity {{ filteredSubmissions.length !== 1 ? 'reports' : 'report' }} for well {{ $route.params.id }}.
         </p>
         <b-table
-            id="submissionHistoryTable"
-            ref="submissionHistoryTable"
-            v-model:busy="submissionsBusy"
-            :items="filteredSubmissions"
-            :fields="tableHeaders"
-            responsive
-            show-empty
-            empty-text="There is currently no submission report history for this well. Scanned copies of paper reports may be available as an attachment."
-            :per-page="submissionsPerPage"
-            :current-page="submissionsPage"
-          >
+          id="submissionHistoryTable"
+          ref="submissionHistoryTable"
+          v-model:busy="submissionsBusy"
+          :items="filteredSubmissions"
+          :fields="tableHeaders"
+          responsive
+          show-empty
+          empty-text="There is currently no submission report history for this well. Scanned copies of paper reports may be available as an attachment."
+          :per-page="submissionsPerPage"
+          :current-page="submissionsPage">
           <template v-slot:cell(report)="data">
             <div>
               <router-link :to="{ name: 'SubmissionDetail', params: { id: $route.params.id, submissionId: data.item.filing_number }}">{{ data.item.well_activity_description }}</router-link>

--- a/app/frontend/src/submissions/components/SubmissionForm/SubmissionHistory.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/SubmissionHistory.vue
@@ -18,34 +18,22 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <p>
           There {{ filteredSubmissions.length !== 1 ? 'are' : 'is' }} {{ filteredSubmissions.length }} activity {{ filteredSubmissions.length !== 1 ? 'reports' : 'report' }} for well {{ $route.params.id }}.
         </p>
-        <b-table
-          id="submissionHistoryTable"
-          ref="submissionHistoryTable"
-          v-model:busy="submissionsBusy"
-          :items="filteredSubmissions"
-          :fields="tableHeaders"
-          responsive
-          show-empty
-          empty-text="There is currently no submission report history for this well. Scanned copies of paper reports may be available as an attachment."
-          :per-page="submissionsPerPage"
-          :current-page="submissionsPage">
-          <template v-slot:cell(report)="data">
-            <div>
-              <router-link :to="{ name: 'SubmissionDetail', params: { id: $route.params.id, submissionId: data.item.filing_number }}">{{ data.item.well_activity_description }}</router-link>
-            </div>
+        <DataTable :value="filteredSubmissions" ref="submissionHistoryTable" scrollable paginator :rows="submissionsPerPage">
+          <template #empty>
+            There is currently no submission report history for this well. Scanned copies of paper reports may be available as an attachment.
           </template>
-          <template v-slot:cell(date_entered)="data">
-            <div>
-              <span v-if="data.item.create_date">{{ moment(data.item.create_date, "MMMM Do YYYY [at] LT") }}</span>
-            </div>
-          </template>
-          <template v-slot:cell(entered_by)="data">
-            <div>
-              {{ data.item.create_user }}
-            </div>
-          </template>
-        </b-table>
-        <b-pagination v-if="!!filteredSubmissions.length && filteredSubmissions.length > submissionsPerPage" size="md" :total-rows="filteredSubmissions.length" v-model="submissionsPage" :per-page="submissionsPerPage" :disabled="submissionsBusy" />
+          <Column header="Report">
+            <template #body="slotProps">
+              <router-link :to="{ name: 'SubmissionDetail', params: { id: $route.params.id, submissionId: slotProps.data.filing_number }}">{{ slotProps.data.well_activity_description }}</router-link>
+            </template>
+          </Column>
+          <Column header="Date Entered">
+            <template #body="slotProps">
+              <span v-if="slotProps.data.create_date">{{ moment(slotProps.data.create_date, "MMMM Do YYYY [at] LT") }}</span>
+            </template>
+          </Column>
+          <Column field="create_user" header="Entered By"/>
+        </DataTable>
       </div>
     </div>
   </form-subsection>

--- a/app/frontend/src/submissions/components/SubmissionForm/SubmissionHistory.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/SubmissionHistory.vue
@@ -12,14 +12,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset class="mt-12">
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Activity Reports</legend>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12">
+  <form-subsection class="mt-12" title="Activity Reports" :id="id" :hideSave="true">
+    <div class="flex">
+      <div>
         <p>
           There {{ filteredSubmissions.length !== 1 ? 'are' : 'is' }} {{ filteredSubmissions.length }} activity {{ filteredSubmissions.length !== 1 ? 'reports' : 'report' }} for well {{ $route.params.id }}.
         </p>
@@ -52,13 +47,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </template>
         </b-table>
         <b-pagination v-if="!!filteredSubmissions.length && filteredSubmissions.length > submissionsPerPage" size="md" :total-rows="filteredSubmissions.length" v-model="submissionsPage" :per-page="submissionsPerPage" :disabled="submissionsBusy" />
-      </b-col>
-    </b-row>
-  </fieldset>
+      </div>
+    </div>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   props: {
@@ -78,6 +74,9 @@ export default {
       type: Array,
       default: () => ([])
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/VerticalAquiferExtents.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/VerticalAquiferExtents.vue
@@ -24,15 +24,20 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <div v-else>
       <api-error v-if="error" :error="error"/>
 
-      <b-table
-        :fields="tableFields"
-        :items="tableData"
-        show-empty
-        empty-text="There are currently no vertical aquifer extents for this well.">
-        <template v-slot:cell(start)="data">{{parseFloat(data.item.start).toFixed(2)}} m</template>
-        <template v-slot:cell(end)="data">{{parseFloat(data.item.end).toFixed(2)}} m</template>
-        <template v-slot:cell(height)="data">{{data.item.height.toFixed(2)}} m</template>
-      </b-table>
+      <DataTable :value="tableData">
+        <template #empty>There are currently no vertical aquifer extents for this well.</template>
+        <Column field="aquifer_id" header="Aquifer Id"/>
+        <Column field="aquifer_name" header="Aquifer Name"/>
+        <Column field="start" header="Start">
+          <template #body="slotProps">{{parseFloat(slotProps.data.start).toFixed(2)}} m</template>
+        </Column>
+        <Column field="end" header="End">
+          <template #body="slotProps">{{parseFloat(slotProps.data.end).toFixed(2)}} m</template>
+        </Column>
+        <Column field="height" header="Height">
+          <template #body="slotProps">{{parseFloat(slotProps.data.height).toFixed(2)}} m</template>
+        </Column>
+      </DataTable>
 
       <div>
         <router-link :to="{ name: 'well-aquifers', params: {wellTagNumber} }" class="btn btn-primary" role="button">
@@ -64,29 +69,7 @@ export default {
     return {
       error: null,
       loading: false,
-      aquifers: [],
-      tableFields: [
-        {
-          key: 'aquifer_id',
-          label: 'Aquifer Id'
-        },
-        {
-          key: 'aquifer_name',
-          label: 'Aquifer Name'
-        },
-        {
-          key: 'start',
-          label: 'Start'
-        },
-        {
-          key: 'end',
-          label: 'End'
-        },
-        {
-          key: 'height',
-          label: 'Height'
-        }
-      ]
+      aquifers: []
     }
   },
   computed: {

--- a/app/frontend/src/submissions/components/SubmissionForm/WaterQuality.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WaterQuality.vue
@@ -12,20 +12,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Water Quality</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="6">
+  <form-subsection title="Water Quality" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-6">
         <form-input
           id="waterCharacteristicsInput"
           label="Characteristics"
@@ -37,8 +26,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           v-model="waterQualityCharacteristicsInput"
           :errors="errors['water_quality_characteristics']"
           :loaded="fieldsLoaded['water_quality_characteristics']"/>
-      </b-col>
-    </b-row>
+      </div>
+    </div>
     <b-row>
       <b-col cols="12" md="5" lg="4">
         <form-input
@@ -74,13 +63,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :loaded="fieldsLoaded['ems']"></form-input>
       </b-col>
     </b-row>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -112,6 +102,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   fields: {
     waterQualityColourInput: 'waterQualityColour',

--- a/app/frontend/src/submissions/components/SubmissionForm/WaterQuality.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WaterQuality.vue
@@ -13,56 +13,48 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Water Quality" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-6">
-        <form-input
-          id="waterCharacteristicsInput"
-          label="Characteristics"
-          select
-          :options="codes?.water_quality_characteristics"
-          value-field="code"
-          text-field="description"
-          hint="Select one or more characteristics. Hold the Ctrl (PC) or Command (Mac) key to select more than one option."
-          v-model="waterQualityCharacteristicsInput"
-          :errors="errors['water_quality_characteristics']"
-          :loaded="fieldsLoaded['water_quality_characteristics']"/>
-      </div>
-    </div>
-    <b-row>
-      <b-col cols="12" md="5" lg="4">
-        <form-input
-            id="waterQualityColour"
-            label="Water Quality Colour"
-            select
-            :options="codes?.water_quality_colours"
-            text-field="description"
-            value-field="code"
-            placeholder="Select colour"
-            v-model="waterQualityColourInput"
-            :errors="errors['water_quality_colour']"
-            :loaded="fieldsLoaded['water_quality_colour']"></form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="5" lg="4">
-        <form-input
-            id="waterQualityOdour"
-            label="Water Quality Odour"
-            v-model="waterQualityOdourInput"
-            :errors="errors['water_quality_odour']"
-            :loaded="fieldsLoaded['water_quality_odour']"></form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="5" lg="4">
-        <form-input
-            id="emsID"
-            label="Environmental Monitoring System (EMS) ID"
-            v-model="emsIDInput"
-            :errors="errors['ems']"
-            :loaded="fieldsLoaded['ems']"></form-input>
-      </b-col>
-    </b-row>
+    <responsive-grid :cols="12" :md="6">
+      <form-input
+        id="waterCharacteristicsInput"
+        label="Characteristics"
+        select
+        :options="codes?.water_quality_characteristics"
+        value-field="code"
+        text-field="description"
+        hint="Select one or more characteristics. Hold the Ctrl (PC) or Command (Mac) key to select more than one option."
+        v-model="waterQualityCharacteristicsInput"
+        :errors="errors['water_quality_characteristics']"
+        :loaded="fieldsLoaded['water_quality_characteristics']"/>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="5" :lg="4">
+      <form-input
+        id="waterQualityColour"
+        label="Water Quality Colour"
+        select
+        :options="codes?.water_quality_colours"
+        text-field="description"
+        value-field="code"
+        placeholder="Select colour"
+        v-model="waterQualityColourInput"
+        :errors="errors['water_quality_colour']"
+        :loaded="fieldsLoaded['water_quality_colour']"></form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="5" :lg="4">
+      <form-input
+        id="waterQualityOdour"
+        label="Water Quality Odour"
+        v-model="waterQualityOdourInput"
+        :errors="errors['water_quality_odour']"
+        :loaded="fieldsLoaded['water_quality_odour']"></form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="5" :lg="4">
+      <form-input
+        id="emsID"
+        label="Environmental Monitoring System (EMS) ID"
+        v-model="emsIDInput"
+        :errors="errors['ems']"
+        :loaded="fieldsLoaded['ems']"></form-input>
+    </responsive-grid>
   </form-subsection>
 </template>
 
@@ -71,6 +63,7 @@ import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -104,7 +97,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   fields: {
     waterQualityColourInput: 'waterQualityColour',

--- a/app/frontend/src/submissions/components/SubmissionForm/WaterQuality.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WaterQuality.vue
@@ -37,7 +37,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         placeholder="Select colour"
         v-model="waterQualityColourInput"
         :errors="errors['water_quality_colour']"
-        :loaded="fieldsLoaded['water_quality_colour']"></form-input>
+        :loaded="fieldsLoaded['water_quality_colour']"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="5" :lg="4">
       <form-input
@@ -45,7 +45,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         label="Water Quality Odour"
         v-model="waterQualityOdourInput"
         :errors="errors['water_quality_odour']"
-        :loaded="fieldsLoaded['water_quality_odour']"></form-input>
+        :loaded="fieldsLoaded['water_quality_odour']"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="5" :lg="4">
       <form-input
@@ -53,7 +53,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         label="Environmental Monitoring System (EMS) ID"
         v-model="emsIDInput"
         :errors="errors['ems']"
-        :loaded="fieldsLoaded['ems']"></form-input>
+        :loaded="fieldsLoaded['ems']"/>
     </responsive-grid>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/WellHistory.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WellHistory.vue
@@ -27,13 +27,13 @@
                 <div v-if="isTable(item)" class="mt-2">
                   {{ readable(formatKey(item.type)) }} changed to:
                   <div v-if="item.diff != null && item.diff.length > 0">
-                    <b-table
-                      responsive
-                      striped
-                      small
-                      fixed
-                      bordered
-                      :items="item.diff"/>
+                    <!-- Columns will need to be added here when testing -->
+                    <DataTable
+                      scrollable
+                      stripedRows
+                      size="small"
+                      showGridlines
+                      :value="item.diff"/>
                   </div>
                   <div v-else>
                     None
@@ -41,13 +41,13 @@
                   <div style="margin-bottom:10px;">
                     From:
                     <div v-if="item.prev != null && item.prev.length > 0">
-                      <b-table
-                        responsive
-                        striped
-                        small
-                        fixed
-                        bordered
-                        :items="item.prev"/>
+                      <!-- Columns will need to be added here when testing -->
+                      <DataTable
+                        scrollable
+                        stripedRows
+                        size="small"
+                        showGridlines
+                        :value="item.prev"/>
                     </div>
                     <div v-else>
                       None

--- a/app/frontend/src/submissions/components/SubmissionForm/WellHistory.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WellHistory.vue
@@ -4,7 +4,7 @@
       <h6 class="card-title mb-0" id="changeHistoryTitle">
         Change History
         <span class="ml-4">
-          <b-button link size="sm" variant="outline-primary" v-on:click="toggleShow">{{showHistory ? "Hide":"Show"}}</b-button>
+          <Button :label="showHistory ? 'Hide':'Show'" size="small" severity="secondary" v-on:click="toggleShow"/>
         </span>
       </h6>
       <div v-if="loading">

--- a/app/frontend/src/submissions/components/SubmissionForm/WellHistory.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WellHistory.vue
@@ -69,7 +69,7 @@
           {{ moment(create_date, "MMMM Do YYYY [at] LT")}}
         </div>
         <div v-if="loading">
-          <b-row><b-col>Loading history...</b-col></b-row>
+          <div class="flex">Loading history...</div>
         </div>
       </div>
     </div>

--- a/app/frontend/src/submissions/components/SubmissionForm/WellType.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WellType.vue
@@ -12,18 +12,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-    <fieldset>
-      <b-row>
-        <b-col cols="12" lg="6">
-          <legend :id="id">Well Class</legend>
-        </b-col>
-        <b-col cols="12" lg="6">
-          <div class="float-right">
-            <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
-            <back-to-top-link v-if="isStaffEdit"/>
-          </div>
-        </b-col>
-      </b-row>
+    <form-subsection title="Well Class" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
       <b-row v-if="isStaffEdit">
         <b-col cols="12" md="3" xl="2">
           <form-input
@@ -195,8 +184,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           ></form-input>
         </b-col>
       </b-row>
-      <b-row v-if="!isStaffEdit">
-        <b-col cols="12" md="6">
+      <div v-if="!isStaffEdit" class="grid grid-cols-12">
+        <div class="col-span-12 md:col-span-6">
           <form-input
               id="workStartDateInput"
               type="date"
@@ -208,8 +197,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
               @input="handleDateInput($event, 'workStartDate')"
               >
           </form-input>
-        </b-col>
-        <b-col cols="12" md="6">
+        </div>
+        <div class="col-span-12 md:col-span-6">
           <form-input
               id="workEndDateInput"
               type="date"
@@ -221,9 +210,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
               @input="handleDateInput($event, 'workEndDate')"
               >
           </form-input>
-        </b-col>
-      </b-row>
-    </fieldset>
+        </div>
+      </div>
+    </form-subsection>
 </template>
 
 <script>
@@ -231,6 +220,7 @@ import { useSubmissionStore } from '@/stores/submission'
 import { useCommonStore } from '@/stores/common'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -277,6 +267,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/WellType.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WellType.vue
@@ -87,8 +87,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :disabled="intendedWaterUseDisabled"
             id="intendedWaterUse"></form-input>
       </responsive-grid>
-      <b-row>
-        <b-col cols="12" md="4" v-if="!isStaffEdit && wellActivityType !== 'CON'">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 md:col-span-4" v-if="!isStaffEdit && wellActivityType !== 'CON'">
           <b-form-group>
             <label>Well Tag Number (if known) <span class="font-weight-bold"></span></label>
             <v-select
@@ -119,38 +119,35 @@ Licensed under the Apache License, Version 2.0 (the "License");
               *displays a maximum of {{MAX_RESULTS}} results
             </small>
           </b-form-group>
-        </b-col>
-        <b-col cols="12" md="4">
+        </div>
+        <div class="col-span-12 md:col-span-4">
           <form-input
               id="idPlateNumber"
               :label="wellIdentificationPlateNumberLabel"
               type="number"
               v-model="idPlateNumberInput"
               :errors="errors['identification_plate_number']"
-              :loaded="fieldsLoaded['identification_plate_number']"
-          ></form-input>
-        </b-col>
-        <b-col cols="12" md="4">
+              :loaded="fieldsLoaded['identification_plate_number']"></form-input>
+        </div>
+        <div class="col-span-12 md:col-span-4">
           <form-input
               id="wellPlateAttached"
               :label="wellIdentificationPlateAttachedLabel"
               type="text"
               v-model="wellPlateAttachedInput"
               :errors="errors['well_identification_plate_attached']"
-              :loaded="fieldsLoaded['well_identification_plate_attached']"
-          ></form-input>
-        </b-col>
-        <b-col cols="12" md="4" v-if="isStaffEdit">
+              :loaded="fieldsLoaded['well_identification_plate_attached']"></form-input>
+        </div>
+        <div class="col-span-12 md:col-span-4" v-if="isStaffEdit">
           <form-input
               id="wellPlateAttachedBy"
               label="Identification Plate Attached By"
               type="text"
               v-model="idPlateAttachedByInput"
               :errors="errors['id_plate_attached_by']"
-              :loaded="fieldsLoaded['id_plate_attached_by']"
-          ></form-input>
-        </b-col>
-      </b-row>
+              :loaded="fieldsLoaded['id_plate_attached_by']"></form-input>
+        </div>
+      </div>
       <responsive-grid v-if="isStaffEdit" :cols="12" :md="4">
         <form-input
           id="waterSupplySystem"

--- a/app/frontend/src/submissions/components/SubmissionForm/WellType.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WellType.vue
@@ -37,16 +37,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
             id="wellClass"
             label="Class of Well *"
             aria-describedby="wellClassInvalidFeedback">
-            <b-form-select
+            <Dropdown
               v-model="wellClassInput"
               :options="codes?.well_classes"
-              value-field="well_class_code"
-              text-field="description"
-              :state="errors['well_class'] ? false : null">
-              <template v-slot:first>
-                <option :value="null">Select class</option>
-              </template>
-            </b-form-select>
+              optionValue="well_class_code"
+              optionLabel="description"
+              :invalid="errors['well_class'] ? true : false"
+              placeholder="Select class"/>
             <b-form-invalid-feedback id="wellClassInvalidFeedback">
               <div v-for="(error, index) in errors['well_class']" :key="`wellClass error ${index}`">
                 {{ error }}
@@ -57,17 +54,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
             id="wellSubclass"
             label="Well Subclass"
             aria-describedby="wellSubclassInvalidFeedback">
-            <b-form-select
+            <Dropdown
               v-model="wellSubclassInput"
               :options="subclasses"
-              value-field="well_subclass_guid"
-              text-field="description"
+              optionValue="well_subclass_guid"
+              optionLabel="description"
               :disabled="wellSubclassDisabled"
-              :state="errors['well_subclass'] ? false : null">
-              <template v-slot:first>
-                <option :value="null">Select subclass</option>
-              </template>
-            </b-form-select>
+              :invalid="errors['well_subclass'] ? true : false"
+              placeholder="Select subclass"/>
             <b-form-invalid-feedback id="wellSubclassInvalidFeedback">
               <div v-for="(error, index) in errors['well_subclass']" :key="`wellSubclass error ${index}`">
                 {{ error }}
@@ -122,30 +116,30 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </div>
         <div class="col-span-12 md:col-span-4">
           <form-input
-              id="idPlateNumber"
-              :label="wellIdentificationPlateNumberLabel"
-              type="number"
-              v-model="idPlateNumberInput"
-              :errors="errors['identification_plate_number']"
-              :loaded="fieldsLoaded['identification_plate_number']"></form-input>
+            id="idPlateNumber"
+            :label="wellIdentificationPlateNumberLabel"
+            type="number"
+            v-model="idPlateNumberInput"
+            :errors="errors['identification_plate_number']"
+            :loaded="fieldsLoaded['identification_plate_number']"></form-input>
         </div>
         <div class="col-span-12 md:col-span-4">
           <form-input
-              id="wellPlateAttached"
-              :label="wellIdentificationPlateAttachedLabel"
-              type="text"
-              v-model="wellPlateAttachedInput"
-              :errors="errors['well_identification_plate_attached']"
-              :loaded="fieldsLoaded['well_identification_plate_attached']"></form-input>
+            id="wellPlateAttached"
+            :label="wellIdentificationPlateAttachedLabel"
+            type="text"
+            v-model="wellPlateAttachedInput"
+            :errors="errors['well_identification_plate_attached']"
+            :loaded="fieldsLoaded['well_identification_plate_attached']"></form-input>
         </div>
         <div class="col-span-12 md:col-span-4" v-if="isStaffEdit">
           <form-input
-              id="wellPlateAttachedBy"
-              label="Identification Plate Attached By"
-              type="text"
-              v-model="idPlateAttachedByInput"
-              :errors="errors['id_plate_attached_by']"
-              :loaded="fieldsLoaded['id_plate_attached_by']"></form-input>
+            id="wellPlateAttachedBy"
+            label="Identification Plate Attached By"
+            type="text"
+            v-model="idPlateAttachedByInput"
+            :errors="errors['id_plate_attached_by']"
+            :loaded="fieldsLoaded['id_plate_attached_by']"></form-input>
         </div>
       </div>
       <responsive-grid v-if="isStaffEdit" :cols="12" :md="4">
@@ -166,26 +160,23 @@ Licensed under the Apache License, Version 2.0 (the "License");
       </responsive-grid>
       <responsive-grid v-if="!isStaffEdit" :cols="12" :md="6">
         <form-input
-            id="workStartDateInput"
-            type="date"
-            :label="startDateOfWorkLabel"
-            placeholder="YYYY-MM-DD"
-            v-model="workStartDateInput"
-            :errors="errors.work_start_date"
-            :loaded="fieldsLoaded['work_start_date']"
-            @input="handleDateInput($event, 'workStartDate')">
-        </form-input>
+          id="workStartDateInput"
+          type="date"
+          :label="startDateOfWorkLabel"
+          placeholder="YYYY-MM-DD"
+          v-model="workStartDateInput"
+          :errors="errors.work_start_date"
+          :loaded="fieldsLoaded['work_start_date']"
+          @input="handleDateInput($event, 'workStartDate')"></form-input>
         <form-input
-            id="workEndDateInput"
-            type="date"
-            :label="endDateOfWorkLabel"
-            placeholder="YYYY-MM-DD"
-            v-model="workEndDateInput"
-            :errors="errors.work_end_date"
-            :loaded="fieldsLoaded['work_end_date']"
-            @input="handleDateInput($event, 'workEndDate')"
-            >
-        </form-input>
+          id="workEndDateInput"
+          type="date"
+          :label="endDateOfWorkLabel"
+          placeholder="YYYY-MM-DD"
+          v-model="workEndDateInput"
+          :errors="errors.work_end_date"
+          :loaded="fieldsLoaded['work_end_date']"
+          @input="handleDateInput($event, 'workEndDate')"></form-input>
       </responsive-grid>
     </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/WellType.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WellType.vue
@@ -13,42 +13,36 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
     <form-subsection title="Well Class" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-      <b-row v-if="isStaffEdit">
-        <b-col cols="12" md="3" xl="2">
-          <form-input
-              id="wellTagNumberStaff"
-              label="Well Tag Number"
-              type="text"
-              :value="$route.params.id"
-              disabled
-          ></form-input>
-        </b-col>
-        <b-col cols="12" md="4">
-          <form-input
-            select
-            v-model="wellStatusCodeInput"
-            :options="codes?.well_status_codes"
-            value-field="well_status_code"
-            text-field="description"
-            label="Well Status"
-            placeholder="Select status"
-            :errors="errors['well_status']"
-            :loaded="fieldsLoaded['well_status']"
-            id="wellStatusCodeInput"></form-input>
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" md="4">
+      <responsive-grid v-if="isStaffEdit" :cols="12" :md="[3, 4]" :xl="[2, undefined]">
+        <form-input
+          id="wellTagNumberStaff"
+          label="Well Tag Number"
+          type="text"
+          :value="$route.params.id"
+          disabled></form-input>
+        <form-input
+          select
+          v-model="wellStatusCodeInput"
+          :options="codes?.well_status_codes"
+          value-field="well_status_code"
+          text-field="description"
+          label="Well Status"
+          placeholder="Select status"
+          :errors="errors['well_status']"
+          :loaded="fieldsLoaded['well_status']"
+          id="wellStatusCodeInput"></form-input>
+      </responsive-grid>
+      <responsive-grid :cols="12" :md="4">
           <b-form-group
-              id="wellClass"
-              label="Class of Well *"
-              aria-describedby="wellClassInvalidFeedback">
+            id="wellClass"
+            label="Class of Well *"
+            aria-describedby="wellClassInvalidFeedback">
             <b-form-select
-                v-model="wellClassInput"
-                :options="codes?.well_classes"
-                value-field="well_class_code"
-                text-field="description"
-                :state="errors['well_class'] ? false : null">
+              v-model="wellClassInput"
+              :options="codes?.well_classes"
+              value-field="well_class_code"
+              text-field="description"
+              :state="errors['well_class'] ? false : null">
               <template v-slot:first>
                 <option :value="null">Select class</option>
               </template>
@@ -59,19 +53,17 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </div>
             </b-form-invalid-feedback>
           </b-form-group>
-        </b-col>
-        <b-col cols="12" md="4">
           <b-form-group
-              id="wellSubclass"
-              label="Well Subclass"
-              aria-describedby="wellSubclassInvalidFeedback">
+            id="wellSubclass"
+            label="Well Subclass"
+            aria-describedby="wellSubclassInvalidFeedback">
             <b-form-select
-                v-model="wellSubclassInput"
-                :options="subclasses"
-                value-field="well_subclass_guid"
-                text-field="description"
-                :disabled="wellSubclassDisabled"
-                :state="errors['well_subclass'] ? false : null">
+              v-model="wellSubclassInput"
+              :options="subclasses"
+              value-field="well_subclass_guid"
+              text-field="description"
+              :disabled="wellSubclassDisabled"
+              :state="errors['well_subclass'] ? false : null">
               <template v-slot:first>
                 <option :value="null">Select subclass</option>
               </template>
@@ -82,8 +74,6 @@ Licensed under the Apache License, Version 2.0 (the "License");
               </div>
             </b-form-invalid-feedback>
           </b-form-group>
-        </b-col>
-        <b-col cols="12" md="4">
           <form-input
             select
             v-model="intendedWaterUseInput"
@@ -96,8 +86,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :loaded="fieldsLoaded['intended_water_use']"
             :disabled="intendedWaterUseDisabled"
             id="intendedWaterUse"></form-input>
-        </b-col>
-      </b-row>
+      </responsive-grid>
       <b-row>
         <b-col cols="12" md="4" v-if="!isStaffEdit && wellActivityType !== 'CON'">
           <b-form-group>
@@ -162,56 +151,45 @@ Licensed under the Apache License, Version 2.0 (the "License");
           ></form-input>
         </b-col>
       </b-row>
-      <b-row v-if="isStaffEdit">
-        <b-col cols="12" md="4">
-          <form-input
-              id="waterSupplySystem"
-              label="Water Supply System Name"
-              type="text"
-              v-model="waterSupplySystemInput"
-              :errors="errors['water_supply_system_name']"
-              :loaded="fieldsLoaded['water_supply_system_name']"
-          ></form-input>
-        </b-col>
-        <b-col cols="12" md="4">
-          <form-input
-              id="waterSupplyWell"
-              label="Water Supply Well Name"
-              type="text"
-              v-model="waterSupplyWellInput"
-              :errors="errors['water_supply_system_well_name']"
-              :loaded="fieldsLoaded['water_supply_system_well_name']"
-          ></form-input>
-        </b-col>
-      </b-row>
-      <div v-if="!isStaffEdit" class="grid grid-cols-12">
-        <div class="col-span-12 md:col-span-6">
-          <form-input
-              id="workStartDateInput"
-              type="date"
-              :label="startDateOfWorkLabel"
-              placeholder="YYYY-MM-DD"
-              v-model="workStartDateInput"
-              :errors="errors.work_start_date"
-              :loaded="fieldsLoaded['work_start_date']"
-              @input="handleDateInput($event, 'workStartDate')"
-              >
-          </form-input>
-        </div>
-        <div class="col-span-12 md:col-span-6">
-          <form-input
-              id="workEndDateInput"
-              type="date"
-              :label="endDateOfWorkLabel"
-              placeholder="YYYY-MM-DD"
-              v-model="workEndDateInput"
-              :errors="errors.work_end_date"
-              :loaded="fieldsLoaded['work_end_date']"
-              @input="handleDateInput($event, 'workEndDate')"
-              >
-          </form-input>
-        </div>
-      </div>
+      <responsive-grid v-if="isStaffEdit" :cols="12" :md="4">
+        <form-input
+          id="waterSupplySystem"
+          label="Water Supply System Name"
+          type="text"
+          v-model="waterSupplySystemInput"
+          :errors="errors['water_supply_system_name']"
+          :loaded="fieldsLoaded['water_supply_system_name']"></form-input>
+        <form-input
+          id="waterSupplyWell"
+          label="Water Supply Well Name"
+          type="text"
+          v-model="waterSupplyWellInput"
+          :errors="errors['water_supply_system_well_name']"
+          :loaded="fieldsLoaded['water_supply_system_well_name']"></form-input>
+      </responsive-grid>
+      <responsive-grid v-if="!isStaffEdit" :cols="12" :md="6">
+        <form-input
+            id="workStartDateInput"
+            type="date"
+            :label="startDateOfWorkLabel"
+            placeholder="YYYY-MM-DD"
+            v-model="workStartDateInput"
+            :errors="errors.work_start_date"
+            :loaded="fieldsLoaded['work_start_date']"
+            @input="handleDateInput($event, 'workStartDate')">
+        </form-input>
+        <form-input
+            id="workEndDateInput"
+            type="date"
+            :label="endDateOfWorkLabel"
+            placeholder="YYYY-MM-DD"
+            v-model="workEndDateInput"
+            :errors="errors.work_end_date"
+            :loaded="fieldsLoaded['work_end_date']"
+            @input="handleDateInput($event, 'workEndDate')"
+            >
+        </form-input>
+      </responsive-grid>
     </form-subsection>
 </template>
 
@@ -220,6 +198,7 @@ import { useSubmissionStore } from '@/stores/submission'
 import { useCommonStore } from '@/stores/common'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
@@ -269,7 +248,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   data () {
     return {

--- a/app/frontend/src/submissions/components/SubmissionForm/WellType.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WellType.vue
@@ -33,53 +33,51 @@ Licensed under the Apache License, Version 2.0 (the "License");
           id="wellStatusCodeInput"/>
       </responsive-grid>
       <responsive-grid :cols="12" :md="4">
-          <b-form-group
+        <div class="flex flex-col gap-2" aria-describedby="wellClassInvalidFeedback">
+          <label>Class of Well *</label>
+          <Select
             id="wellClass"
-            label="Class of Well *"
-            aria-describedby="wellClassInvalidFeedback">
-            <Select
-              v-model="wellClassInput"
-              :options="codes?.well_classes"
-              optionValue="well_class_code"
-              optionLabel="description"
-              :invalid="errors['well_class'] ? true : false"
-              placeholder="Select class"/>
-            <b-form-invalid-feedback id="wellClassInvalidFeedback">
-              <div v-for="(error, index) in errors['well_class']" :key="`wellClass error ${index}`">
-                {{ error }}
-              </div>
-            </b-form-invalid-feedback>
-          </b-form-group>
-          <b-form-group
+            v-model="wellClassInput"
+            :options="codes?.well_classes"
+            optionValue="well_class_code"
+            optionLabel="description"
+            :invalid="errors['well_class'] ? true : false"
+            placeholder="Select class"/>
+          <div id="wellClassInvalidFeedback">
+            <div v-for="(error, index) in errors['well_class']" class="mt-1 text-sm text-red-600" :key="`wellClass error ${index}`">
+              {{ error }}
+            </div>
+          </div>
+        </div>
+        <div class="flex flex-col gap-2" aria-describedby="wellSubclassInvalidFeedback">
+          <label>Well Subclass</label>
+          <Select
             id="wellSubclass"
-            label="Well Subclass"
-            aria-describedby="wellSubclassInvalidFeedback">
-            <Select
-              v-model="wellSubclassInput"
-              :options="subclasses"
-              optionValue="well_subclass_guid"
-              optionLabel="description"
-              :disabled="wellSubclassDisabled"
-              :invalid="errors['well_subclass'] ? true : false"
-              placeholder="Select subclass"/>
-            <b-form-invalid-feedback id="wellSubclassInvalidFeedback">
-              <div v-for="(error, index) in errors['well_subclass']" :key="`wellSubclass error ${index}`">
-                {{ error }}
-              </div>
-            </b-form-invalid-feedback>
-          </b-form-group>
-          <form-input
-            select
-            v-model="intendedWaterUseInput"
-            :options="intendedWaterUseOptions"
-            value-field="intended_water_use_code"
-            text-field="description"
-            label="Intended Water Use *"
-            placeholder="Select intended use"
-            :errors="errors['intended_water_use']"
-            :loaded="fieldsLoaded['intended_water_use']"
-            :disabled="intendedWaterUseDisabled"
-            id="intendedWaterUse"/>
+            v-model="wellSubclassInput"
+            :options="subclasses"
+            optionValue="well_subclass_guid"
+            optionLabel="description"
+            :disabled="wellSubclassDisabled"
+            :invalid="errors['well_subclass'] ? true : false"
+            placeholder="Select subclass"/>
+          <div id="wellSubclassInvalidFeedback">
+            <div v-for="(error, index) in errors['well_subclass']" class="mt-1 text-sm text-red-600" :key="`wellSubclass error ${index}`">
+              {{ error }}
+            </div>
+          </div>
+        </div>
+        <form-input
+          select
+          v-model="intendedWaterUseInput"
+          :options="intendedWaterUseOptions"
+          value-field="intended_water_use_code"
+          text-field="description"
+          label="Intended Water Use *"
+          placeholder="Select intended use"
+          :errors="errors['intended_water_use']"
+          :loaded="fieldsLoaded['intended_water_use']"
+          :disabled="intendedWaterUseDisabled"
+          id="intendedWaterUse"/>
       </responsive-grid>
       <div class="grid grid-cols-12">
         <div class="col-span-12 md:col-span-4" v-if="!isStaffEdit && wellActivityType !== 'CON'">

--- a/app/frontend/src/submissions/components/SubmissionForm/WellType.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WellType.vue
@@ -19,7 +19,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           label="Well Tag Number"
           type="text"
           :value="$route.params.id"
-          disabled></form-input>
+          disabled/>
         <form-input
           select
           v-model="wellStatusCodeInput"
@@ -30,14 +30,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
           placeholder="Select status"
           :errors="errors['well_status']"
           :loaded="fieldsLoaded['well_status']"
-          id="wellStatusCodeInput"></form-input>
+          id="wellStatusCodeInput"/>
       </responsive-grid>
       <responsive-grid :cols="12" :md="4">
           <b-form-group
             id="wellClass"
             label="Class of Well *"
             aria-describedby="wellClassInvalidFeedback">
-            <Dropdown
+            <Select
               v-model="wellClassInput"
               :options="codes?.well_classes"
               optionValue="well_class_code"
@@ -54,7 +54,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             id="wellSubclass"
             label="Well Subclass"
             aria-describedby="wellSubclassInvalidFeedback">
-            <Dropdown
+            <Select
               v-model="wellSubclassInput"
               :options="subclasses"
               optionValue="well_subclass_guid"
@@ -79,12 +79,12 @@ Licensed under the Apache License, Version 2.0 (the "License");
             :errors="errors['intended_water_use']"
             :loaded="fieldsLoaded['intended_water_use']"
             :disabled="intendedWaterUseDisabled"
-            id="intendedWaterUse"></form-input>
+            id="intendedWaterUse"/>
       </responsive-grid>
       <div class="grid grid-cols-12">
         <div class="col-span-12 md:col-span-4" v-if="!isStaffEdit && wellActivityType !== 'CON'">
-          <b-form-group>
-            <label>Well Tag Number (if known) <span class="font-weight-bold"></span></label>
+          <div class="flex flex-col gap-2">
+            <label for="wellTagNumberSelect">Well Tag Number (if known)</label>
             <v-select
               v-model="wellTagNumberInput"
               :disabled="wells === null"
@@ -112,7 +112,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             <small id="wellTagNumberSelectHint" class="form-text text-muted">
               *displays a maximum of {{MAX_RESULTS}} results
             </small>
-          </b-form-group>
+          </div>
         </div>
         <div class="col-span-12 md:col-span-4">
           <form-input
@@ -121,7 +121,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             type="number"
             v-model="idPlateNumberInput"
             :errors="errors['identification_plate_number']"
-            :loaded="fieldsLoaded['identification_plate_number']"></form-input>
+            :loaded="fieldsLoaded['identification_plate_number']"/>
         </div>
         <div class="col-span-12 md:col-span-4">
           <form-input
@@ -130,7 +130,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             type="text"
             v-model="wellPlateAttachedInput"
             :errors="errors['well_identification_plate_attached']"
-            :loaded="fieldsLoaded['well_identification_plate_attached']"></form-input>
+            :loaded="fieldsLoaded['well_identification_plate_attached']"/>
         </div>
         <div class="col-span-12 md:col-span-4" v-if="isStaffEdit">
           <form-input
@@ -139,7 +139,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
             type="text"
             v-model="idPlateAttachedByInput"
             :errors="errors['id_plate_attached_by']"
-            :loaded="fieldsLoaded['id_plate_attached_by']"></form-input>
+            :loaded="fieldsLoaded['id_plate_attached_by']"/>
         </div>
       </div>
       <responsive-grid v-if="isStaffEdit" :cols="12" :md="4">
@@ -149,14 +149,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
           type="text"
           v-model="waterSupplySystemInput"
           :errors="errors['water_supply_system_name']"
-          :loaded="fieldsLoaded['water_supply_system_name']"></form-input>
+          :loaded="fieldsLoaded['water_supply_system_name']"/>
         <form-input
           id="waterSupplyWell"
           label="Water Supply Well Name"
           type="text"
           v-model="waterSupplyWellInput"
           :errors="errors['water_supply_system_well_name']"
-          :loaded="fieldsLoaded['water_supply_system_well_name']"></form-input>
+          :loaded="fieldsLoaded['water_supply_system_well_name']"/>
       </responsive-grid>
       <responsive-grid v-if="!isStaffEdit" :cols="12" :md="6">
         <form-input
@@ -167,7 +167,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           v-model="workStartDateInput"
           :errors="errors.work_start_date"
           :loaded="fieldsLoaded['work_start_date']"
-          @input="handleDateInput($event, 'workStartDate')"></form-input>
+          @input="handleDateInput($event, 'workStartDate')"/>
         <form-input
           id="workEndDateInput"
           type="date"
@@ -176,7 +176,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           v-model="workEndDateInput"
           :errors="errors.work_end_date"
           :loaded="fieldsLoaded['work_end_date']"
-          @input="handleDateInput($event, 'workEndDate')"></form-input>
+          @input="handleDateInput($event, 'workEndDate')"/>
       </responsive-grid>
     </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/WorkDates.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WorkDates.vue
@@ -21,7 +21,7 @@ limitations under the License.
         placeholder="YYYY-MM-DD"
         v-model="constructionStartDateInput"
         :errors="errors.construction_start_date"
-        :loaded="fieldsLoaded['construction_start_date']"></form-input>
+        :loaded="fieldsLoaded['construction_start_date']"/>
       <form-input
         id="constructionEndDateInput"
         type="date"
@@ -29,7 +29,7 @@ limitations under the License.
         placeholder="YYYY-MM-DD"
         v-model="constructionEndDateInput"
         :errors="errors.construction_end_date"
-        :loaded="fieldsLoaded['construction_end_date']"></form-input>
+        :loaded="fieldsLoaded['construction_end_date']"/>
       <form-input
         id="alterationStartDateInput"
         type="date"
@@ -37,7 +37,7 @@ limitations under the License.
         placeholder="YYYY-MM-DD"
         v-model="alterationStartDateInput"
         :errors="errors.alteration_start_date"
-        :loaded="fieldsLoaded['alteration_start_date']"></form-input>
+        :loaded="fieldsLoaded['alteration_start_date']"/>
       <form-input
         id="alterationEndDateInput"
         type="date"
@@ -45,7 +45,7 @@ limitations under the License.
         placeholder="YYYY-MM-DD"
         v-model="alterationEndDateInput"
         :errors="errors.alteration_end_date"
-        :loaded="fieldsLoaded['alteration_end_date']"></form-input>
+        :loaded="fieldsLoaded['alteration_end_date']"/>
       <form-input
         id="decommissionStartDateInput"
         type="date"
@@ -53,7 +53,7 @@ limitations under the License.
         placeholder="YYYY-MM-DD"
         v-model="decommissionStartDateInput"
         :errors="errors.decommission_start_date"
-        :loaded="fieldsLoaded['decommission_start_date']"></form-input>
+        :loaded="fieldsLoaded['decommission_start_date']"/>
       <form-input
         id="decommissionEndDateInput"
         type="date"
@@ -61,7 +61,7 @@ limitations under the License.
         placeholder="YYYY-MM-DD"
         v-model="decommissionEndDateInput"
         :errors="errors.decommission_end_date"
-        :loaded="fieldsLoaded['decommission_end_date']"></form-input>
+        :loaded="fieldsLoaded['decommission_end_date']"/>
     </responsive-grid>
   </form-subsection>
 </template>

--- a/app/frontend/src/submissions/components/SubmissionForm/WorkDates.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WorkDates.vue
@@ -13,84 +13,63 @@ limitations under the License.
 */
 <template>
   <form-subsection title="Well Work Dates" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <b-row v-if="isStaffEdit">
-      <b-col cols="6" md="6">
-        <form-input
-          id="constructionStartDateInput"
-          type="date"
-          label="Start Date of Construction"
-          placeholder="YYYY-MM-DD"
-          v-model="constructionStartDateInput"
-          :errors="errors.construction_start_date"
-          :loaded="fieldsLoaded['construction_start_date']">
-        </form-input>
-      </b-col>
-      <b-col cols="6" md="6">
-        <form-input
-          id="constructionEndDateInput"
-          type="date"
-          label="End Date of Construction"
-          placeholder="YYYY-MM-DD"
-          v-model="constructionEndDateInput"
-          :errors="errors.construction_end_date"
-          :loaded="fieldsLoaded['construction_end_date']">
-        </form-input>
-      </b-col>
-    </b-row>
-    <b-row v-if="isStaffEdit">
-      <b-col cols="6" md="6">
-        <form-input
-          id="alterationStartDateInput"
-          type="date"
-          label="Start Date of Alteration"
-          placeholder="YYYY-MM-DD"
-          v-model="alterationStartDateInput"
-          :errors="errors.alteration_start_date"
-          :loaded="fieldsLoaded['alteration_start_date']">
-        </form-input>
-      </b-col>
-      <b-col cols="6" md="6">
-        <form-input
-          id="alterationEndDateInput"
-          type="date"
-          label="End Date of Alteration"
-          placeholder="YYYY-MM-DD"
-          v-model="alterationEndDateInput"
-          :errors="errors.alteration_end_date"
-          :loaded="fieldsLoaded['alteration_end_date']">
-        </form-input>
-      </b-col>
-    </b-row>
-    <b-row v-if="isStaffEdit">
-      <b-col cols="6" md="6">
-        <form-input
-          id="decommissionStartDateInput"
-          type="date"
-          label="Start Date of Decommission"
-          placeholder="YYYY-MM-DD"
-          v-model="decommissionStartDateInput"
-          :errors="errors.decommission_start_date"
-          :loaded="fieldsLoaded['decommission_start_date']">
-        </form-input>
-      </b-col>
-      <b-col cols="6" md="6">
-        <form-input
-          id="decommissionEndDateInput"
-          type="date"
-          label="End Date of Decommission"
-          placeholder="YYYY-MM-DD"
-          v-model="decommissionEndDateInput"
-          :errors="errors.decommission_end_date"
-          :loaded="fieldsLoaded['decommission_end_date']">
-        </form-input>
-      </b-col>
-    </b-row>
+    <responsive-grid v-if="isStaffEdit" :cols="6" :md="6">
+      <form-input
+        id="constructionStartDateInput"
+        type="date"
+        label="Start Date of Construction"
+        placeholder="YYYY-MM-DD"
+        v-model="constructionStartDateInput"
+        :errors="errors.construction_start_date"
+        :loaded="fieldsLoaded['construction_start_date']"></form-input>
+      <form-input
+        id="constructionEndDateInput"
+        type="date"
+        label="End Date of Construction"
+        placeholder="YYYY-MM-DD"
+        v-model="constructionEndDateInput"
+        :errors="errors.construction_end_date"
+        :loaded="fieldsLoaded['construction_end_date']"></form-input>
+      <form-input
+        id="alterationStartDateInput"
+        type="date"
+        label="Start Date of Alteration"
+        placeholder="YYYY-MM-DD"
+        v-model="alterationStartDateInput"
+        :errors="errors.alteration_start_date"
+        :loaded="fieldsLoaded['alteration_start_date']"></form-input>
+      <form-input
+        id="alterationEndDateInput"
+        type="date"
+        label="End Date of Alteration"
+        placeholder="YYYY-MM-DD"
+        v-model="alterationEndDateInput"
+        :errors="errors.alteration_end_date"
+        :loaded="fieldsLoaded['alteration_end_date']"></form-input>
+      <form-input
+        id="decommissionStartDateInput"
+        type="date"
+        label="Start Date of Decommission"
+        placeholder="YYYY-MM-DD"
+        v-model="decommissionStartDateInput"
+        :errors="errors.decommission_start_date"
+        :loaded="fieldsLoaded['decommission_start_date']"></form-input>
+      <form-input
+        id="decommissionEndDateInput"
+        type="date"
+        label="End Date of Decommission"
+        placeholder="YYYY-MM-DD"
+        v-model="decommissionEndDateInput"
+        :errors="errors.decommission_end_date"
+        :loaded="fieldsLoaded['decommission_end_date']"></form-input>
+    </responsive-grid>
   </form-subsection>
 </template>
 
 <script>
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -123,7 +102,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   computed: {
   },

--- a/app/frontend/src/submissions/components/SubmissionForm/WorkDates.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/WorkDates.vue
@@ -12,20 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 <template>
-  <fieldset>
-    <b-row>
-      <b-col cols="12" lg="6">
-        <legend :id="id">Well Work Dates</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
-        <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">
-            Save
-          </b-btn>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </b-col>
-    </b-row>
+  <form-subsection title="Well Work Dates" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <b-row v-if="isStaffEdit">
       <b-col cols="6" md="6">
         <form-input
@@ -98,11 +85,12 @@ limitations under the License.
         </form-input>
       </b-col>
     </b-row>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -133,6 +121,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   computed: {
   },

--- a/app/frontend/src/submissions/components/SubmissionForm/Yield.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Yield.vue
@@ -12,18 +12,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
     limitations under the License.
 */
 <template>
-  <fieldset :id="id">
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 lg:col-span-6">
-        <legend :id="id">Yield</legend>
-      </div>
-      <div class="col-span-12 lg:col-span-6">
-        <div class="float-right">
-          <Button v-if="isStaffEdit" label="Save" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
-          <back-to-top-link v-if="isStaffEdit"/>
-        </div>
-      </div>
-    </div>
+  <form-subsection title="Yield" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <div class="grid grid-cols-12 mt-4">
       <div class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input
@@ -112,13 +101,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
         />
       </div>
     </div>
-  </fieldset>
+  </form-subsection>
 </template>
 
 <script>
 import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
+import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -152,6 +142,9 @@ export default {
       type: Boolean,
       isInput: false
     }
+  },
+  components: {
+    FormSubsection
   },
   computed: {
     codes () {

--- a/app/frontend/src/submissions/components/SubmissionForm/Yield.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Yield.vue
@@ -22,19 +22,19 @@ Licensed under the Apache License, Version 2.0 (the "License");
         text-field="description"
         value-field="yield_estimation_method_code"
         v-model="yieldEstimationMethodInput"
-        placeholder="Select method"></form-input>
+        placeholder="Select method"/>
       <form-input
         id="yieldEstimationRate"
         label="Yield Estimation Rate"
         type="number"
         hint="USgpm"
-        v-model="yieldEstimationRateInput"></form-input>
+        v-model="yieldEstimationRateInput"/>
       <form-input
         id="yieldEstimationRate"
         label="Yield Estimation Rate"
         type="number"
         hint="USgpm"
-        v-model="yieldEstimationRateInput"></form-input>
+        v-model="yieldEstimationRateInput"/>
     </responsive-grid>
     <responsive-grid :cols="12" :md="4" :lg="3">
       <form-input
@@ -42,9 +42,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
         label="SWL Before Test"
         type="number"
         v-model="staticLevelInput"
-        hint="ft (btoc)"></form-input>
-      <b-form-group label="Hydro-fracturing Performed">
-        <RadioButtonGroup class="mt-1" v-model="hydroFracturingPerformedInput" name="hydroFracturingPerformed">
+        hint="ft (btoc)"/>
+      <div class="flex flex-col gap-2">
+        <label for="hydroFracturingPerformed">Hydro-fracturing Performed</label>
+        <RadioButtonGroup 
+          class="mt-1" 
+          v-model="hydroFracturingPerformedInput"
+          id="hydroFracturingPerformed"
+          name="hydroFracturingPerformed">
           <div>
             <RadioButton inputId="hydroFracturingPerformedInput.false" :value="false"/>
             <label for="hydroFracturingPerformedInput.false" class="ml-2">No</label>
@@ -54,13 +59,13 @@ Licensed under the Apache License, Version 2.0 (the "License");
             <label for="hydroFracturingPerformedInput.true" class="ml-2">Yes</label>
           </div>
         </RadioButtonGroup>
-      </b-form-group>
+      </div>
       <form-input
         id="hydroFracturingYieldIncrease"
         label="Increase in Well Yield Due to Hydro-fracturing"
         type="number"
         v-model="hydroFracturingYieldIncreaseInput"
-        hint="USgpm"></form-input>
+        hint="USgpm"/>
     </responsive-grid>
     <div class="grid grid-cols-12">
       <div class="col-span-12 md:col-span-4 lg:col-span-3">
@@ -69,7 +74,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           label="Drawdown"
           type="number"
           v-model="drawdownInput"
-          hint="ft (btoc)"></form-input>
+          hint="ft (btoc)"/>
       </div>
       <div v-if="isStaffEdit" class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input

--- a/app/frontend/src/submissions/components/SubmissionForm/Yield.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Yield.vue
@@ -13,19 +13,19 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <fieldset :id="id">
-    <b-row>
-      <b-col cols="12" lg="6">
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 lg:col-span-6">
         <legend :id="id">Yield</legend>
-      </b-col>
-      <b-col cols="12" lg="6">
+      </div>
+      <div class="col-span-12 lg:col-span-6">
         <div class="float-right">
-          <b-btn v-if="isStaffEdit" variant="primary" class="ml-2" @click="$emit('save')" :disabled="saveDisabled">Save</b-btn>
+          <Button v-if="isStaffEdit" label="Save" class="ml-2" @click="$emit('save')" :disabled="saveDisabled"/>
           <back-to-top-link v-if="isStaffEdit"/>
         </div>
-      </b-col>
-    </b-row>
-    <b-row class="mt-4">
-      <b-col cols="12" md="4" lg="3">
+      </div>
+    </div>
+    <div class="grid grid-cols-12 mt-4">
+      <div class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input
             id="yieldEstimationMethod"
             label="Yield Estimation Method"
@@ -35,34 +35,34 @@ Licensed under the Apache License, Version 2.0 (the "License");
             value-field="yield_estimation_method_code"
             v-model="yieldEstimationMethodInput"
             placeholder="Select method"></form-input>
-      </b-col>
-      <b-col cols="12" md="4" lg="3">
+      </div>
+      <div class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input
             id="yieldEstimationRate"
             label="Yield Estimation Rate"
             type="number"
             hint="USgpm"
             v-model="yieldEstimationRateInput"></form-input>
-      </b-col>
-      <b-col cols="12" md="4" lg="3">
+      </div>
+      <div class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input
             id="yieldEstimationDuration"
             label="Yield Estimation Duration"
             type="number"
             hint="Hours"
             v-model="yieldEstimationDurationInput"></form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="4" lg="3">
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input
             id="staticWaterLevelTest"
             label="SWL Before Test"
             type="number"
             v-model="staticLevelInput"
             hint="ft (btoc)"></form-input>
-      </b-col>
-      <b-col cols="12" md="4" lg="3">
+      </div>
+      <div class="col-span-12 md:col-span-4 lg:col-span-3">
         <b-form-group label="Hydro-fracturing Performed">
           <b-form-radio-group v-model="hydroFracturingPerformedInput"
             id="hydroFracPerformedOptions"
@@ -72,8 +72,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
             <b-form-radio :value="true">Yes</b-form-radio>
           </b-form-radio-group>
         </b-form-group>
-      </b-col>
-      <b-col cols="12" md="4" lg="4">
+      </div>
+      <div class="col-span-12 md:col-span-4 lg:col-span-4">
         <form-input
           id="hydroFracturingYieldIncrease"
           label="Increase in Well Yield Due to Hydro-fracturing"
@@ -81,10 +81,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
           v-model="hydroFracturingYieldIncreaseInput"
           hint="USgpm"
         ></form-input>
-      </b-col>
-    </b-row>
-    <b-row>
-      <b-col cols="12" md="4" lg="3">
+      </div>
+    </div>
+    <div class="grid grid-cols-12">
+      <div class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input
             id="drawdown"
             label="Drawdown"
@@ -92,8 +92,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
             v-model="drawdownInput"
             hint="ft (btoc)"
             ></form-input>
-      </b-col>
-      <b-col v-if="isStaffEdit" cols="12" md="4" lg="3">
+      </div>
+      <div v-if="isStaffEdit" class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input
           id="recommendedPumpDepth"
           label="Recommended Pump Depth"
@@ -101,8 +101,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           v-model="recommendedPumpDepthInput"
           hint="ft (btoc)"
         />
-      </b-col>
-      <b-col v-if="isStaffEdit" cols="12" md="4" lg="3">
+      </div>
+      <div v-if="isStaffEdit" class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input
           id="recommendedPumpRate"
           label="Recommended Pump Rate"
@@ -110,8 +110,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
           v-model="recommendedPumpRateInput"
           hint="USgpm"
         />
-      </b-col>
-    </b-row>
+      </div>
+    </div>
   </fieldset>
 </template>
 

--- a/app/frontend/src/submissions/components/SubmissionForm/Yield.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Yield.vue
@@ -13,65 +13,52 @@ Licensed under the Apache License, Version 2.0 (the "License");
 */
 <template>
   <form-subsection title="Yield" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
-    <div class="grid grid-cols-12 mt-4">
-      <div class="col-span-12 md:col-span-4 lg:col-span-3">
+    <responsive-grid class="mt-4" :cols="12" :md="4" :lg="3">
         <form-input
-            id="yieldEstimationMethod"
-            label="Yield Estimation Method"
-            select
-            :options="codes?.yield_estimation_methods"
-            text-field="description"
-            value-field="yield_estimation_method_code"
-            v-model="yieldEstimationMethodInput"
-            placeholder="Select method"></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-4 lg:col-span-3">
+          id="yieldEstimationMethod"
+          label="Yield Estimation Method"
+          select
+          :options="codes?.yield_estimation_methods"
+          text-field="description"
+          value-field="yield_estimation_method_code"
+          v-model="yieldEstimationMethodInput"
+          placeholder="Select method"></form-input>
         <form-input
-            id="yieldEstimationRate"
-            label="Yield Estimation Rate"
-            type="number"
-            hint="USgpm"
-            v-model="yieldEstimationRateInput"></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-4 lg:col-span-3">
-        <form-input
-            id="yieldEstimationDuration"
-            label="Yield Estimation Duration"
-            type="number"
-            hint="Hours"
-            v-model="yieldEstimationDurationInput"></form-input>
-      </div>
-    </div>
-    <div class="grid grid-cols-12">
-      <div class="col-span-12 md:col-span-4 lg:col-span-3">
-        <form-input
-            id="staticWaterLevelTest"
-            label="SWL Before Test"
-            type="number"
-            v-model="staticLevelInput"
-            hint="ft (btoc)"></form-input>
-      </div>
-      <div class="col-span-12 md:col-span-4 lg:col-span-3">
-        <b-form-group label="Hydro-fracturing Performed">
-          <b-form-radio-group v-model="hydroFracturingPerformedInput"
-            id="hydroFracPerformedOptions"
-            name="hydroFracturingPerformed"
-          >
-            <b-form-radio :value="false">No</b-form-radio>
-            <b-form-radio :value="true">Yes</b-form-radio>
-          </b-form-radio-group>
-        </b-form-group>
-      </div>
-      <div class="col-span-12 md:col-span-4 lg:col-span-4">
-        <form-input
-          id="hydroFracturingYieldIncrease"
-          label="Increase in Well Yield Due to Hydro-fracturing"
+          id="yieldEstimationRate"
+          label="Yield Estimation Rate"
           type="number"
-          v-model="hydroFracturingYieldIncreaseInput"
           hint="USgpm"
-        ></form-input>
-      </div>
-    </div>
+          v-model="yieldEstimationRateInput"></form-input>
+        <form-input
+          id="yieldEstimationRate"
+          label="Yield Estimation Rate"
+          type="number"
+          hint="USgpm"
+          v-model="yieldEstimationRateInput"></form-input>
+    </responsive-grid>
+    <responsive-grid :cols="12" :md="4" :lg="3">
+      <form-input
+        id="staticWaterLevelTest"
+        label="SWL Before Test"
+        type="number"
+        v-model="staticLevelInput"
+        hint="ft (btoc)"></form-input>
+      <b-form-group label="Hydro-fracturing Performed">
+        <b-form-radio-group v-model="hydroFracturingPerformedInput"
+          id="hydroFracPerformedOptions"
+          name="hydroFracturingPerformed"
+        >
+          <b-form-radio :value="false">No</b-form-radio>
+          <b-form-radio :value="true">Yes</b-form-radio>
+        </b-form-radio-group>
+      </b-form-group>
+      <form-input
+        id="hydroFracturingYieldIncrease"
+        label="Increase in Well Yield Due to Hydro-fracturing"
+        type="number"
+        v-model="hydroFracturingYieldIncreaseInput"
+        hint="USgpm"></form-input>
+    </responsive-grid>
     <div class="grid grid-cols-12">
       <div class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input
@@ -109,6 +96,7 @@ import { useSubmissionStore } from '@/stores/submission'
 
 import inputBindingsMixin from '@/common/inputBindingsMixin.js'
 import FormSubsection from '../FormSubcomponents/FormSubsection.vue'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 
 export default {
   mixins: [inputBindingsMixin],
@@ -144,7 +132,8 @@ export default {
     }
   },
   components: {
-    FormSubsection
+    FormSubsection,
+    ResponsiveGrid
   },
   computed: {
     codes () {

--- a/app/frontend/src/submissions/components/SubmissionForm/Yield.vue
+++ b/app/frontend/src/submissions/components/SubmissionForm/Yield.vue
@@ -14,27 +14,27 @@ Licensed under the Apache License, Version 2.0 (the "License");
 <template>
   <form-subsection title="Yield" :id="id" :isStaffEdit="isStaffEdit" :saveDisabled="saveDisabled">
     <responsive-grid class="mt-4" :cols="12" :md="4" :lg="3">
-        <form-input
-          id="yieldEstimationMethod"
-          label="Yield Estimation Method"
-          select
-          :options="codes?.yield_estimation_methods"
-          text-field="description"
-          value-field="yield_estimation_method_code"
-          v-model="yieldEstimationMethodInput"
-          placeholder="Select method"></form-input>
-        <form-input
-          id="yieldEstimationRate"
-          label="Yield Estimation Rate"
-          type="number"
-          hint="USgpm"
-          v-model="yieldEstimationRateInput"></form-input>
-        <form-input
-          id="yieldEstimationRate"
-          label="Yield Estimation Rate"
-          type="number"
-          hint="USgpm"
-          v-model="yieldEstimationRateInput"></form-input>
+      <form-input
+        id="yieldEstimationMethod"
+        label="Yield Estimation Method"
+        select
+        :options="codes?.yield_estimation_methods"
+        text-field="description"
+        value-field="yield_estimation_method_code"
+        v-model="yieldEstimationMethodInput"
+        placeholder="Select method"></form-input>
+      <form-input
+        id="yieldEstimationRate"
+        label="Yield Estimation Rate"
+        type="number"
+        hint="USgpm"
+        v-model="yieldEstimationRateInput"></form-input>
+      <form-input
+        id="yieldEstimationRate"
+        label="Yield Estimation Rate"
+        type="number"
+        hint="USgpm"
+        v-model="yieldEstimationRateInput"></form-input>
     </responsive-grid>
     <responsive-grid :cols="12" :md="4" :lg="3">
       <form-input
@@ -44,13 +44,16 @@ Licensed under the Apache License, Version 2.0 (the "License");
         v-model="staticLevelInput"
         hint="ft (btoc)"></form-input>
       <b-form-group label="Hydro-fracturing Performed">
-        <b-form-radio-group v-model="hydroFracturingPerformedInput"
-          id="hydroFracPerformedOptions"
-          name="hydroFracturingPerformed"
-        >
-          <b-form-radio :value="false">No</b-form-radio>
-          <b-form-radio :value="true">Yes</b-form-radio>
-        </b-form-radio-group>
+        <RadioButtonGroup class="mt-1" v-model="hydroFracturingPerformedInput" name="hydroFracturingPerformed">
+          <div>
+            <RadioButton inputId="hydroFracturingPerformedInput.false" :value="false"/>
+            <label for="hydroFracturingPerformedInput.false" class="ml-2">No</label>
+          </div>
+          <div>
+            <RadioButton inputId="hydroFracturingPerformedInput.true" :value="true"/>
+            <label for="hydroFracturingPerformedInput.true" class="ml-2">Yes</label>
+          </div>
+        </RadioButtonGroup>
       </b-form-group>
       <form-input
         id="hydroFracturingYieldIncrease"
@@ -62,12 +65,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <div class="grid grid-cols-12">
       <div class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input
-            id="drawdown"
-            label="Drawdown"
-            type="number"
-            v-model="drawdownInput"
-            hint="ft (btoc)"
-            ></form-input>
+          id="drawdown"
+          label="Drawdown"
+          type="number"
+          v-model="drawdownInput"
+          hint="ft (btoc)"></form-input>
       </div>
       <div v-if="isStaffEdit" class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input
@@ -75,8 +77,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           label="Recommended Pump Depth"
           type="number"
           v-model="recommendedPumpDepthInput"
-          hint="ft (btoc)"
-        />
+          hint="ft (btoc)"/>
       </div>
       <div v-if="isStaffEdit" class="col-span-12 md:col-span-4 lg:col-span-3">
         <form-input
@@ -84,8 +85,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
           label="Recommended Pump Rate"
           type="number"
           v-model="recommendedPumpRateInput"
-          hint="USgpm"
-        />
+          hint="USgpm"/>
       </div>
     </div>
   </form-subsection>

--- a/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
+++ b/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
@@ -14,82 +14,82 @@ Licensed under the Apache License, Version 2.0 (the "License");
 <template>
   <div>
     <h1 class="card-title">
-      <b-row>
-        <b-col cols="12">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12">
           <div>Well Activity Submission<span v-if="!reportSubmitted"> Preview</span></div>
-          <b-btn v-if="reportSubmitted" @click="$emit('startNewReport')" variant="primary">Submit New Report</b-btn>
-          <b-btn v-else class="float-right" @click="$emit('back')" variant="primary">Back to Edit</b-btn>
-        </b-col>
-      </b-row>
+          <Button v-if="reportSubmitted" label="Submit New Report" @click="$emit('startNewReport')"/>
+          <Button v-else label="Back to Edit" class="float-right" @click="$emit('back')"/>
+        </div>
+      </div>
     </h1>
     <fieldset class="my-4 detail-section">
       <legend>Type of Work and Well Class</legend>
-      <b-row>
-        <b-col>
+      <div class="flex">
+        <div>
           <span class="font-weight-bold">Report Type:</span> {{ codeToDescription('activity_types', activity) }}
-        </b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Class of Well:</span> {{ codeToDescription('well_classes', form.well_class) }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Subclass:</span> {{ wellSubclass }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Intended Water Use:</span> {{ codeToDescription('intended_water_uses', form.intended_water_use) }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4" id="wellTagNumberDisplay">
+        </div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Class of Well:</span> {{ codeToDescription('well_classes', form.well_class) }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Subclass:</span> {{ wellSubclass }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Intended Water Use:</span> {{ codeToDescription('intended_water_uses', form.intended_water_use) }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4" id="wellTagNumberDisplay">
           <span class="font-weight-bold">Well Tag Number: </span>
           <router-link :to="{ name: 'SubmissionsEdit', params: { id: form.well }}" v-if="reportSubmitted && canEditWells">
             {{ form.well }}
           </router-link>
           <span v-else>{{ form.well }}</span>
-        </b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Well Identification Plate Number:</span> {{ form.identification_plate_number }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Where Plate Attached:</span> {{ form.well_identification_plate_attached }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Work Start Date:</span> {{ form.work_start_date }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Work End Date:</span> {{ form.work_end_date }}</b-col>
-      </b-row>
+        </div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Well Identification Plate Number:</span> {{ form.identification_plate_number }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Where Plate Attached:</span> {{ form.well_identification_plate_attached }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Work Start Date:</span> {{ form.work_start_date }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Work End Date:</span> {{ form.work_end_date }}</div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section">
       <legend>Person Responsible for Work</legend>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Person Responsible for Work:</span> {{ form.person_responsible ? form.person_responsible['name'] : '' }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Person Who Performed Work:</span> {{ form.driller_name }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Company of Person Responsible for Work:</span> {{ form.company_of_person_responsible ? form.company_of_person_responsible['org_verbose_name'] : '' }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Consultant Name:</span> {{ form.consultant_name }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Consultant Company:</span> {{ form.consultant_company }}</b-col>
-      </b-row>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Person Responsible for Work:</span> {{ form.person_responsible ? form.person_responsible['name'] : '' }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Person Who Performed Work:</span> {{ form.driller_name }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Company of Person Responsible for Work:</span> {{ form.company_of_person_responsible ? form.company_of_person_responsible['org_verbose_name'] : '' }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Consultant Name:</span> {{ form.consultant_name }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Consultant Company:</span> {{ form.consultant_company }}</div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section">
       <legend>Well Owner</legend>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Name:</span> {{ form.owner_full_name }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="3"><span class="font-weight-bold">Mailing address:</span> {{ form.owner_mailing_address }}</b-col>
-        <b-col cols="12" lg="3"><span class="font-weight-bold">City:</span> {{ form.owner_city }}</b-col>
-        <b-col cols="12" lg="3"><span class="font-weight-bold">Province:</span> {{ form.owner_province_state }}</b-col>
-        <b-col cols="12" lg="3"><span class="font-weight-bold">Postal Code:</span> {{ form.owner_postal_code }}</b-col>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Name:</span> {{ form.owner_full_name }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-3"><span class="font-weight-bold">Mailing address:</span> {{ form.owner_mailing_address }}</div>
+        <div class="col-span-12 lg:col-span-3"><span class="font-weight-bold">City:</span> {{ form.owner_city }}</div>
+        <div class="col-span-12 lg:col-span-3"><span class="font-weight-bold">Province:</span> {{ form.owner_province_state }}</div>
+        <div class="col-span-12 lg:col-span-3"><span class="font-weight-bold">Postal Code:</span> {{ form.owner_postal_code }}</div>
 
-      </b-row>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section">
       <legend>Location Information</legend>
-      <b-row>
-        <b-col cols="12" lg="6" xl="4">
-          <b-row>
-            <b-col><span class="font-weight-bold">Street Address:</span> {{ form.street_address }}</b-col>
-          </b-row>
-          <b-row>
-            <b-col><span class="font-weight-bold">Town/City:</span> {{ form.city }}</b-col>
-          </b-row>
-          <b-row>
-            <b-col>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-6 xl:col-span-4">
+          <div>
+            <div><span class="font-weight-bold">Street Address:</span> {{ form.street_address }}</div>
+          </div>
+          <div>
+            <div><span class="font-weight-bold">Town/City:</span> {{ form.city }}</div>
+          </div>
+          <div>
+            <div>
               <div class="my-4"><span class="font-weight-bold">Legal Description:</span></div>
               <div class="table-responsive">
                 <table class="table table-sm table-striped table-bordered">
@@ -136,41 +136,41 @@ Licensed under the Apache License, Version 2.0 (the "License");
                   <span class="font-weight-bold">Description of Well Location:</span> {{ form.well_location_description }}
                 </div>
               </div>
-            </b-col>
-          </b-row>
-        </b-col>
-        <b-col cols="12" lg="6" xl="6" offset-xl="2">
+            </div>
+          </div>
+        </div>
+        <div class="col-span-12 lg:col-span-6 xl:col-span-6 xl:col-start-3">
           <div>
             <coords-map :latitude="form.latitude" :longitude="form.longitude" :draggable="false" :drinking_water="form.drinking_water_protection_area_ind"/>
           </div>
           <div class="my-4">&nbsp;</div>
           <div><span class="font-weight-bold">Geographic Coordinates - North American Datum of 1983 (NAD 83)</span></div>
-          <b-row>
-            <b-col cols="12" lg="4"><span class="font-weight-bold">Latitude:</span> {{form.latitude}}</b-col>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Longitude:</span> {{form.longitude}}</b-col>
-          </b-row>
-          <b-row>
-            <b-col cols="12" lg="4"><span class="font-weight-bold">UTM Easting:</span> {{UTM.easting}}</b-col>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">UTM Northing:</span> {{UTM.northing}}</b-col>
-          </b-row>
-          <b-row>
-            <b-col cols="12" lg="4"><span class="font-weight-bold">Zone:</span> {{UTM.zone}}</b-col>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Location Accuracy Code:</span> {{form.location_accuracy_code}}</b-col>
-          </b-row>
-        </b-col>
-      </b-row>
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Latitude:</span> {{form.latitude}}</div>
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Longitude:</span> {{form.longitude}}</div>
+          </div>
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">UTM Easting:</span> {{UTM.easting}}</div>
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">UTM Northing:</span> {{UTM.northing}}</div>
+          </div>
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Zone:</span> {{UTM.zone}}</div>
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Location Accuracy Code:</span> {{form.location_accuracy_code}}</div>
+          </div>
+        </div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section">
       <legend>Method of Drilling</legend>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Ground elevation:</span> {{ form.ground_elevation }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Method of determining elevation:</span> {{ codeToDescription('ground_elevation_methods', form.ground_elevation_method) }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Drilling methods:</span> <div v-for="(item, index) in form.drilling_methods" :key="index">{{ codeToDescription('drilling_methods', item) }}</div></b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Orientation of well:</span> {{ form.well_orientation_status }}</b-col>
-      </b-row>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Ground elevation:</span> {{ form.ground_elevation }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Method of determining elevation:</span> {{ codeToDescription('ground_elevation_methods', form.ground_elevation_method) }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Drilling methods:</span> <div v-for="(item, index) in form.drilling_methods" :key="index">{{ codeToDescription('drilling_methods', item) }}</div></div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Orientation of well:</span> {{ form.well_orientation_status }}</div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.lithology">
@@ -247,39 +247,39 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
     <fieldset class="my-4 detail-section" v-if="sections.backfill">
       <legend>Surface Seal and Backfill Details</legend>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Surface Seal Material:</span> {{ codeToDescription('surface_seal_materials', form.surface_seal_material) }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Backfill Material Above Surface Seal:</span> {{ codeToDescription('surface_seal_materials', form.backfill_type) }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Surface Seal Installation Method:</span> {{ codeToDescription('surface_seal_methods', form.surface_seal_method) }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Backfill Depth:</span> {{ form.backfill_depth }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Surface Seal Thickness:</span> {{ form.surface_seal_thickness }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Surface Seal Depth:</span> {{ form.surface_seal_depth }}</b-col>
-      </b-row>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Surface Seal Material:</span> {{ codeToDescription('surface_seal_materials', form.surface_seal_material) }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Backfill Material Above Surface Seal:</span> {{ codeToDescription('surface_seal_materials', form.backfill_type) }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Surface Seal Installation Method:</span> {{ codeToDescription('surface_seal_methods', form.surface_seal_method) }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Backfill Depth:</span> {{ form.backfill_depth }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Surface Seal Thickness:</span> {{ form.surface_seal_thickness }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Surface Seal Depth:</span> {{ form.surface_seal_depth }}</div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.liner">
       <legend>Liner Details</legend>
-      <b-row>
-        <b-col cols="12" lg="6">
-          <b-row>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Liner Material:</span> {{ codeToDescription('liner_materials', form.liner_material) }}</b-col>
-          </b-row>
-          <b-row>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Liner Diameter:</span> {{ form.liner_diameter }}</b-col>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Liner Thickness:</span> {{ form.liner_thickness }}</b-col>
-          </b-row>
-          <b-row>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Liner from:</span> {{ form.liner_from }}</b-col>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Liner to:</span> {{ form.liner_to }}</b-col>
-          </b-row>
-        </b-col>
-        <b-col cols="12" lg="6">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-6">
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Liner Material:</span> {{ codeToDescription('liner_materials', form.liner_material) }}</div>
+          </div>
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Liner Diameter:</span> {{ form.liner_diameter }}</div>
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Liner Thickness:</span> {{ form.liner_thickness }}</div>
+          </div>
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Liner from:</span> {{ form.liner_from }}</div>
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Liner to:</span> {{ form.liner_to }}</div>
+          </div>
+        </div>
+        <div class="col-span-12 lg:col-span-6">
           <div class="font-weight-bold">Liner perforations</div>
           <b-table
               striped
@@ -292,37 +292,37 @@ Licensed under the Apache License, Version 2.0 (the "License");
             <template v-slot:cell(from)="data">{{data.item.start}} ft</template>
             <template v-slot:cell(to)="data" >{{data.item.end}} ft</template>
           </b-table>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.screens">
       <legend>Screen Details</legend>
-      <b-row>
-        <b-col cols="12" lg="4">
-          <b-row>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Intake Method:</span> {{ codeToDescription('screen_intake_methods', form.screen_intake_method) }}</b-col>
-          </b-row>
-          <b-row>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Type:</span> {{ codeToDescription('screen_types', form.screen_type) }}</b-col>
-          </b-row>
-          <b-row>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Material:</span> {{ codeToDescription('screen_materials', form.screen_material) }}</b-col>
-          </b-row>
-          <b-row>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Opening:</span> {{ codeToDescription('screen_openings', form.screen_opening) }}</b-col>
-          </b-row>
-          <b-row>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Bottom:</span> {{ codeToDescription('screen_bottoms', form.screen_bottom) }}</b-col>
-          </b-row>
-          <b-row>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Other Material:</span> {{form.other_screen_material}}</b-col>
-          </b-row>
-          <b-row>
-            <b-col cols="12" lg="6"><span class="font-weight-bold">Information:</span> {{form.screen_information}}</b-col>
-          </b-row>
-        </b-col>
-        <b-col cols="12" lg="8">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4">
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Intake Method:</span> {{ codeToDescription('screen_intake_methods', form.screen_intake_method) }}</div>
+          </div>
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Type:</span> {{ codeToDescription('screen_types', form.screen_type) }}</div>
+          </div>
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Material:</span> {{ codeToDescription('screen_materials', form.screen_material) }}</div>
+          </div>
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Opening:</span> {{ codeToDescription('screen_openings', form.screen_opening) }}</div>
+          </div>
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Bottom:</span> {{ codeToDescription('screen_bottoms', form.screen_bottom) }}</div>
+          </div>
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Other Material:</span> {{form.other_screen_material}}</div>
+          </div>
+          <div class="grid grid-cols-12">
+            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Information:</span> {{form.screen_information}}</div>
+          </div>
+        </div>
+        <div class="col-span-12 lg:col-span-8">
           <div class="font-weight-bold">Installed Screens</div>
           <b-table
               striped
@@ -336,104 +336,104 @@ Licensed under the Apache License, Version 2.0 (the "License");
             <template v-slot:cell(to)="data">{{data.item.end}} ft</template>
             <template v-slot:cell(assembly_type)="data">{{codeToDescription('screen_assemblies', data.item.assembly_type)}}</template>
           </b-table>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.filterPack">
       <legend>Filter Pack</legend>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Filter pack from:</span> {{ form.filter_pack_from }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Filter pack to:</span> {{ form.filter_pack_to }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Filter pack thickness:</span> {{ form.filter_pack_thickness }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Filter pack material:</span> {{ codeToDescription('filter_pack_material', form.filter_pack_material) }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Filter pack material size:</span> {{ form.filter_pack_material_size }}</b-col>
-      </b-row>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Filter pack from:</span> {{ form.filter_pack_from }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Filter pack to:</span> {{ form.filter_pack_to }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Filter pack thickness:</span> {{ form.filter_pack_thickness }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Filter pack material:</span> {{ codeToDescription('filter_pack_material', form.filter_pack_material) }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Filter pack material size:</span> {{ form.filter_pack_material_size }}</div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.wellDevelopment">
       <legend>Well Development</legend>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Developed by:</span> <div v-for="(item, index) in form.development_methods" :key="index"> {{ codeToDescription('development_methods', item) }}</div></b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Development Total Duration:</span> {{ form.development_hours }} {{ form.development_hours ? 'hours':'' }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Development Notes:</span> {{ form.development_notes }}</b-col>
-      </b-row>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Developed by:</span> <div v-for="(item, index) in form.development_methods" :key="index"> {{ codeToDescription('development_methods', item) }}</div></div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Development Total Duration:</span> {{ form.development_hours }} {{ form.development_hours ? 'hours':'' }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Development Notes:</span> {{ form.development_notes }}</div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.wellYield">
       <legend>Well Yield</legend>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Estimation Method:</span> {{codeToDescription('yield_estimation_methods', form.yield_estimation_method)}} </b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Estimation Rate:</span> {{form.yield_estimation_rate}} </b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Estimation Duration:</span> {{form.yield_estimation_duration}}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Static Water Level Before Test:</span> {{form.static_level_before_test}}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Drawdown:</span> {{form.drawdown}}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Hydrofracturing Performed:</span> {{ nullBooleanToYesNo(form.hydro_fracturing_performed) }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Increase in Yield Due to Hydrofracturing:</span> {{form.hydro_fracturing_yield_increase}}</b-col>
-      </b-row>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Estimation Method:</span> {{codeToDescription('yield_estimation_methods', form.yield_estimation_method)}} </div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Estimation Rate:</span> {{form.yield_estimation_rate}} </div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Estimation Duration:</span> {{form.yield_estimation_duration}}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Static Water Level Before Test:</span> {{form.static_level_before_test}}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Drawdown:</span> {{form.drawdown}}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Hydrofracturing Performed:</span> {{ nullBooleanToYesNo(form.hydro_fracturing_performed) }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Increase in Yield Due to Hydrofracturing:</span> {{form.hydro_fracturing_yield_increase}}</div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.waterQuality">
       <legend>Water Quality</legend>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Characteristics:</span>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Characteristics:</span>
           <span v-for="(item, index) in form.water_quality_characteristics" :key="`previewWaterCharacteristic${index}`">
             <!-- Add a comma before each item except index 0 -->
             {{ index ? ', ': ''}}{{ codeToDescription('water_quality_characteristics', item) }}
           </span>
-        </b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Water Quality Colour:</span> {{ codeToDescription('water_quality_colours', form.water_quality_colour) }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="6"><span class="font-weight-bold">Water Quality Odour:</span> {{ form.water_quality_odour }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="6"><span class="font-weight-bold">EMS ID:</span> {{ form.ems }}</b-col>
-      </b-row>
+        </div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Water Quality Colour:</span> {{ codeToDescription('water_quality_colours', form.water_quality_colour) }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Water Quality Odour:</span> {{ form.water_quality_odour }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">EMS ID:</span> {{ form.ems }}</div>
+      </div>
     </fieldset>
     <fieldset class="my-4 detail-section" v-if="sections.wellCompletion">
       <legend>Well Completion Data</legend>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Total Depth Drilled:</span> {{ form.total_depth_drilled }} {{ form.total_depth_drilled ? 'ft bgl':''}}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Static Water Level (BTOC):</span> {{ form.static_water_level }} {{ form.static_water_level ? 'feet': ''}}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Artesian Pressure (head):</span> {{ form.artesian_pressure_head }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Finished Well Depth:</span> {{ form.finished_well_depth }} {{ form.finished_well_depth ? 'feet':''}}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Estimated Well Yield:</span> {{ form.well_yield }} {{ form.well_yield ? 'USGPM': ''}}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Artesian Pressure (PSI):</span> {{ form.artesian_pressure }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Final Casing Stick Up:</span> {{ form.final_casing_stick_up }} {{ form.final_casing_stick_up ? 'inches':''}}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Artesian Condition:</span> {{ nullBooleanToYesNo(form.artesian_conditions) }} </b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Well Cap:</span> {{ form.well_cap_type }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Depth to Bedrock:</span> {{ form.bedrock_depth }} {{ form.bedrock_depth ? 'feet':''}}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Artesian Flow:</span> {{ form.artesian_flow }} {{ form.artesian_flow ? 'USGPM': ''}}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Well Disinfected:</span> {{ form.well_disinfected_status }}</b-col>
-      </b-row>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Total Depth Drilled:</span> {{ form.total_depth_drilled }} {{ form.total_depth_drilled ? 'ft bgl':''}}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Static Water Level (BTOC):</span> {{ form.static_water_level }} {{ form.static_water_level ? 'feet': ''}}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Artesian Pressure (head):</span> {{ form.artesian_pressure_head }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Finished Well Depth:</span> {{ form.finished_well_depth }} {{ form.finished_well_depth ? 'feet':''}}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Estimated Well Yield:</span> {{ form.well_yield }} {{ form.well_yield ? 'USGPM': ''}}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Artesian Pressure (PSI):</span> {{ form.artesian_pressure }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Final Casing Stick Up:</span> {{ form.final_casing_stick_up }} {{ form.final_casing_stick_up ? 'inches':''}}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Artesian Condition:</span> {{ nullBooleanToYesNo(form.artesian_conditions) }} </div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Well Cap:</span> {{ form.well_cap_type }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Depth to Bedrock:</span> {{ form.bedrock_depth }} {{ form.bedrock_depth ? 'feet':''}}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Artesian Flow:</span> {{ form.artesian_flow }} {{ form.artesian_flow ? 'USGPM': ''}}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Well Disinfected:</span> {{ form.well_disinfected_status }}</div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.decommissionInformation">
       <legend>Well Decommission Information</legend>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Reason for Decommission:</span> {{ form.decommission_reason }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Method of Decommission:</span> {{ form.decommission_method }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Sealant Material:</span> {{ form.decommission_sealant_material }}</b-col>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Backfill Material:</span> {{ form.decommission_backfill_material }}</b-col>
-      </b-row>
-      <b-row>
-        <b-col cols="12" lg="4"><span class="font-weight-bold">Decommission Details:</span> {{ form.decommission_details }}</b-col>
-      </b-row>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Reason for Decommission:</span> {{ form.decommission_reason }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Method of Decommission:</span> {{ form.decommission_method }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Sealant Material:</span> {{ form.decommission_sealant_material }}</div>
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Backfill Material:</span> {{ form.decommission_backfill_material }}</div>
+      </div>
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Decommission Details:</span> {{ form.decommission_details }}</div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section">
@@ -483,8 +483,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
     <fieldset v-if="commonStore.uploadFiles && commonStore.uploadFiles.length > 0">
       <legend>Documents to Upload</legend>
-      <b-row>
-        <b-col cols="12" lg="8">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-8">
           <b-list-group>
             <b-list-group-item v-for="(f, index) in commonStore.uploadFiles" :key="index">
               {{f.file ? f.file.name.replace('null', '{ASSIGNED_WELL_ID}') : f.name}}
@@ -497,36 +497,36 @@ Licensed under the Apache License, Version 2.0 (the "License");
               ></a>
             </b-list-group-item>
           </b-list-group>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
     </fieldset>
 
     <fieldset v-if="uploadedFiles && uploadedFiles.public && uploadedFiles.public.length > 0 && reportSubmitted">
       <legend>Uploaded Documents</legend>
-      <b-row>
-        <b-col cols="12" lg="4">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4">
           <b-list-group>
             <b-list-group-item v-for="(f, index) in uploadedFiles.public" :key="index">{{f.name}}</b-list-group-item>
           </b-list-group>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
     </fieldset>
 
     <fieldset v-if="uploadedFiles && uploadedFiles.private && uploadedFiles.private.length > 0 && reportSubmitted">
       <legend>Uploaded Internal Documentation</legend>
-      <b-row>
-        <b-col cols="12" lg="4">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-4">
           <b-list-group>
             <b-list-group-item v-for="(f, index) in uploadedFiles.private" :key="index">{{f.name}}</b-list-group-item>
           </b-list-group>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section">
       <legend>General Disclaimer</legend>
-      <b-row>
-        <b-col cols="12" lg="9">
+      <div class="grid grid-cols-12">
+        <div class="col-span-12 lg:col-span-9">
           This information is collected by the Ministry of Water, Land and Resource Stewardship under section 26 (c)
           of the Freedom of Information and Protection of Privacy Act and section 117 (1) of the
           Water Sustainability Act (WSA).
@@ -549,19 +549,19 @@ Licensed under the Apache License, Version 2.0 (the "License");
           <br><br>
           Should you have any questions about the collection or use of this information, please contact the
           Groundwater Data Specialist, email: <a href = "mailto: groundwater@gov.bc.ca" class="text-blue-500 hover:underline">groundwater@gov.bc.ca.</a>
-        </b-col>
-      </b-row>
+        </div>
+      </div>
     </fieldset>
 
     <!-- Back / Next / Submit controls -->
-    <b-row v-if="!reportSubmitted" class="mt-12">
-      <b-col>
-        <b-btn @click="$emit('back')" variant="primary">Back to Edit</b-btn>
-      </b-col>
-      <b-col class="pr-6 text-right">
+    <div v-if="!reportSubmitted" class="mt-12">
+      <div>
+        <Button label="Back to Edit" @click="$emit('back')"/>
+      </div>
+      <div class="pr-6 text-right">
         <b-btn id="formSubmitButton" type="submit" variant="primary" ref="activitySubmitBtn" :disabled="formSubmitLoading">Submit</b-btn>
-      </b-col>
-    </b-row>
+      </div>
+    </div>
   </div>
 </template>
 

--- a/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
+++ b/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
@@ -204,19 +204,20 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <fieldset class="my-4 detail-section" v-if="sections.closureDescription">
       <legend>Decommission Description</legend>
       <div class="table-responsive">
-        <b-table
-          striped
-          small
-          bordered
-          :items="filterBlankRows(form.decommission_description_set)"
-          :fields="['start', 'end', 'material', 'observations']"
-          show-empty
-        >
-          <template v-slot:cell(start)="data">{{data.item.start}} ft</template>
-          <template v-slot:cell(end)="data">{{data.item.end}} ft</template>
-          <template v-slot:cell(material)="data">{{codeToDescription('decommission_materials', data.item.material)}}</template>
-          <template v-slot:cell(observations)="data">{{codeToDescription('decommission_materials', data.item.observations)}}</template>
-        </b-table>
+        <DataTable stripedRows size="small" showGridlines :value="filterBlankRows(form.decommission_description_set)">
+          <Column field="start"/>
+          <Column field="end"/>
+          <Column field="material">
+            <template #body="slotProps">
+              {{ codeToDescription('decommission_materials', slotProps.data.material) }}
+            </template>
+          </Column>
+          <Column field="observations">
+            <template #body="slotProps">
+              {{ codeToDescription('decommission_materials', slotProps.data.observations) }}
+            </template>
+          </Column>
+        </DataTable>
       </div>
     </fieldset>
 

--- a/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
+++ b/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
@@ -14,8 +14,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
 <template>
   <div>
     <h1 class="card-title">
-      <div class="grid grid-cols-12">
-        <div class="col-span-12">
+      <div class="flex">
+        <div>
           <div>Well Activity Submission<span v-if="!reportSubmitted"> Preview</span></div>
           <Button v-if="reportSubmitted" label="Submit New Report" @click="$emit('startNewReport')"/>
           <Button v-else label="Back to Edit" class="float-right" @click="$emit('back')"/>
@@ -49,41 +49,34 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
     <fieldset class="my-4 detail-section">
       <legend>Person Responsible for Work</legend>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Person Responsible for Work:</span> {{ form.person_responsible ? form.person_responsible['name'] : '' }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Person Who Performed Work:</span> {{ form.driller_name }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Company of Person Responsible for Work:</span> {{ form.company_of_person_responsible ? form.company_of_person_responsible['org_verbose_name'] : '' }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Consultant Name:</span> {{ form.consultant_name }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Consultant Company:</span> {{ form.consultant_company }}</div>
-      </div>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Person Responsible for Work:</b> {{ form.person_responsible ? form.person_responsible['name'] : '' }}</span>
+        <span><b>Person Who Performed Work:</b> {{ form.driller_name }}</span>
+        <span><b>Company of Person Responsible for Work:</b> {{ form.company_of_person_responsible ? form.company_of_person_responsible['org_verbose_name'] : '' }}</span>
+        <span><b>Consultant Name:</b> {{ form.consultant_name }}</span>
+        <span><b>Consultant Company:</b> {{ form.consultant_company }}</span>
+      </responsive-grid>
     </fieldset>
 
     <fieldset class="my-4 detail-section">
       <legend>Well Owner</legend>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Name:</span> {{ form.owner_full_name }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-3"><span class="font-weight-bold">Mailing address:</span> {{ form.owner_mailing_address }}</div>
-        <div class="col-span-12 lg:col-span-3"><span class="font-weight-bold">City:</span> {{ form.owner_city }}</div>
-        <div class="col-span-12 lg:col-span-3"><span class="font-weight-bold">Province:</span> {{ form.owner_province_state }}</div>
-        <div class="col-span-12 lg:col-span-3"><span class="font-weight-bold">Postal Code:</span> {{ form.owner_postal_code }}</div>
-
-      </div>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Name:</b> {{ form.owner_full_name }}</span>
+      </responsive-grid>
+      <responsive-grid :cols="12" :lg="3">
+        <span><b>Mailing address:</b> {{ form.owner_mailing_address }}</span>
+        <span><b>City:</b> {{ form.owner_city }}</span>
+        <span><b>Province:</b> {{ form.owner_province_state }}</span>
+        <span><b>Postal Code:</b> {{ form.owner_postal_code }}</span>
+      </responsive-grid>
     </fieldset>
 
     <fieldset class="my-4 detail-section">
       <legend>Location Information</legend>
       <div class="grid grid-cols-12">
         <div class="col-span-12 lg:col-span-6 xl:col-span-4">
-          <div>
-            <div><span class="font-weight-bold">Street Address:</span> {{ form.street_address }}</div>
-          </div>
-          <div>
-            <div><span class="font-weight-bold">Town/City:</span> {{ form.city }}</div>
-          </div>
+          <div><span><b>Street Address:</b> {{ form.street_address }}</span></div>
+          <div><span><b>Town/City:</b> {{ form.city }}</span></div>
           <div>
             <div>
               <div class="my-4"><span class="font-weight-bold">Legal Description:</span></div>
@@ -141,32 +134,29 @@ Licensed under the Apache License, Version 2.0 (the "License");
           </div>
           <div class="my-4">&nbsp;</div>
           <div><span class="font-weight-bold">Geographic Coordinates - North American Datum of 1983 (NAD 83)</span></div>
-          <div class="grid grid-cols-12">
-            <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Latitude:</span> {{form.latitude}}</div>
-            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Longitude:</span> {{form.longitude}}</div>
-          </div>
-          <div class="grid grid-cols-12">
-            <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">UTM Easting:</span> {{UTM.easting}}</div>
-            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">UTM Northing:</span> {{UTM.northing}}</div>
-          </div>
-          <div class="grid grid-cols-12">
-            <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Zone:</span> {{UTM.zone}}</div>
-            <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Location Accuracy Code:</span> {{form.location_accuracy_code}}</div>
-          </div>
+          <!-- I think this table scheme should work, even though each row will have 10/12 columns filled, bc the 4 will overflow -->
+          <responsive-grid :cols="12" :lg="[4, 6, 4, 6, 4, 6]">
+            <span><b>Latitude:</b> {{form.latitude}}</span>
+            <span><b>Longitude:</b> {{form.longitude}}</span>
+            <span><b>UTM Easting:</b> {{UTM.easting}}</span>
+            <span><b>UTM Northing:</b> {{UTM.northing}}</span>
+            <span><b>Zone:</b> {{UTM.zone}}</span>
+            <span><b>Location Accuracy Code:</b> {{form.location_accuracy_code}}</span>
+          </responsive-grid>
         </div>
       </div>
     </fieldset>
 
     <fieldset class="my-4 detail-section">
       <legend>Method of Drilling</legend>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Ground elevation:</span> {{ form.ground_elevation }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Method of determining elevation:</span> {{ codeToDescription('ground_elevation_methods', form.ground_elevation_method) }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Drilling methods:</span> <div v-for="(item, index) in form.drilling_methods" :key="index">{{ codeToDescription('drilling_methods', item) }}</div></div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Orientation of well:</span> {{ form.well_orientation_status }}</div>
-      </div>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Ground elevation:</b> {{ form.ground_elevation }}</span>
+        <span><b>Method of determining elevation:</b> {{ codeToDescription('ground_elevation_methods', form.ground_elevation_method) }}</span>
+      </responsive-grid>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Drilling methods:</b> <span v-for="(item, index) in form.drilling_methods" :key="index">{{ codeToDescription('drilling_methods', item) }}</span></span>
+        <span><b>Orientation of well:</b> {{ form.well_orientation_status }}</span>
+      </responsive-grid>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.lithology">
@@ -244,20 +234,20 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
     <fieldset class="my-4 detail-section" v-if="sections.backfill">
       <legend>Surface Seal and Backfill Details</legend>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Surface Seal Material:</span> {{ codeToDescription('surface_seal_materials', form.surface_seal_material) }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Backfill Material Above Surface Seal:</span> {{ codeToDescription('surface_seal_materials', form.backfill_type) }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Surface Seal Installation Method:</span> {{ codeToDescription('surface_seal_methods', form.surface_seal_method) }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Backfill Depth:</span> {{ form.backfill_depth }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Surface Seal Thickness:</span> {{ form.surface_seal_thickness }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Surface Seal Depth:</span> {{ form.surface_seal_depth }}</div>
-      </div>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Surface Seal Material:</b> {{ codeToDescription('surface_seal_materials', form.surface_seal_material) }}</span>
+        <span><b>Backfill Material Above Surface Seal:</b> {{ codeToDescription('surface_seal_materials', form.backfill_type) }}</span>
+      </responsive-grid>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Surface Seal Installation Method:</b> {{ codeToDescription('surface_seal_methods', form.surface_seal_method) }}</span>
+        <span><b>Backfill Depth:</b> {{ form.backfill_depth }}</span>
+      </responsive-grid>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Surface Seal Thickness:</b> {{ form.surface_seal_thickness }}</span>
+      </responsive-grid>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Surface Seal Depth:</b> {{ form.surface_seal_depth }}</span>
+      </responsive-grid>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.liner">
@@ -339,99 +329,89 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
     <fieldset class="my-4 detail-section" v-if="sections.filterPack">
       <legend>Filter Pack</legend>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Filter pack from:</span> {{ form.filter_pack_from }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Filter pack to:</span> {{ form.filter_pack_to }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Filter pack thickness:</span> {{ form.filter_pack_thickness }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Filter pack material:</span> {{ codeToDescription('filter_pack_material', form.filter_pack_material) }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Filter pack material size:</span> {{ form.filter_pack_material_size }}</div>
-      </div>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Filter pack from:</b> {{ form.filter_pack_from }}</span>
+        <span><b>Filter pack to:</b> {{ form.filter_pack_to }}</span>
+        <span><b>Filter pack thickness:</b> {{ form.filter_pack_thickness }}</span>
+        <span><b>Filter pack material:</b> {{ codeToDescription('filter_pack_material', form.filter_pack_material) }}</span>
+        <span><b>Filter pack material size:</b> {{ form.filter_pack_material_size }}</span>
+      </responsive-grid>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.wellDevelopment">
       <legend>Well Development</legend>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Developed by:</span> <div v-for="(item, index) in form.development_methods" :key="index"> {{ codeToDescription('development_methods', item) }}</div></div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Development Total Duration:</span> {{ form.development_hours }} {{ form.development_hours ? 'hours':'' }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Development Notes:</span> {{ form.development_notes }}</div>
-      </div>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Developed by:</b> <span v-for="(item, index) in form.development_methods" :key="index"> {{ codeToDescription('development_methods', item) }}</span></span>
+        <span><b>Development Total Duration:</b> {{ form.development_hours }} {{ form.development_hours ? 'hours':'' }}</span>
+        <span><b>Development Notes:</b> {{ form.development_notes }}</span>
+      </responsive-grid>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.wellYield">
       <legend>Well Yield</legend>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Estimation Method:</span> {{codeToDescription('yield_estimation_methods', form.yield_estimation_method)}} </div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Estimation Rate:</span> {{form.yield_estimation_rate}} </div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Estimation Duration:</span> {{form.yield_estimation_duration}}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Static Water Level Before Test:</span> {{form.static_level_before_test}}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Drawdown:</span> {{form.drawdown}}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Hydrofracturing Performed:</span> {{ nullBooleanToYesNo(form.hydro_fracturing_performed) }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Increase in Yield Due to Hydrofracturing:</span> {{form.hydro_fracturing_yield_increase}}</div>
-      </div>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Estimation Method:</b> {{codeToDescription('yield_estimation_methods', form.yield_estimation_method)}} </span>
+        <span><b>Estimation Rate:</b> {{form.yield_estimation_rate}} </span>
+        <span><b>Estimation Duration:</b> {{form.yield_estimation_duration}}</span>
+        <span><b>Static Water Level Before Test:</b> {{form.static_level_before_test}}</span>
+        <span><b>Drawdown:</b> {{form.drawdown}}</span>
+      </responsive-grid>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Hydrofracturing Performed:</b> {{ nullBooleanToYesNo(form.hydro_fracturing_performed) }}</span>
+        <span><b>Increase in Yield Due to Hydrofracturing:</b> {{form.hydro_fracturing_yield_increase}}</span>
+      </responsive-grid>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.waterQuality">
       <legend>Water Quality</legend>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Characteristics:</span>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Characteristics:</b>
           <span v-for="(item, index) in form.water_quality_characteristics" :key="`previewWaterCharacteristic${index}`">
             <!-- Add a comma before each item except index 0 -->
             {{ index ? ', ': ''}}{{ codeToDescription('water_quality_characteristics', item) }}
           </span>
-        </div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Water Quality Colour:</span> {{ codeToDescription('water_quality_colours', form.water_quality_colour) }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">Water Quality Odour:</span> {{ form.water_quality_odour }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-6"><span class="font-weight-bold">EMS ID:</span> {{ form.ems }}</div>
-      </div>
+        </span>
+        <span><b>Water Quality Colour:</b> {{ codeToDescription('water_quality_colours', form.water_quality_colour) }}</span>
+      </responsive-grid>
+      <responsive-grid :cols="12" :lg="6">
+        <span><b>Water Quality Odour:</b> {{ form.water_quality_odour }}</span>
+      </responsive-grid>
+      <responsive-grid :cols="12" :lg="6">
+        <span><b>EMS ID:</b> {{ form.ems }}</span>
+      </responsive-grid>
     </fieldset>
     <fieldset class="my-4 detail-section" v-if="sections.wellCompletion">
       <legend>Well Completion Data</legend>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Total Depth Drilled:</span> {{ form.total_depth_drilled }} {{ form.total_depth_drilled ? 'ft bgl':''}}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Static Water Level (BTOC):</span> {{ form.static_water_level }} {{ form.static_water_level ? 'feet': ''}}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Artesian Pressure (head):</span> {{ form.artesian_pressure_head }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Finished Well Depth:</span> {{ form.finished_well_depth }} {{ form.finished_well_depth ? 'feet':''}}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Estimated Well Yield:</span> {{ form.well_yield }} {{ form.well_yield ? 'USGPM': ''}}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Artesian Pressure (PSI):</span> {{ form.artesian_pressure }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Final Casing Stick Up:</span> {{ form.final_casing_stick_up }} {{ form.final_casing_stick_up ? 'inches':''}}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Artesian Condition:</span> {{ nullBooleanToYesNo(form.artesian_conditions) }} </div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Well Cap:</span> {{ form.well_cap_type }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Depth to Bedrock:</span> {{ form.bedrock_depth }} {{ form.bedrock_depth ? 'feet':''}}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Artesian Flow:</span> {{ form.artesian_flow }} {{ form.artesian_flow ? 'USGPM': ''}}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Well Disinfected:</span> {{ form.well_disinfected_status }}</div>
-      </div>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Total Depth Drilled:</b> {{ form.total_depth_drilled }} {{ form.total_depth_drilled ? 'ft bgl':''}}</span>
+        <span><b>Static Water Level (BTOC):</b> {{ form.static_water_level }} {{ form.static_water_level ? 'feet': ''}}</span>
+        <span><b>Artesian Pressure (head):</b> {{ form.artesian_pressure_head }}</span>
+        <span><b>Finished Well Depth:</b> {{ form.finished_well_depth }} {{ form.finished_well_depth ? 'feet':''}}</span>
+        <span><b>Estimated Well Yield:</b> {{ form.well_yield }} {{ form.well_yield ? 'USGPM': ''}}</span>
+        <span><b>Artesian Pressure (PSI):</b> {{ form.artesian_pressure }}</span>
+        <span><b>Final Casing Stick Up:</b> {{ form.final_casing_stick_up }} {{ form.final_casing_stick_up ? 'inches':''}}</span>
+        <span><b>Artesian Condition:</b> {{ nullBooleanToYesNo(form.artesian_conditions) }} </span>
+        <span><b>Well Cap:</b> {{ form.well_cap_type }}</span>
+        <span><b>Depth to Bedrock:</b> {{ form.bedrock_depth }} {{ form.bedrock_depth ? 'feet':''}}</span>
+        <span><b>Artesian Flow:</b> {{ form.artesian_flow }} {{ form.artesian_flow ? 'USGPM': ''}}</span>
+        <span><b>Well Disinfected:</b> {{ form.well_disinfected_status }}</span>
+      </responsive-grid>
     </fieldset>
 
     <fieldset class="my-4 detail-section" v-if="sections.decommissionInformation">
       <legend>Well Decommission Information</legend>
 
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Reason for Decommission:</span> {{ form.decommission_reason }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Method of Decommission:</span> {{ form.decommission_method }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Sealant Material:</span> {{ form.decommission_sealant_material }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Backfill Material:</span> {{ form.decommission_backfill_material }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Decommission Details:</span> {{ form.decommission_details }}</div>
-      </div>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Reason for Decommission:</b> {{ form.decommission_reason }}</span>
+        <span><b>Method of Decommission:</b> {{ form.decommission_method }}</span>
+      </responsive-grid>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Sealant Material:</b> {{ form.decommission_sealant_material }}</span>
+        <span><b>Backfill Material:</b> {{ form.decommission_backfill_material }}</span>
+      </responsive-grid>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Decommission Details:</b> {{ form.decommission_details }}</span>
+      </responsive-grid>
     </fieldset>
 
     <fieldset class="my-4 detail-section">
@@ -465,18 +445,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
     <fieldset class="my-4 detail-section">
       <legend>Comments</legend>
-      <p>
-        {{ form.comments ? form.comments : 'No comments submitted' }}
-      </p>
-      <p>
-        <span class="font-weight-bold">Alternative Specs Submitted:</span> {{ nullBooleanToYesNo(form.alternative_specs_submitted) }}
-      </p>
-      <p>
-        <span class="font-weight-bold">Technical Report:</span> {{ nullBooleanToYesNo(form.technical_report) }}
-      </p>
-      <p>
-        <span class="font-weight-bold">Drinking Water Area Indicator:</span> {{ nullBooleanToYesNo(form.drinking_water_protection_area_ind) }}
-      </p>
+      <p>{{ form.comments ? form.comments : 'No comments submitted' }}</p>
+      <p><b>Alternative Specs Submitted:</b> {{ nullBooleanToYesNo(form.alternative_specs_submitted) }}</p>
+      <p><b>Technical Report:</b> {{ nullBooleanToYesNo(form.technical_report) }}</p>
+      <p><b>Drinking Water Area Indicator:</b> {{ nullBooleanToYesNo(form.drinking_water_protection_area_ind) }}</p>
     </fieldset>
 
     <fieldset v-if="commonStore.uploadFiles && commonStore.uploadFiles.length > 0">

--- a/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
+++ b/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
@@ -162,32 +162,25 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <fieldset class="my-4 detail-section" v-if="sections.lithology">
       <legend>Lithology</legend>
       <div class="table-responsive">
-        <b-table
-          striped
-          small
-          bordered
-          :items="filterBlankRows(form.lithologydescription_set)"
-          show-empty
-          :fields="[
-            'from',
-            'to',
-            'description',
-            'colour',
-            'hardness',
-            'moisture',
-            'descriptor',
-            'water_bearing_estimated_flow',
-            'observations'
-          ]">
-          <template v-slot:cell(description)="data">{{data.item.lithology_raw_data}}</template>
-          <template v-slot:cell(from)="data">{{data.item.start}}</template>
-          <template v-slot:cell(to)="data">{{data.item.end}}</template>
-          <template v-slot:cell(colour)="data">{{codeToDescription('lithology_colours', data.item.lithology_colour) }}</template>
-          <template v-slot:cell(hardness)="data">{{codeToDescription('lithology_hardness_codes', data.item.lithology_hardness) }}</template>
-          <template v-slot:cell(moisture)="data">{{codeToDescription('lithology_moisture_codes', data.item.lithology_moisture) }}</template>
-          <template v-slot:cell(descriptor)="data">{{codeToDescription('lithology_descriptors', data.item.lithology_description) }}</template>
-          <template v-slot:cell(observations)="data">{{ data.item.lithology_observation }}</template>
-        </b-table>
+        <DataTable stripedRows size="small" showGridlines :value="filterBlankRows(form.lithologydescription_set)">
+          <Column field="start" header="From"/>
+          <Column field="end" header="To"/>
+          <Column field="lithology_raw_data" header="Description"/>
+          <Column field="lithology_colour" header="Colour">
+            <template #body="slotProps">{{ codeToDescription('lithology_colours', slotProps.data.lithology_colour) }}</template>
+          </Column>
+          <Column field="lithology_hardness" header="Hardness">
+            <template #body="slotProps">{{ codeToDescription('lithology_hardness_codes', slotProps.data.lithology_hardness) }}</template>
+          </Column>
+          <Column field="lithology_moisture" header="Moisture">
+            <template #body="slotProps">{{ codeToDescription('lithology_moisture_codes', slotProps.data.lithology_moisture) }}</template>
+          </Column>
+          <Column field="lithology_description" header="Descriptor">
+            <template #body="slotProps">{{ codeToDescription('lithology_descriptors', slotProps.data.lithology_description) }}</template>
+          </Column>
+          <Column field="water_bearing_estimated_flow"/>
+          <Column field="lithology_observation" header="Observations"/>
+        </DataTable>
       </div>
     </fieldset>
 
@@ -198,14 +191,10 @@ Licensed under the Apache License, Version 2.0 (the "License");
           <Column field="start"/>
           <Column field="end"/>
           <Column field="material">
-            <template #body="slotProps">
-              {{ codeToDescription('decommission_materials', slotProps.data.material) }}
-            </template>
+            <template #body="slotProps">{{ codeToDescription('decommission_materials', slotProps.data.material) }}</template>
           </Column>
           <Column field="observations">
-            <template #body="slotProps">
-              {{ codeToDescription('decommission_materials', slotProps.data.observations) }}
-            </template>
+            <template #body="slotProps">{{ codeToDescription('decommission_materials', slotProps.data.observations) }}</template>
           </Column>
         </DataTable>
       </div>
@@ -214,21 +203,25 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <fieldset class="my-4 detail-section">
       <legend>Casing Details</legend>
       <div class="table-responsive">
-        <b-table
-            striped
-            small
-            bordered
-            :items="filterBlankRows(form.casing_set)"
-            :fields="['from', 'to', 'casing_type', 'casing_material', 'diameter', 'wall_thickness', 'drive_shoe_status']"
-            show-empty>
-
-          <template v-slot:cell(from)="data">{{data.item.start}}{{data.item.start ? ' ft' : '' }}</template>
-          <template v-slot:cell(to)="data">{{data.item.end}}{{data.item.end ? ' ft' : '' }}</template>
-          <template v-slot:cell(casing_type)="data">{{codeToDescription('casing_codes', data.item.casing_code)}}</template>
-          <template v-slot:cell(casing_material)="data">{{codeToDescription('casing_materials', data.item.casing_material)}}</template>
-          <template v-slot:cell(drive_shoe_status)="data">{{codeToDescription('drive_shoe_status', data.item.drive_shoe_status)}}</template>
-
-        </b-table>
+        <DataTable stripedRows size="small" showGridlines :value="filterBlankRows(form.casing_set)">
+          <Column field="start" header="From">
+            <template #body="slotProps">{{slotProps.data.start}}{{slotProps.data.start ? ' ft' : '' }}</template>
+          </Column>
+          <Column field="end" header="To">
+            <template #body="slotProps">{{slotProps.data.end}}{{slotProps.data.end ? ' ft' : '' }}</template>
+          </Column>
+          <Column field="casing_code" header="Casing Type">
+            <template #body="slotProps">{{codeToDescription('casing_codes', slotProps.data.casing_code)}}</template>
+          </Column>
+          <Column field="casing_material">
+            <template #body="slotProps">{{codeToDescription('casing_materials', slotProps.data.casing_material)}}</template>
+          </Column>
+          <Column field="diameter"/>
+          <Column field="wall_thickness"/>
+          <Column field="drive_shoe_status">
+            <template #body="slotProps">{{codeToDescription('drive_shoe_status', slotProps.data.drive_shoe_status)}}</template>
+          </Column>
+        </DataTable>
       </div>
     </fieldset>
 
@@ -268,17 +261,14 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </div>
         <div class="col-span-12 lg:col-span-6">
           <div class="font-weight-bold">Liner perforations</div>
-          <b-table
-              striped
-              small
-              bordered
-              :items="filterBlankRows(form.linerperforation_set)"
-              :fields="['from', 'to']"
-              show-empty
-          >
-            <template v-slot:cell(from)="data">{{data.item.start}} ft</template>
-            <template v-slot:cell(to)="data" >{{data.item.end}} ft</template>
-          </b-table>
+          <DataTable stripedRows size="small" showGridlines :value="filterBlankRows(form.linerperforation_set)">
+            <Column field="start" header="From">
+              <template #body="slotProps">{{slotProps.data.start}} ft</template>
+            </Column>
+            <Column field="end" header="To">
+              <template #body="slotProps">{{slotProps.data.end}} ft</template>
+            </Column>
+          </DataTable>
         </div>
       </div>
     </fieldset>
@@ -311,18 +301,19 @@ Licensed under the Apache License, Version 2.0 (the "License");
         </div>
         <div class="col-span-12 lg:col-span-8">
           <div class="font-weight-bold">Installed Screens</div>
-          <b-table
-              striped
-              small
-              bordered
-              :items="filterBlankRows(form.screen_set)"
-              :fields="['from', 'to', 'diameter', 'assembly_type', 'slot_size']"
-              show-empty
-              >
-            <template v-slot:cell(from)="data">{{data.item.start}} ft</template>
-            <template v-slot:cell(to)="data">{{data.item.end}} ft</template>
-            <template v-slot:cell(assembly_type)="data">{{codeToDescription('screen_assemblies', data.item.assembly_type)}}</template>
-          </b-table>
+          <DataTable stripedRows size="small" showGridlines :value="filterBlankRows(form.screen_set)">
+            <Column field="start" header="From">
+              <template #body="slotProps">{{slotProps.data.start}} ft</template>
+            </Column>
+            <Column field="end" header="To">
+              <template #body="slotProps">{{slotProps.data.end}} ft</template>
+            </Column>
+            <Column field="diameter"/>
+            <Column field="assembly_type">
+              <template #body="slotProps">{{codeToDescription('screen_assemblies', slotProps.data.assembly_type)}}</template>
+            </Column>
+            <Column field="slot_size"/>
+          </DataTable>
         </div>
       </div>
     </fieldset>
@@ -417,29 +408,25 @@ Licensed under the Apache License, Version 2.0 (the "License");
     <fieldset class="my-4 detail-section">
       <legend>Pumping Test Information and Aquifer Parameters</legend>
       <div class="table-responsive">
-        <b-table
-            striped
-            small
-            bordered
-            :items="filterBlankRows(form.aquifer_parameters_set)"
-            :fields="[
-                  'start_date_pumping_test',
-                  'pumping_test_description',
-                  { key: 'test_duration', label: 'Test Duration (min)' },
-                  'boundary_effect',
-                  'storativity',
-                  { key: 'transmissivity', label: 'Transmissivity (m²/day)' },
-                  { key: 'hydraulic_conductivity', label: 'Hydraulic Conductivity (m/day)' },
-                  'specific_yield',
-                  { key: 'specific_capacity', label: 'Specific Capacity (L/s/m)' },
-                  'analysis_method',
-                  'comments'
-                ]"
-            show-empty>
-            <template v-slot:cell(pumping_test_description)="data">{{codeToDescription('pumping_test_description_codes', data.item.pumping_test_description)}}</template>
-            <template v-slot:cell(boundary_effect)="data">{{codeToDescription('boundary_effect_codes', data.item.boundary_effect)}}</template>
-            <template v-slot:cell(analysis_method)="data">{{codeToDescription('analysis_method_codes', data.item.analysis_method)}}</template>
-        </b-table>
+        <DataTable stripedRows size="small" showGridlines :value="filterBlankRows(form.aquifer_parameters_set)">
+          <Column field="start_date_pumping_test"/>
+          <Column field="pumping_test_description">
+            <template #body="slotProps">{{codeToDescription('pumping_test_description_codes', slotProps.data.pumping_test_description)}}</template>
+          </Column>
+          <Column field="test_duration" header="Test Duration (min)"/>
+          <Column field="boundary_effect">
+            <template #body="slotProps">{{codeToDescription('boundary_effect_codes', slotProps.data.boundary_effect)}}</template>
+          </Column>
+          <Column field="storativity"/>
+          <Column field="transmissivity" header="Transmissivity (m²/day)"/>
+          <Column field="hydraulic_conductivity" header="Hydraulic Conductivity (m/day)"/>
+          <Column field="specific_yield"/>
+          <Column field="specific_capacity" header="Specific Capacity (L/s/m)"/>
+          <Column field="analysis_method">
+            <template #body="slotProps">{{codeToDescription('analysis_method_codes', slotProps.data.analysis_method)}}</template>
+          </Column>
+          <Column field="comments"/>
+        </DataTable>
       </div>
     </fieldset>
 

--- a/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
+++ b/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
@@ -29,26 +29,22 @@ Licensed under the Apache License, Version 2.0 (the "License");
           <span class="font-weight-bold">Report Type:</span> {{ codeToDescription('activity_types', activity) }}
         </div>
       </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Class of Well:</span> {{ codeToDescription('well_classes', form.well_class) }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Subclass:</span> {{ wellSubclass }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Intended Water Use:</span> {{ codeToDescription('intended_water_uses', form.intended_water_use) }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4" id="wellTagNumberDisplay">
-          <span class="font-weight-bold">Well Tag Number: </span>
+      <responsive-grid :cols="12" :lg="4">
+        <span><b>Class of Well:</b> {{ codeToDescription('well_classes', form.well_class) }}</span>
+        <span><b>Subclass:</b> {{ wellSubclass }}</span>
+        <span><b>Intended Water Use:</b> {{ codeToDescription('intended_water_uses', form.intended_water_use) }}</span>
+        <span>
+          <b>Well Tag Number: </b>
           <router-link :to="{ name: 'SubmissionsEdit', params: { id: form.well }}" v-if="reportSubmitted && canEditWells">
             {{ form.well }}
           </router-link>
           <span v-else>{{ form.well }}</span>
-        </div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Well Identification Plate Number:</span> {{ form.identification_plate_number }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Where Plate Attached:</span> {{ form.well_identification_plate_attached }}</div>
-      </div>
-      <div class="grid grid-cols-12">
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Work Start Date:</span> {{ form.work_start_date }}</div>
-        <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Work End Date:</span> {{ form.work_end_date }}</div>
-      </div>
+        </span>
+        <span><b>Well Identification Plate Number:</b> {{ form.identification_plate_number }}</span>
+        <span><b>Where Plate Attached:</b> {{ form.well_identification_plate_attached }}</span>
+        <span><b>Work Start Date:</b> {{ form.work_start_date }}</span>
+        <span><b>Work End Date:</b> {{ form.work_end_date }}</span>
+      </responsive-grid>
     </fieldset>
 
     <fieldset class="my-4 detail-section">
@@ -423,6 +419,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
     <fieldset class="my-4 detail-section" v-if="sections.decommissionInformation">
       <legend>Well Decommission Information</legend>
+
       <div class="grid grid-cols-12">
         <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Reason for Decommission:</span> {{ form.decommission_reason }}</div>
         <div class="col-span-12 lg:col-span-4"><span class="font-weight-bold">Method of Decommission:</span> {{ form.decommission_method }}</div>
@@ -571,11 +568,13 @@ import CoordsMap from '@/submissions/components/SubmissionForm/CoordsMap.vue'
 import convertCoordinatesMixin from '@/common/convertCoordinatesMixin.js'
 import filterBlankRows from '@/common/filterBlankRows'
 import codeToDescription from '@/common/codeToDescription.js'
+import ResponsiveGrid from '@/common/components/ResponsiveGrid.vue'
 
 export default {
   name: 'SubmissionPreview',
   components: {
-    CoordsMap
+    CoordsMap,
+    ResponsiveGrid
   },
   mixins: [filterBlankRows, codeToDescription, convertCoordinatesMixin],
   props: [

--- a/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
+++ b/app/frontend/src/submissions/components/SubmissionPreview/SubmissionPreview.vue
@@ -482,8 +482,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <legend>Documents to Upload</legend>
       <div class="grid grid-cols-12">
         <div class="col-span-12 lg:col-span-8">
-          <b-list-group>
-            <b-list-group-item v-for="(f, index) in commonStore.uploadFiles" :key="index">
+          <ul class="border border-gray-200 rounded-lg">
+            <li v-for="(f, index) in commonStore.uploadFiles" class="px-4 py-2" :key="index">
               {{f.file ? f.file.name.replace('null', '{ASSIGNED_WELL_ID}') : f.name}}
               <a
                 class="fa fa-trash fa-lg"
@@ -492,8 +492,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 href="#"
                 @click="handleDelete(index)"
               ></a>
-            </b-list-group-item>
-          </b-list-group>
+            </li>
+          </ul>
         </div>
       </div>
     </fieldset>
@@ -502,9 +502,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <legend>Uploaded Documents</legend>
       <div class="grid grid-cols-12">
         <div class="col-span-12 lg:col-span-4">
-          <b-list-group>
-            <b-list-group-item v-for="(f, index) in uploadedFiles.public" :key="index">{{f.name}}</b-list-group-item>
-          </b-list-group>
+          <ul class="border border-gray-200 rounded-lg">
+            <li v-for="(f, index) in uploadedFiles.public" class="px-4 py-2" :key="index">{{f.name}}</li>
+          </ul>
         </div>
       </div>
     </fieldset>
@@ -513,9 +513,9 @@ Licensed under the Apache License, Version 2.0 (the "License");
       <legend>Uploaded Internal Documentation</legend>
       <div class="grid grid-cols-12">
         <div class="col-span-12 lg:col-span-4">
-          <b-list-group>
-            <b-list-group-item v-for="(f, index) in uploadedFiles.private" :key="index">{{f.name}}</b-list-group-item>
-          </b-list-group>
+          <ul class="border border-gray-200 rounded-lg">
+            <li v-for="(f, index) in uploadedFiles.private" class="px-4 py-2" :key="index">{{f.name}}</li>
+          </ul>
         </div>
       </div>
     </fieldset>
@@ -556,7 +556,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <Button label="Back to Edit" @click="$emit('back')"/>
       </div>
       <div class="pr-6 text-right">
-        <b-btn id="formSubmitButton" type="submit" variant="primary" ref="activitySubmitBtn" :disabled="formSubmitLoading">Submit</b-btn>
+        <Button label="Submit" id="formSubmitButton" type="submit" ref="activitySubmitBtn" :disabled="formSubmitLoading"/>
       </div>
     </div>
   </div>

--- a/app/frontend/src/submissions/views/SubmissionDetail.vue
+++ b/app/frontend/src/submissions/views/SubmissionDetail.vue
@@ -8,9 +8,9 @@
       </template>
     </Breadcrumb>
   </div>
-  <b-card v-if="commonStore.userRoles.wells.edit || commonStore.userRoles.submissions.edit" class="container p-1">
-    <b-card-body>
-      <h1>Activity Report Summary</h1>
+  <Card v-if="commonStore.userRoles.wells.edit || commonStore.userRoles.submissions.edit" class="container p-1">
+    <template #title>Activity Report Summary</template>
+    <template #content>
       <div v-if="loading">
         <div class="fa-2x text-center">
           <i class="fa fa-circle-o-notch fa-spin"></i>
@@ -30,8 +30,8 @@
           </template>
         </dl>
       </div>
-    </b-card-body>
-  </b-card>
+    </template>
+  </Card>
 </div>
 
 </template>

--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -41,7 +41,7 @@ governing permissions and limitations under the License. */
             </p>
           </Message>
 
-          <b-form @submit.prevent="confirmSubmit">
+          <Form @submit="confirmSubmit">
             <!-- if preview === true : Preview -->
             <submission-preview
               v-if="preview"
@@ -94,16 +94,16 @@ governing permissions and limitations under the License. */
               id="confirmSubmitModal"
               centered
               title="Confirm submission"
-              @shown="$refs.confirmSubmitConfirmBtn.focus()"
+              @show="$refs.confirmSubmitConfirmBtn.focus()"
               :return-focus="$refs.activitySubmitBtn"
             >
               Are you sure you want to submit this activity report?
-              <div slot="modal-footer">
+              <template #footer>
                 <Button label="Save" @click="confirmSubmitModal = false;formSubmit();" ref="confirmSubmitConfirmBtn"/>
                 <Button label="Cancel" severity="secondary" @click="confirmSubmitModal = false"/>
-              </div>
+              </template>
             </b-modal>
-          </b-form>
+          </Form>
         </div>
       </div>
       <div class="card" v-else-if="!commonStore.keycloak.authenticated">

--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -407,7 +407,7 @@ export default {
           this.formSubmitSuccess = true;
           this.formSubmitSuccessWellTag = response.data.well;
 
-          this.$emit("formSaved");
+          this.$refs.activitySubmissionForm.onFormSave();
           // Save completed notification
 
           if (this.isStaffEdit) {

--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -89,20 +89,19 @@ governing permissions and limitations under the License. */
             </div>
 
             <!-- Form submission confirmation -->
-            <b-modal
-              v-model="confirmSubmitModal"
-              id="confirmSubmitModal"
-              centered
-              title="Confirm submission"
+            <Dialog
+              v-model:visible="confirmSubmitModal"
+              modal
+              header="Confirm submission"
               @show="$refs.confirmSubmitConfirmBtn.focus()"
-              :return-focus="$refs.activitySubmitBtn"
+              @after-hide="$refs.activitySubmitBtn.focus()"
             >
               Are you sure you want to submit this activity report?
               <template #footer>
                 <Button label="Save" @click="confirmSubmitModal = false;formSubmit();" ref="confirmSubmitConfirmBtn"/>
                 <Button label="Cancel" severity="secondary" @click="confirmSubmitModal = false"/>
               </template>
-            </b-modal>
+            </Dialog>
           </Form>
         </div>
       </div>

--- a/app/frontend/src/submissions/views/SubmissionsHome.vue
+++ b/app/frontend/src/submissions/views/SubmissionsHome.vue
@@ -99,19 +99,8 @@ governing permissions and limitations under the License. */
             >
               Are you sure you want to submit this activity report?
               <div slot="modal-footer">
-                <b-btn
-                  variant="primary"
-                  @click="
-                    confirmSubmitModal = false;
-                    formSubmit();
-                  "
-                  ref="confirmSubmitConfirmBtn"
-                >
-                  Save
-                </b-btn>
-                <b-btn variant="light" @click="confirmSubmitModal = false">
-                  Cancel
-                </b-btn>
+                <Button label="Save" @click="confirmSubmitModal = false;formSubmit();" ref="confirmSubmitConfirmBtn"/>
+                <Button label="Cancel" severity="secondary" @click="confirmSubmitModal = false"/>
               </div>
             </b-modal>
           </b-form>

--- a/app/frontend/src/wells/components/AdvancedSearchFilter.vue
+++ b/app/frontend/src/wells/components/AdvancedSearchFilter.vue
@@ -134,11 +134,11 @@
           </b-form-row>
         </b-col>
       </b-form-row>
-      <b-form-invalid-feedback :id="`${id}InvalidFeedback`">
-        <div v-for="(error, index) in errors" :key="`${id}Input error ${index}`">
+      <div :id="`${id}InvalidFeedback`">
+        <div v-for="(error, index) in errors" class="mt-1 text-sm text-red-600" :key="`${id}Input error ${index}`">
           {{ error }}
         </div>
-      </b-form-invalid-feedback>
+      </div>
     </b-col>
     <b-col cols="1" v-if="removable">
       <b-button-close @click="$emit('remove')" class="pt-1">&times;</b-button-close>

--- a/app/frontend/src/wells/components/SearchResultFilter.vue
+++ b/app/frontend/src/wells/components/SearchResultFilter.vue
@@ -45,11 +45,11 @@
         :text-field="textField"
         v-model="localValue[paramNames[0]]"
         @keyup.enter="applyFilter()" />
-      <b-form-invalid-feedback :id="`${id}InvalidFeedback`">
-        <div v-for="(error, index) in errors" :key="`${id}Input error ${index}`">
+      <div :id="`${id}InvalidFeedback`">
+        <div v-for="(error, index) in errors" class="mt-1 text-sm text-red-600" :key="`${id}Input error ${index}`">
           {{ error }}
         </div>
-      </b-form-invalid-feedback>
+      </div>
     </b-col>
     <b-col sm="5" v-if="type === 'range' || type === 'dateRange'">
       <b-form-input

--- a/app/frontend/src/wells/views/EditWellAquifers.vue
+++ b/app/frontend/src/wells/views/EditWellAquifers.vue
@@ -162,7 +162,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 </template>
 
 <script>
-
+import { ConfirmDialog, InputGroupAddon } from 'primevue'
 import { debounce, uniq } from 'lodash-es'
 import ApiService from '@/common/services/ApiService.js'
 import APIErrorMessage from '@/common/components/APIErrorMessage.vue'
@@ -173,7 +173,9 @@ export default {
   components: {
     'api-error': APIErrorMessage,
     'form-input': FormInput,
-    'v-select': vSelect
+    'v-select': vSelect,
+    ConfirmDialog,
+    InputGroupAddon
   },
   data () {
     return {

--- a/app/frontend/src/wells/views/EditWellAquifers.vue
+++ b/app/frontend/src/wells/views/EditWellAquifers.vue
@@ -120,12 +120,11 @@ Licensed under the Apache License, Version 2.0 (the "License");
                               </div>
                             </template>
                           </v-select>
-                          <!-- There isn't a replacement. Will need to redo error logic later.
-                            <b-form-invalid-feedback :id="`aquifer${index}InvalidFeedback`">
-                            <div v-for="(error, errIndex) in getRowError(index).aquifer_id" :key="`aquifer${index}Input error ${errIndex}`">
+                          <div :id="`aquifer${index}InvalidFeedback`">
+                            <div v-for="(error, e_index) in getRowError(index).aquifer_id" class="mt-1 text-sm text-red-600" :key="`aquifer${index}Input error ${e_index}`">
                               {{ error }}
                             </div>
-                          </b-form-invalid-feedback> -->
+                          </div>
                         </InputGroupAddon>
                       </td>
                       <td class="py-0 text-right">

--- a/app/frontend/src/wells/views/WellDetail.vue
+++ b/app/frontend/src/wells/views/WellDetail.vue
@@ -72,29 +72,27 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 target="_blank"
               >{{ observation_well_number }}</a>
             </span>
-          </responsive-grid>
-          <responsive-grid :cols="12" :md="4">
+
             <span><b>Well Identification Plate Number:</b> {{ identification_plate_number }}</span>
             <span><b>Well Class:</b> {{ well_class }}</span>
             <span><b>Observation Well Status:</b> {{ observation_well_status }}</span>
-          </responsive-grid>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Owner Name:</span> {{ owner_full_name }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Well Subclass:</span> {{ well_subclass }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Environmental Monitoring System (EMS) ID:</span> {{ ems }}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Intended Water Use:</span> {{ intended_water_use }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Aquifer Number: </span>
+
+            <span><b>Owner Name:</b> {{ owner_full_name }}</span>
+            <span><b>Well Subclass:</b> {{ well_subclass }}</span>
+            <span><b>Environmental Monitoring System (EMS) ID:</b> {{ ems }}</span>
+
+            <span><b>Intended Water Use:</b> {{ intended_water_use }}</span>
+            <span>
+              <b>Aquifer Number: </b>
               <router-link v-if="aquifer" :to="{ name: 'aquifers-view', params: { id: aquifer } }">
                 {{ aquifer }}
               </router-link>
-            </div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Alternative specs submitted:</span> {{ alternative_specs_submitted }}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Artesian Condition:</span> {{ booleanToYesNo(artesian_conditions) }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Technical Report:</span>
+            </span>
+            <span><b>Alternative specs submitted:</b> {{ alternative_specs_submitted }}</span>
+
+            <span><b>Artesian Condition:</b> {{ booleanToYesNo(artesian_conditions) }}</span>
+            <span>
+              <b>Technical Report:</b>
               <a
                 v-if="technical_report"
                 id="technical_report"
@@ -103,37 +101,35 @@ Licensed under the Apache License, Version 2.0 (the "License");
                 rel="noopener noreferrer"
               > Report Available</a>
               <span v-if="!technical_report"> N/A</span>
-            </div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Drinking Water Area Indicator:</span> {{ booleanToYesNo(drinking_water_protection_area_ind) }}</div>
-          </div>
+            </span>
+            <span><b>Drinking Water Area Indicator:</b> {{ booleanToYesNo(drinking_water_protection_area_ind) }}</span>
+          </responsive-grid>
         </fieldset>
 
         <!-- LINKS -->
         <fieldset id="jump_links_fieldset" class="d-print-none detail-section my-4">
           <legend class="w-full mb-2">Sections</legend>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#location_information_fieldset">Location Information</a></div>
-            <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#well_activity_fieldset">Well Activity</a></div>
-            <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#well_work_dates_fieldset">Well Work Dates</a></div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#well_completion_data_fieldset">Well Completion Data and Artesian Flow</a></div>
-            <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#lithology_fieldset">Lithology</a></div>
-            <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#casing_fieldset">Casing Details</a></div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#aquifer_parameters_fieldset">Aquifer Parameters</a></div>
-            <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#surface_seal_fieldset">Surface Seal and Backfill Details</a></div>
-            <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#liner_details_fieldset">Liner Details</a></div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#screen_details_fieldset">Screen Details</a></div>
-            <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#well_development_fieldset">Well Development</a></div>
-            <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#well_yield_fieldset">Well Yield</a></div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
+          <responsive-grid :cols="12" :md="4">
+            <a class="jump_link" href="#location_information_fieldset">Location Information</a>
+            <a class="jump_link" href="#well_activity_fieldset">Well Activity</a>
+            <a class="jump_link" href="#well_work_dates_fieldset">Well Work Dates</a>
+
+            <a class="jump_link" href="#well_completion_data_fieldset">Well Completion Data and Artesian Flow</a>
+            <a class="jump_link" href="#lithology_fieldset">Lithology</a>
+            <a class="jump_link" href="#casing_fieldset">Casing Details</a>
+
+            <a class="jump_link" href="#aquifer_parameters_fieldset">Aquifer Parameters</a>
+            <a class="jump_link" href="#surface_seal_fieldset">Surface Seal and Backfill Details</a>
+            <a class="jump_link" href="#liner_details_fieldset">Liner Details</a>
+
+            <a class="jump_link" href="#screen_details_fieldset">Screen Details</a>
+            <a class="jump_link" href="#well_development_fieldset">Well Development</a>
+            <a class="jump_link" href="#well_yield_fieldset">Well Yield</a>
+          </responsive-grid>
+          <div class="grid grid-cols-12">
             <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#well_decommissioning_fieldset">Well Decommissioning</a></div>
             <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#well_comments_fieldset">Comments</a></div>
+            <!-- Can't put in reponsive grid bc of this v-if; it doesn't support conditional col display -->
             <div v-if="commonStore.config && commonStore.config.enable_documents" class="col-span-12 md:col-span-4"><a class="jump_link" href="#documents_fieldset">Documentation</a></div>
             <div class="col-span-12 md:col-span-4"><a class="jump_link" href="#disclaimer_fieldset">Disclaimer</a></div>
           </div>
@@ -142,20 +138,21 @@ Licensed under the Apache License, Version 2.0 (the "License");
         <!-- LICENSING -->
         <fieldset id="well_licensing_fieldset" class="my-4 detail-section">
           <legend class="w-full mb-2">Licensing Information</legend>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Licensed Status:</span> {{ recordLicence?.status }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Licence Number{{ recordLicence.number.length > 1 ? "s" : "" }}:</span>&nbsp;
+          <responsive-grid :cols="12" :md="4">
+            <span><b>Licensed Status:</b> {{ recordLicence?.status }}</span>
+            <span>
+              <b>Licence Number{{ recordLicence.number.length > 1 ? "s" : "" }}:</b>&nbsp;
               <a v-for="(licence, index) in recordLicence.number" :href="`https://j200.gov.bc.ca/pub/ams/Default.aspx?PossePresentation=AMSPublic&amp;PosseObjectDef=o_ATIS_DocumentSearch&amp;PosseMenuName=WS_Main&Criteria_LicenceNumber=${licence}`" target="_blank">
                 {{ licence}}{{ index + 1 < recordLicence.number.length ? ", " : ""}}
               </a>
-            </div>
-          </div>
+            </span>
+          </responsive-grid>
         </fieldset>
 
         <!-- LOCATION -->
         <fieldset id="location_information_fieldset" class="my-4 detail-section">
           <legend class="w-full mb-2">Location Information</legend>
-          <div class="grid grid-cols-12 gap-4">
+          <div class="grid grid-cols-12">
             <div class="col-span-12 md:col-span-6">
               <div>
                 <span class="font-bold">Street Address:</span> {{ street_address }}
@@ -291,34 +288,30 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
         <fieldset id="well_completion_data_fieldset" class="my-4 detail-section">
           <legend class="w-full mb-2">Well Completion Data</legend>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Total Depth Drilled:</span> {{ excludeZeroDecimals(total_depth_drilled) }} {{ total_depth_drilled ? 'ft bgl':''}}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Estimated Well Yield:</span> {{ excludeZeroDecimals(well_yield) }} {{ well_yield ? 'USgpm':'' }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Static Water Level (BTOC):</span> {{ excludeZeroDecimals(static_water_level) }} {{ static_water_level ? 'feet btoc': ''}}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Finished Well Depth:</span> {{ excludeZeroDecimals(finished_well_depth) }} {{ finished_well_depth ? 'ft bgl':''}}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Well Cap:</span> {{ well_cap_type }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Artesian Flow:</span> {{ excludeZeroDecimals(artesian_flow) }} {{ artesian_flow ? 'USgpm':'' }}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Final Casing Stick Up:</span> {{ excludeZeroDecimals(final_casing_stick_up) }} {{ final_casing_stick_up ? 'inches':''}}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Well Disinfected Status:</span> {{ well_disinfected_status }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Artesian Pressure (head):</span> {{ excludeZeroDecimals(artesian_pressure_head) }}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Depth to Bedrock:</span> {{ excludeZeroDecimals(bedrock_depth) }} {{ bedrock_depth ? 'feet bgl':''}}</div>
-            <div class="col-span-12 md:col-span-4">
-              <span class="font-bold">Drilling Method<span v-if="drilling_methods && drilling_methods.length > 1">s</span>:</span>
+          <responsive-grid :cols="12" :md="4">
+            <span><b>Total Depth Drilled:</b> {{ excludeZeroDecimals(total_depth_drilled) }} {{ total_depth_drilled ? 'ft bgl':''}}</span>
+            <span><b>Estimated Well Yield:</b> {{ excludeZeroDecimals(well_yield) }} {{ well_yield ? 'USgpm':'' }}</span>
+            <span><b>Static Water Level (BTOC):</b> {{ excludeZeroDecimals(static_water_level) }} {{ static_water_level ? 'feet btoc': ''}}</span>
+
+            <span><b>Finished Well Depth:</b> {{ excludeZeroDecimals(finished_well_depth) }} {{ finished_well_depth ? 'ft bgl':''}}</span>
+            <span><b>Well Cap:</b> {{ well_cap_type }}</span>
+            <span><b>Artesian Flow:</b> {{ excludeZeroDecimals(artesian_flow) }} {{ artesian_flow ? 'USgpm':'' }}</span>
+
+            <span><b>Final Casing Stick Up:</b> {{ excludeZeroDecimals(final_casing_stick_up) }} {{ final_casing_stick_up ? 'inches':''}}</span>
+            <span><b>Well Disinfected Status:</b> {{ well_disinfected_status }}</span>
+            <span><b>Artesian Pressure (head):</b> {{ excludeZeroDecimals(artesian_pressure_head) }}</span>
+
+            <span><b>Depth to Bedrock:</b> {{ excludeZeroDecimals(bedrock_depth) }} {{ bedrock_depth ? 'feet bgl':''}}</span>
+            <span>
+              <b>Drilling Method<span v-if="drilling_methods && drilling_methods.length > 1">s</span>:</b>
               <span v-for="(method, index) in drilling_methods" :key="`drillingMethod${index}`"><span v-if="index > 0">,</span> {{ method.description }}</span>
-            </div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Artesian Pressure (PSI):</span> {{ excludeZeroDecimals(artesian_pressure) }}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Ground elevation:</span> {{ excludeZeroDecimals(ground_elevation) }} {{ ground_elevation ? 'feet':'' }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Method of determining elevation:</span> {{ ground_elevation_method }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Orientation of Well:</span> {{ well_orientation_status }}</div>
-          </div>
+            </span>
+            <span><b>Artesian Pressure (PSI):</b> {{ excludeZeroDecimals(artesian_pressure) }}</span>
+
+            <span><b>Ground elevation:</b> {{ excludeZeroDecimals(ground_elevation) }} {{ ground_elevation ? 'feet':'' }}</span>
+            <span><b>Method of determining elevation:</b> {{ ground_elevation_method }}</span>
+            <span><b>Orientation of Well:</b> {{ well_orientation_status }}</span>
+          </responsive-grid>
         </fieldset>
 
         <fieldset id="lithology_fieldset" class="my-4 detail-section">
@@ -389,25 +382,25 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
         <fieldset id="surface_seal_fieldset" class="my-4 detail-section">
           <legend class="w-full mb-2">Surface Seal and Backfill Details</legend>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Surface Seal Material:</span> {{ codeToDescription('surface_seal_materials', surface_seal_material) }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Backfill Material Above Surface Seal:</span> {{ codeToDescription('surface_seal_materials', backfill_above_surface_seal) }}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Surface Seal Installation Method:</span> {{ codeToDescription('surface_seal_methods', surface_seal_method) }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Backfill Depth:</span> {{ excludeZeroDecimals(backfill_depth) }} {{ backfill_depth ? 'feet':'' }}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Surface Seal Thickness:</span> {{ excludeZeroDecimals(surface_seal_thickness) }} {{ surface_seal_thickness ? 'inches':'' }}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Surface Seal Depth:</span> {{ excludeZeroDecimals(surface_seal_depth) }} {{ surface_seal_depth ? 'feet':''}}</div>
-          </div>
+          <responsive-grid :cols="12" :md="4">
+            <span><b>Surface Seal Material:</b> {{ codeToDescription('surface_seal_materials', surface_seal_material) }}</span>
+            <span><b>Backfill Material Above Surface Seal:</b> {{ codeToDescription('surface_seal_materials', backfill_above_surface_seal) }}</span>
+          </responsive-grid>
+          <responsive-grid :cols="12" :md="4">
+            <span><b>Surface Seal Installation Method:</b> {{ codeToDescription('surface_seal_methods', surface_seal_method) }}</span>
+            <span><b>Backfill Depth:</b> {{ excludeZeroDecimals(backfill_depth) }} {{ backfill_depth ? 'feet':'' }}</span>
+          </responsive-grid>
+          <responsive-grid :cols="12" :md="4">
+            <span><b>Surface Seal Thickness:</b> {{ excludeZeroDecimals(surface_seal_thickness) }} {{ surface_seal_thickness ? 'inches':'' }}</span>
+          </responsive-grid>
+          <responsive-grid :cols="12" :md="4">
+            <span><b>Surface Seal Depth:</b> {{ excludeZeroDecimals(surface_seal_depth) }} {{ surface_seal_depth ? 'feet':''}}</span>
+          </responsive-grid>
         </fieldset>
 
         <fieldset id="liner_details_fieldset" class="my-4 detail-section">
           <legend class="w-full mb-2">Liner Details</legend>
-          <div class="grid grid-cols-12 gap-4">
+          <div class="grid grid-cols-12">
             <div class="col-span-12 md:col-span-6">
               <div><span class="font-bold">Liner Material:</span> {{ codeToDescription('liner_materials', liner_material) }}</div>
               <div class="grid grid-cols-2">
@@ -444,7 +437,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
         <fieldset id="screen_details_fieldset" class="my-4 detail-section">
           <legend class="w-full mb-2">Screen Details</legend>
-          <div class="grid grid-cols-12 gap-4">
+          <div class="grid grid-cols-12">
             <div class="col-span-12 md:col-span-3">
               <div><span class="font-bold">Intake Method:</span> {{ codeToDescription('screen_intake_methods', screen_intake_method) }}</div>
               <div><span class="font-bold">Type:</span> {{ codeToDescription('screen_types', screen_type) }}</div>
@@ -487,47 +480,43 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
         <fieldset id="well_development_fieldset" class="my-4 detail-section">
           <legend class="w-full mb-2">Well Development</legend>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4">
-              <span class="font-bold">Developed by:</span>
+          <responsive-grid :cols="12" :md="4">
+            <span>
+              <b>Developed by:</b>
               <span v-for="(method, index) in development_methods" :key="`developmentMethod${index}`"><span v-if="index > 0">,</span> {{ method.description }}</span>
-            </div>
-            <div class="col-span-12 md:col-span-4">
-              <span class="font-bold">Development Total Duration:</span> {{ excludeZeroDecimals(development_hours) }} {{ development_hours ? 'hours':'' }}
-            </div>
-          </div>
+            </span>
+            <span><b>Development Total Duration:</b> {{ excludeZeroDecimals(development_hours) }} {{ development_hours ? 'hours':'' }}</span>
+          </responsive-grid>
         </fieldset>
 
         <fieldset id="well_yield_fieldset" class="my-4 detail-section">
           <legend class="w-full mb-2">Well Yield</legend>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Estimation Method:</span> {{codeToDescription('yield_estimation_methods', yield_estimation_method)}} </div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Estimation Rate:</span> {{ excludeZeroDecimals(yield_estimation_rate) }} {{ yield_estimation_rate ? 'USgpm':'' }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Estimation Duration:</span> {{ excludeZeroDecimals(yield_estimation_duration) }} {{ yield_estimation_duration ? 'hours':'' }}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Static Water Level Before Test:</span> {{ excludeZeroDecimals(static_level_before_test) }} {{ static_level_before_test ? 'ft (btoc)':'' }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Drawdown:</span> {{ excludeZeroDecimals(drawdown) }} {{ drawdown ? 'ft (btoc)':'' }}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Hydrofracturing Performed:</span> {{booleanToYesNo(hydro_fracturing_performed)}}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Increase in Yield Due to Hydrofracturing:</span> {{ excludeZeroDecimals(hydro_fracturing_yield_increase) }} {{ hydro_fracturing_yield_increase ? 'USgpm':'' }}</div>
-          </div>
+          <responsive-grid :cols="12" :md="4">
+            <span><b>Estimation Method:</b> {{codeToDescription('yield_estimation_methods', yield_estimation_method)}}</span>
+            <span><b>Estimation Rate:</b> {{ excludeZeroDecimals(yield_estimation_rate) }} {{ yield_estimation_rate ? 'USgpm':'' }}</span>
+            <span><b>Estimation Duration:</b> {{ excludeZeroDecimals(yield_estimation_duration) }} {{ yield_estimation_duration ? 'hours':'' }}</span>
+            <span><b>Static Water Level Before Test:</b> {{ excludeZeroDecimals(static_level_before_test) }} {{ static_level_before_test ? 'ft (btoc)':'' }}</span>
+            <span><b>Drawdown:</b> {{ excludeZeroDecimals(drawdown) }} {{ drawdown ? 'ft (btoc)':'' }}</span>
+          </responsive-grid>
+          <responsive-grid :cols="12" :md="4">
+            <span><b>Hydrofracturing Performed:</b> {{booleanToYesNo(hydro_fracturing_performed)}}</span>
+            <span><b>Increase in Yield Due to Hydrofracturing:</b> {{ excludeZeroDecimals(hydro_fracturing_yield_increase) }} {{ hydro_fracturing_yield_increase ? 'USgpm':'' }}</span>
+          </responsive-grid>
         </fieldset>
 
         <fieldset id="well_decommissioning_fieldset" class="my-4 detail-section">
           <legend class="w-full mb-2">Well Decommission Information</legend>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Reason for Decommission:</span> {{ decommission_reason }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Method of Decommission:</span> {{ decommission_method }}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Sealant Material:</span> {{ decommission_sealant_material }}</div>
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Backfill Material:</span> {{ decommission_backfill_material }}</div>
-          </div>
-          <div class="grid grid-cols-12 gap-4">
-            <div class="col-span-12 md:col-span-4"><span class="font-bold">Decommission Details:</span> {{ decommission_details }}</div>
-          </div>
+          <responsive-grid :cols="12" :md="4">
+            <span><b>Reason for Decommission:</b> {{ decommission_reason }}</span>
+            <span><b>Method of Decommission:</b> {{ decommission_method }}</span>
+          </responsive-grid>
+          <responsive-grid :cols="12" :md="4">
+            <span><b>Sealant Material:</b> {{ decommission_sealant_material }}</span>
+            <span><b>Backfill Material:</b> {{ decommission_backfill_material }}</span>
+          </responsive-grid>
+          <responsive-grid :cols="12" :md="4">
+            <span><b>Decommission Details:</b> {{ decommission_details }}</span>
+          </responsive-grid>
         </fieldset>
 
         <fieldset id="aquifer_parameters_fieldset" class="my-4 detail-section">

--- a/app/frontend/src/wells/views/WellSearch.vue
+++ b/app/frontend/src/wells/views/WellSearch.vue
@@ -134,6 +134,7 @@ import axios from 'axios'
 import { isEqual } from 'lodash'
 import smoothScroll from 'smoothscroll'
 import { mapStores } from 'pinia'
+import { TabPanels, TabPanel } from 'primevue'
 
 import ApiService from '@/common/services/ApiService.js'
 
@@ -154,6 +155,8 @@ export default {
     'basic-search-form': BasicSearchForm,
     'search-map': SearchMap,
     'search-results': SearchResults,
+    TabPanels,
+    TabPanel,
   },
   data () {
     return {


### PR DESCRIPTION
## Pull Request Standards

- [ ] The title of the PR is accurate
- [ ] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [ ] The PR title includes the ticket number in format of `[GWELLS-###]`
- [ ] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Converted <b- components to regular HTML/Primevue components
- I switched out a lot of b-rows and b-cols for a new component I made called responsive-grid. This component takes in X number of children and wraps each of them in a div. This div gets various classes assigned to it to give it nice grid behavior. The snag is that an element inside of a responsive-grid can't be conditionally rendered, so I only switched out instances without conditional elements. In some places, I combined b-rows into a single grid, in some places I kept them separate. I was able to combine rows when the elements in a row always fill the full row. There are lots of instances where, for some reason, 1/3 or more of a row is purposefully left empty. Don't ask me why.

WARNING: This PR is a NIGHTMARE to review on GitHub. GitHub really struggles when you change the indentation of elements. If you're planning to review this, I recommend pulling the branch locally and comparing each file to the red version of the code under "Files changed". That was how I reviewed my work today.
