### PR TITLE
fix[GWELLS-2694]: Matomo is back, back again!

### DIFF
--- a/app/frontend/src/main.js
+++ b/app/frontend/src/main.js
@@ -49,7 +49,7 @@ const STAGING_GWELLS_URLS = [
 ];
 const BASE_PATH = "/gwells/";
 const PRODUCTION_MATOMO_HOST =
-  "https://water-matomo.apps.silver.devops.gov.bc.ca";
+  "https://matomo-26e83e-prod.apps.silver.devops.gov.bc.ca";
 const TEST_MATOMO_HOST =
   "https://water-matomo-staging.apps.silver.devops.gov.bc.ca";
 
@@ -133,7 +133,7 @@ app.use(pinia);
 if (isProduction()) {
   app.use(VueMatomo, {
     host: PRODUCTION_MATOMO_HOST,
-    siteId: 2,
+    siteId: 1,
     router: router,
     domains: "apps.nrs.gov.bc.ca",
   });

--- a/openshift/ocp4/matomo/matomo-db.dc.yaml
+++ b/openshift/ocp4/matomo/matomo-db.dc.yaml
@@ -1,0 +1,111 @@
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: matomo-db
+  generation: 16
+  namespace: 26e83e-prod
+  labels:
+    app: matomo
+    name: matomo-db
+    service: matomo-db
+    template: matomo-template
+spec:
+  strategy:
+    type: Recreate
+    recreateParams:
+      timeoutSeconds: 600
+    resources: {}
+    activeDeadlineSeconds: 21600
+  triggers:
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - mariadb
+        from:
+          kind: ImageStreamTag
+          namespace: 26e83e-tools
+          name: 'mariadb:prod'
+        lastTriggeredImage: 'registry.redhat.io/rhel8/mariadb-103@sha256:363f7f7293cd7040ba610bbea830f3bc71e2d70d1f2540a0926dc683bfff79c9'
+    - type: ConfigChange
+  replicas: 1
+  revisionHistoryLimit: 10
+  test: false
+  selector:
+    name: matomo-db
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: matomo
+        name: matomo-db
+    spec:
+      volumes:
+        - name: matomo-db-data
+          persistentVolumeClaim:
+            claimName: matomo-db
+      containers:
+        - resources:
+            limits:
+              cpu: 250m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - '-i'
+                - '-c'
+                - MYSQL_PWD="$MYSQL_PASSWORD" mysql -h 127.0.0.1 -u $MYSQL_USER -D $MYSQL_DATABASE -e 'SELECT 1'
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          name: mariadb
+          livenessProbe:
+            tcpSocket:
+              port: 3306
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          env:
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: matomo-db
+                  key: database-user
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: matomo-db
+                  key: database-password
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: matomo-db
+                  key: database-root-password
+            - name: MYSQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: matomo-db
+                  key: database-name
+          ports:
+            - containerPort: 3306
+              protocol: TCP
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: matomo-db-data
+              mountPath: /var/lib/mysql/data
+          terminationMessagePolicy: File
+          image: 'registry.redhat.io/rhel8/mariadb-103@sha256:363f7f7293cd7040ba610bbea830f3bc71e2d70d1f2540a0926dc683bfff79c9'
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler

--- a/openshift/ocp4/matomo/matomo-db.pvc.yaml
+++ b/openshift/ocp4/matomo/matomo-db.pvc.yaml
@@ -1,0 +1,24 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: matomo-db
+  namespace: 26e83e-prod
+  finalizers:
+    - kubernetes.io/pvc-protection
+  labels:
+    app: matomo
+    name: matomo-db
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: netapp-file-standard
+  volumeMode: Filesystem
+status:
+  phase: Bound
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 5Gi

--- a/openshift/ocp4/matomo/matomo.dc.yaml
+++ b/openshift/ocp4/matomo/matomo.dc.yaml
@@ -1,0 +1,110 @@
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: matomo
+  generation: 5
+  namespace: 26e83e-prod
+  labels:
+    app: matomo
+    name: matomo
+    service: matomo
+    template: matomo-template
+spec:
+  strategy:
+    type: Rolling
+    rollingParams:
+      updatePeriodSeconds: 1
+      intervalSeconds: 1
+      timeoutSeconds: 600
+      maxUnavailable: 25%
+      maxSurge: 25%
+    resources: {}
+    activeDeadlineSeconds: 21600
+  triggers:
+    - type: ConfigChange
+  replicas: 1
+  revisionHistoryLimit: 10
+  test: false
+  selector:
+    app: matomo
+    deploymentconfig: matomo
+    template: matomo-template
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: matomo
+        deploymentconfig: matomo
+        name: matomo
+        template: matomo-template
+    spec:
+      volumes:
+        - name: matomo-source
+          emptyDir: {}
+        - name: matomo
+          persistentVolumeClaim:
+            claimName: matomo
+      containers:
+        - resources: {}
+          readinessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          name: matomo
+          livenessProbe:
+            tcpSocket:
+              port: 9000
+            initialDelaySeconds: 1
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          ports:
+            - containerPort: 9000
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: matomo-source
+              mountPath: /var/www/html
+            - name: matomo
+              mountPath: /var/www/html/config
+          terminationMessagePolicy: File
+          image: 'image-registry.openshift-image-registry.svc:5000/26e83e-tools/matomo@sha256:61d87395a67d966c2af4636726071ff85328f6db6c6c6479f15cee337472dc9e'
+        - resources: {}
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 1
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          name: matomo-proxy
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 1
+            timeoutSeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: matomo-source
+              mountPath: /var/www/html
+          terminationMessagePolicy: File
+          image: 'image-registry.openshift-image-registry.svc:5000/26e83e-tools/matomo-proxy@sha256:76d7f6f07975dca65818684a3362f91a39690b333ad346d549b11a3691dea59a'
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler

--- a/openshift/ocp4/matomo/matomo.pvc.yaml
+++ b/openshift/ocp4/matomo/matomo.pvc.yaml
@@ -1,0 +1,24 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: matomo
+  namespace: 26e83e-prod
+  finalizers:
+    - kubernetes.io/pvc-protection
+  labels:
+    app: matomo
+    name: matomo
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: netapp-file-standard
+  volumeMode: Filesystem
+status:
+  phase: Bound
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi


### PR DESCRIPTION
## Pull Request Standards

- [x] The title of the PR is accurate
- [x] The title includes the type of change [`HOTFIX`, `FEATURE`, `etc`]  
- [x] The PR title includes the ticket number in format of `[GWELLS-###]`
- [ ] Documentation is updated to reflect change [`README`, `functions`, `team documents`]

# Description

This PR includes the following proposed change(s):

- Updated failing deployment configs in openshift prod and test to pull new mariadb 10.3 image, they are now running again
- Changed prod matomo url
- Added backup copies of dc and pvc for matomo
- Learnt lots about openshift, deployment config (defines container, when to deploy) > replication controller > pod (containers here, mounts pvc, exposes route)
<img width="1362" height="583" alt="Screenshot 2026-06-16 at 10 23 08 AM" src="https://github.com/user-attachments/assets/fc36698f-8c6c-461d-8ee7-d975b5aabdda" />
<img width="130" height="129" alt="Screenshot 2026-06-16 at 10 23 23 AM" src="https://github.com/user-attachments/assets/bde4b735-72b9-47ab-a96b-fb8a61dfd262" />
<img width="352" height="579" alt="Screenshot 2026-06-16 at 10 23 49 AM" src="https://github.com/user-attachments/assets/95e51775-d145-4ae1-b6ab-35d6c73e7d0c" />
<img width="265" height="552" alt="Screenshot 2026-06-16 at 10 24 00 AM" src="https://github.com/user-attachments/assets/d2b12a87-78ea-4013-8296-50567fca0e4e" />